### PR TITLE
Add USB capture session dataclasses and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .venv/
+venv/
 dist/
 build/
 

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -1,0 +1,21 @@
+"""In-memory data structures for parsed USB capture sessions."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class USBDevice:
+    """A USB device observed in a parsed capture."""
+
+    bus_num: int
+    dev_num: int
+    endpoints: list[int]
+
+
+@dataclass
+class CaptureSession:
+    """A parsed USB capture held in memory for later analysis."""
+
+    filepath: str
+    devices: list[USBDevice]
+    packet_count: int

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,20 @@
+"""Tests for USB capture session data structures."""
+
+from bsu_tool.session import CaptureSession, USBDevice
+
+
+def test_capture_session_stores_capture_metadata() -> None:
+    """CaptureSession stores filepath, devices, endpoints, and packet count."""
+    device = USBDevice(bus_num=1, dev_num=7, endpoints=[0, 1, 129])
+    session = CaptureSession(
+        filepath="/captures/sample.pcapng",
+        devices=[device],
+        packet_count=42,
+    )
+
+    assert session.filepath == "/captures/sample.pcapng"
+    assert session.devices == [device]
+    assert session.packet_count == 42
+    assert session.devices[0].bus_num == 1
+    assert session.devices[0].dev_num == 7
+    assert session.devices[0].endpoints == [0, 1, 129]


### PR DESCRIPTION
## What does this PR do?

Adds the in-memory USB capture session data model.

This PR defines:
- `USBDevice`
- `CaptureSession`

It also adds a unit test that creates a `CaptureSession` and verifies its fields.

Closes #20

## How was it tested?

Ran locally:

- `./venv/bin/ruff check .`
- `./venv/bin/ruff format --check .`
- `./venv/bin/pyright`
- `pytest`

All checks passed.

## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR