### PR TITLE
Add pcap-ng reader and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ htmlcov/
 
 # OS
 .DS_Store
+
+# VSCode
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,5 @@ repos:
     rev: v1.1.409
     hooks:
       - id: pyright
+        additional_dependencies: 
+          - "pytest>=8.0"

--- a/bsu_tool/pcapng/__init__.py
+++ b/bsu_tool/pcapng/__init__.py
@@ -6,7 +6,7 @@ separate module so the two layers can be tested independently.
 
 Typical use::
 
-    from bsu_tool.parser import PcapNgReader, EnhancedPacketBlock
+    from pcapng.parser import PcapNgReader, EnhancedPacketBlock
 
     with open("capture.pcapng", "rb") as fp:
         for block in PcapNgReader(fp):

--- a/bsu_tool/pcapng/__init__.py
+++ b/bsu_tool/pcapng/__init__.py
@@ -6,7 +6,7 @@ separate module so the two layers can be tested independently.
 
 Typical use::
 
-    from pcapng.parser import PcapNgReader, EnhancedPacketBlock
+    from bsu_tool.pcapng import PcapNgReader, EnhancedPacketBlock
 
     with open("capture.pcapng", "rb") as fp:
         for block in PcapNgReader(fp):

--- a/bsu_tool/pcapng/__init__.py
+++ b/bsu_tool/pcapng/__init__.py
@@ -1,0 +1,53 @@
+"""pcap-ng parsing for bsu-tool.
+
+The parser is intentionally layered: this module decodes pcap-ng *block*
+structure only. URB-level decoding of packet payloads belongs in a
+separate module so the two layers can be tested independently.
+
+Typical use::
+
+    from bsu_tool.parser import PcapNgReader, EnhancedPacketBlock
+
+    with open("capture.pcapng", "rb") as fp:
+        for block in PcapNgReader(fp):
+            if isinstance(block, EnhancedPacketBlock):
+                ...  # do something with block.packet_data
+"""
+
+from __future__ import annotations
+
+from .blocks import (
+    Block,
+    ByteOrder,
+    EnhancedPacketBlock,
+    InterfaceDescriptionBlock,
+    InterfaceStatisticsBlock,
+    Option,
+    SectionHeaderBlock,
+    SimplePacketBlock,
+    UnknownBlock,
+)
+from .errors import (
+    InvalidBlockError,
+    PcapNgError,
+    TruncatedFileError,
+    UnsupportedVersionError,
+)
+from .reader import PcapNgReader
+
+__all__ = [
+    "Block",
+    "ByteOrder",
+    "EnhancedPacketBlock",
+    "InterfaceDescriptionBlock",
+    "InterfaceStatisticsBlock",
+    "InvalidBlockError",
+    "Option",
+    "PcapNgError",
+    "PcapNgReader",
+    "SectionHeaderBlock",
+    "SimplePacketBlock",
+    "TruncatedFileError",
+    "UnknownBlock",
+    "UnsupportedVersionError",
+]

--- a/bsu_tool/pcapng/blocks.py
+++ b/bsu_tool/pcapng/blocks.py
@@ -1,0 +1,133 @@
+"""Data classes representing pcap-ng blocks.
+
+Every block we expose is a frozen dataclass — once parsed, blocks are
+immutable. Options are exposed as a tuple of raw :class:`Option` records;
+higher-level code is responsible for interpreting option codes by context
+(option codes are not globally unique — code 2 means something different
+inside an SHB than inside an EPB).
+
+We model the well-known block types we expect to see in usbmon captures
+(Section Header, Interface Description, Enhanced Packet, Simple Packet,
+Interface Statistics) and fall back to :class:`UnknownBlock` for anything
+else, so callers never lose data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+#: Endianness of a section, established by the byte-order magic in its SHB.
+ByteOrder = Literal["little", "big"]
+
+
+@dataclass(frozen=True, slots=True)
+class Option:
+    """A single TLV option from a block's options list.
+
+    Options are stored as raw bytes; the parser deliberately does not try
+    to interpret well-known option codes (e.g. ``opt_comment``) because
+    interpretation depends on which block type the option appears in.
+    """
+
+    code: int
+    value: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class SectionHeaderBlock:
+    """Section Header Block (block type ``0x0A0D0D0A``).
+
+    Marks the start of a section. ``section_length`` is signed: a value of
+    -1 means the writer did not record the length (common for live captures).
+    """
+
+    byte_order: ByteOrder
+    major_version: int
+    minor_version: int
+    section_length: int
+    options: tuple[Option, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class InterfaceDescriptionBlock:
+    """Interface Description Block (block type ``0x00000001``).
+
+    Describes one capture interface. ``link_type`` is the LINKTYPE_*
+    value defined by tcpdump.org; usbmon captures use LINKTYPE_USB_LINUX
+    (189) or LINKTYPE_USB_LINUX_MMAPPED (220).
+    """
+
+    link_type: int
+    snap_len: int
+    options: tuple[Option, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class EnhancedPacketBlock:
+    """Enhanced Packet Block (block type ``0x00000006``).
+
+    The standard form for captured packets in modern pcap-ng files. The
+    timestamp is split into a high and low 32-bit word; the units are
+    determined by the ``if_tsresol`` option of the referenced interface
+    (default: microseconds).
+    """
+
+    interface_id: int
+    timestamp_high: int
+    timestamp_low: int
+    captured_len: int
+    original_len: int
+    packet_data: bytes
+    options: tuple[Option, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SimplePacketBlock:
+    """Simple Packet Block (block type ``0x00000003``).
+
+    A stripped-down packet block with no timestamp and no interface id —
+    it implicitly belongs to interface 0. Rare in usbmon captures but
+    cheap to support.
+    """
+
+    original_len: int
+    packet_data: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class InterfaceStatisticsBlock:
+    """Interface Statistics Block (block type ``0x00000005``).
+
+    Per-interface counters (packets received, dropped, etc.) emitted at
+    capture stop time. The actual statistics live in the options.
+    """
+
+    interface_id: int
+    timestamp_high: int
+    timestamp_low: int
+    options: tuple[Option, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class UnknownBlock:
+    """A block whose type we do not specifically model.
+
+    The body is exposed verbatim (with its trailing total-length stripped)
+    so that callers can implement support for additional block types
+    without modifying the parser.
+    """
+
+    block_type: int
+    body: bytes
+
+
+#: Tagged union of every block type the parser can yield.
+Block = (
+    SectionHeaderBlock
+    | InterfaceDescriptionBlock
+    | EnhancedPacketBlock
+    | SimplePacketBlock
+    | InterfaceStatisticsBlock
+    | UnknownBlock
+)

--- a/bsu_tool/pcapng/errors.py
+++ b/bsu_tool/pcapng/errors.py
@@ -1,0 +1,36 @@
+"""Exceptions raised by the pcap-ng parser.
+
+All parser-level exceptions inherit from :class:`PcapNgError`, so callers that
+just want to report parse failures can catch a single base class.
+"""
+
+from __future__ import annotations
+
+
+class PcapNgError(Exception):
+    """Base class for all pcap-ng parser errors."""
+
+
+class TruncatedFileError(PcapNgError):
+    """Raised when the input stream ends in the middle of a block.
+
+    This is distinct from a clean end-of-stream between blocks, which the
+    reader signals via normal iterator termination (``StopIteration``).
+    """
+
+
+class InvalidBlockError(PcapNgError):
+    """Raised when a block is structurally invalid.
+
+    Examples include: a block-total-length that is not a multiple of 4,
+    a leading and trailing total-length that disagree, an option whose
+    declared length runs off the end of the block, or a Section Header
+    Block with an unrecognized byte-order magic.
+    """
+
+
+class UnsupportedVersionError(PcapNgError):
+    """Raised when a Section Header Block declares a major version we do not support.
+
+    We accept pcap-ng major version 1; any other value raises this.
+    """

--- a/bsu_tool/pcapng/reader.py
+++ b/bsu_tool/pcapng/reader.py
@@ -1,0 +1,406 @@
+"""pcap-ng block reader.
+
+Iterates over the blocks of a pcap-ng file, yielding parsed dataclass
+representations. The reader:
+
+* validates the block framing (block-type, leading length, trailing length);
+* tracks the current section's byte order, established by each Section
+  Header Block;
+* parses the well-known block types we model in :mod:`bsu_tool.parser.blocks`;
+* falls back to :class:`UnknownBlock` for anything unrecognized.
+
+It does **not** decode the contents of packet bodies — for usbmon captures,
+that is the job of the URB decoder layer.
+
+References
+----------
+The pcap-ng format is specified in
+https://www.ietf.org/archive/id/draft-ietf-opsawg-pcapng-04.html and the
+older Wireshark wiki at https://wiki.wireshark.org/Development/PcapNg.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import BinaryIO, Final
+
+from .blocks import (
+    Block,
+    ByteOrder,
+    EnhancedPacketBlock,
+    InterfaceDescriptionBlock,
+    InterfaceStatisticsBlock,
+    Option,
+    SectionHeaderBlock,
+    SimplePacketBlock,
+    UnknownBlock,
+)
+from .errors import (
+    InvalidBlockError,
+    TruncatedFileError,
+    UnsupportedVersionError,
+)
+
+# --- Block-type identifiers ------------------------------------------------
+
+#: Section Header Block. The byte sequence ``0a 0d 0d 0a`` is a palindrome,
+#: so we can recognize the SHB before we know the section's byte order.
+BLOCK_TYPE_SHB: Final[int] = 0x0A0D0D0A
+SHB_TYPE_BYTES: Final[bytes] = b"\x0a\x0d\x0d\x0a"
+
+BLOCK_TYPE_IDB: Final[int] = 0x00000001
+BLOCK_TYPE_SPB: Final[int] = 0x00000003
+BLOCK_TYPE_ISB: Final[int] = 0x00000005
+BLOCK_TYPE_EPB: Final[int] = 0x00000006
+
+# --- Byte-order magic ------------------------------------------------------
+
+#: Byte-order magic as it appears on the wire when the section is little-endian.
+BOM_LITTLE: Final[bytes] = b"\x4d\x3c\x2b\x1a"
+#: Byte-order magic as it appears on the wire when the section is big-endian.
+BOM_BIG: Final[bytes] = b"\x1a\x2b\x3c\x4d"
+
+# --- Versions and option marker -------------------------------------------
+
+SUPPORTED_MAJOR: Final[int] = 1
+
+#: Option code that terminates an options list (``opt_endofopt``).
+OPT_ENDOFOPT: Final[int] = 0
+
+# --- Minimum block sizes (used for sanity checks) -------------------------
+# Every block has the 12-byte framing: type(4) + length(4) + length(4).
+# The constants below are minimum *body* sizes — i.e. the bytes between
+# the leading and trailing length fields.
+
+#: Minimum total block size — the 12-byte framing alone, with empty body.
+_MIN_BLOCK_SIZE: Final[int] = 12
+
+# SHB body = BOM(4) + major(2) + minor(2) + section_length(8) = 16 bytes.
+_MIN_SHB_BODY: Final[int] = 16
+#: Minimum total SHB size including framing.
+_MIN_SHB_SIZE: Final[int] = _MIN_BLOCK_SIZE + _MIN_SHB_BODY
+
+# IDB body = link_type(2) + reserved(2) + snap_len(4) = 8 bytes.
+_MIN_IDB_BODY: Final[int] = 8
+
+# EPB body = interface_id(4) + ts_high(4) + ts_low(4)
+#          + captured_len(4) + original_len(4) = 20 bytes.
+_MIN_EPB_BODY: Final[int] = 20
+
+# SPB body = original_len(4) = 4 bytes.
+_MIN_SPB_BODY: Final[int] = 4
+
+# ISB body = interface_id(4) + ts_high(4) + ts_low(4) = 12 bytes.
+_MIN_ISB_BODY: Final[int] = 12
+
+
+def _pad4(n: int) -> int:
+    """Round ``n`` up to the next multiple of 4.
+
+    pcap-ng pads variable-length fields (option values, packet data) so
+    that following fields stay 32-bit aligned.
+    """
+    return (n + 3) & ~3
+
+
+def _parse_options(data: bytes, byte_order: ByteOrder) -> tuple[Option, ...]:
+    """Parse a sequence of TLV options.
+
+    The list is terminated either by an ``opt_endofopt`` record (code 0,
+    length 0) or by the end of ``data``. Each option's value is padded to
+    a 4-byte boundary on the wire; the padding is consumed but not
+    included in the returned :class:`Option`.
+    """
+    if not data:
+        return ()
+
+    options: list[Option] = []
+    pos = 0
+    end = len(data)
+
+    while pos + 4 <= end:
+        code = int.from_bytes(data[pos : pos + 2], byte_order)
+        length = int.from_bytes(data[pos + 2 : pos + 4], byte_order)
+        pos += 4
+
+        if code == OPT_ENDOFOPT and length == 0:
+            return tuple(options)
+
+        if pos + length > end:
+            raise InvalidBlockError(f"option code {code} declares length {length} but only {end - pos} bytes remain")
+
+        value = bytes(data[pos : pos + length])
+        options.append(Option(code=code, value=value))
+        pos += _pad4(length)
+
+    # No explicit opt_endofopt — that's permitted; reaching the end of the
+    # options buffer is also a valid terminator.
+    return tuple(options)
+
+
+class PcapNgReader:
+    """Iterates the blocks of a pcap-ng stream.
+
+    Parameters
+    ----------
+    stream:
+        A binary, readable file-like object positioned at the start of a
+        pcap-ng file. The reader does not seek; a non-seekable stream
+        (e.g. a pipe) works fine.
+
+    The reader is its own iterator::
+
+        with open("capture.pcapng", "rb") as fp:
+            for block in PcapNgReader(fp):
+                ...
+    """
+
+    __slots__ = ("_byte_order", "_offset", "_stream")
+
+    def __init__(self, stream: BinaryIO) -> None:
+        self._stream = stream
+        # Byte order is unknown until we read the first SHB.
+        self._byte_order: ByteOrder | None = None
+        # Tracking the byte offset gives us better error messages.
+        self._offset = 0
+
+    @property
+    def byte_order(self) -> ByteOrder | None:
+        """The byte order of the current section, or ``None`` before the first SHB."""
+        return self._byte_order
+
+    @property
+    def offset(self) -> int:
+        """The current byte offset within the stream."""
+        return self._offset
+
+    def __iter__(self) -> Iterator[Block]:
+        return self
+
+    def __next__(self) -> Block:
+        type_bytes = self._stream.read(4)
+        if len(type_bytes) == 0:
+            # Clean end-of-stream between blocks — done.
+            raise StopIteration
+        if len(type_bytes) < 4:
+            raise TruncatedFileError(f"at offset {self._offset}: truncated block type ({len(type_bytes)} of 4 bytes)")
+        self._offset += 4
+
+        if type_bytes == SHB_TYPE_BYTES:
+            return self._read_shb()
+
+        if self._byte_order is None:
+            raise InvalidBlockError(f"at offset {self._offset - 4}: first block is not a Section Header Block")
+
+        block_type = int.from_bytes(type_bytes, self._byte_order)
+        return self._read_generic_block(block_type)
+
+    # ---------------------------------------------------------------- helpers
+
+    def _read_exact(self, n: int) -> bytes:
+        """Read exactly ``n`` bytes or raise :class:`TruncatedFileError`."""
+        data = self._stream.read(n)
+        if len(data) != n:
+            raise TruncatedFileError(f"at offset {self._offset}: expected {n} bytes, got {len(data)}")
+        self._offset += n
+        return data
+
+    # ---------------------------------------------------------------- SHB
+
+    def _read_shb(self) -> SectionHeaderBlock:
+        """Read the rest of a Section Header Block.
+
+        Called after the 4-byte block type has already been consumed.
+        Establishes the section's byte order from the BOM; this byte
+        order then applies to every block until the next SHB.
+        """
+        block_start = self._offset - 4
+
+        # We need the byte-order magic to interpret the total-length field,
+        # so we read the next 8 bytes (length + BOM) and resolve the BOM first.
+        head = self._read_exact(8)
+        bom = head[4:8]
+
+        if bom == BOM_LITTLE:
+            byte_order: ByteOrder = "little"
+        elif bom == BOM_BIG:
+            byte_order = "big"
+        else:
+            raise InvalidBlockError(f"at offset {block_start}: invalid byte-order magic {bom.hex()}")
+
+        total_length = int.from_bytes(head[0:4], byte_order)
+        if total_length < _MIN_SHB_SIZE:
+            raise InvalidBlockError(
+                f"at offset {block_start}: SHB total length {total_length} below minimum {_MIN_SHB_SIZE}"
+            )
+        if total_length % 4 != 0:
+            raise InvalidBlockError(f"at offset {block_start}: SHB total length {total_length} is not a multiple of 4")
+
+        # We've consumed 4 (type) + 4 (length) + 4 (BOM) = 12 bytes so far.
+        rest = self._read_exact(total_length - 12)
+
+        major = int.from_bytes(rest[0:2], byte_order)
+        minor = int.from_bytes(rest[2:4], byte_order)
+        # section_length is signed: -1 means "not specified".
+        section_length = int.from_bytes(rest[4:12], byte_order, signed=True)
+
+        options_data = rest[12:-4]
+        trailing_length = int.from_bytes(rest[-4:], byte_order)
+        if trailing_length != total_length:
+            raise InvalidBlockError(
+                f"at offset {block_start}: SHB trailing length {trailing_length} != leading length {total_length}"
+            )
+
+        if major != SUPPORTED_MAJOR:
+            raise UnsupportedVersionError(f"at offset {block_start}: unsupported pcap-ng version {major}.{minor}")
+
+        options = _parse_options(options_data, byte_order)
+        # The byte order of the new section now applies to subsequent blocks.
+        self._byte_order = byte_order
+
+        return SectionHeaderBlock(
+            byte_order=byte_order,
+            major_version=major,
+            minor_version=minor,
+            section_length=section_length,
+            options=options,
+        )
+
+    # ---------------------------------------------------------------- generic
+
+    def _read_generic_block(self, block_type: int) -> Block:
+        """Read a non-SHB block.
+
+        Called after the 4-byte block type has been consumed and the
+        section's byte order is known.
+        """
+        assert self._byte_order is not None  # checked by caller
+        byte_order = self._byte_order
+        block_start = self._offset - 4
+
+        total_length_bytes = self._read_exact(4)
+        total_length = int.from_bytes(total_length_bytes, byte_order)
+
+        if total_length < _MIN_BLOCK_SIZE:
+            raise InvalidBlockError(
+                f"at offset {block_start}: block total length {total_length} below minimum {_MIN_BLOCK_SIZE}"
+            )
+        if total_length % 4 != 0:
+            raise InvalidBlockError(
+                f"at offset {block_start}: block total length {total_length} is not a multiple of 4"
+            )
+
+        # Body + trailing total-length = total_length - 8.
+        body_with_trailer = self._read_exact(total_length - 8)
+        body = body_with_trailer[:-4]
+        trailing_length = int.from_bytes(body_with_trailer[-4:], byte_order)
+        if trailing_length != total_length:
+            raise InvalidBlockError(
+                f"at offset {block_start}: block trailing length {trailing_length} != leading length {total_length}"
+            )
+
+        return self._dispatch(block_type, body, byte_order, block_start)
+
+    def _dispatch(
+        self,
+        block_type: int,
+        body: bytes,
+        byte_order: ByteOrder,
+        block_start: int,
+    ) -> Block:
+        """Dispatch a validated block body to its type-specific parser."""
+        if block_type == BLOCK_TYPE_IDB:
+            return self._parse_idb(body, byte_order, block_start)
+        if block_type == BLOCK_TYPE_EPB:
+            return self._parse_epb(body, byte_order, block_start)
+        if block_type == BLOCK_TYPE_SPB:
+            return self._parse_spb(body, byte_order, block_start)
+        if block_type == BLOCK_TYPE_ISB:
+            return self._parse_isb(body, byte_order, block_start)
+        return UnknownBlock(block_type=block_type, body=bytes(body))
+
+    # ---------------------------------------------------------------- IDB
+
+    @staticmethod
+    def _parse_idb(body: bytes, byte_order: ByteOrder, block_start: int) -> InterfaceDescriptionBlock:
+        if len(body) < _MIN_IDB_BODY:
+            raise InvalidBlockError(f"at offset {block_start}: IDB body too small ({len(body)} bytes)")
+        link_type = int.from_bytes(body[0:2], byte_order)
+        # body[2:4] is reserved; specification says it MUST be ignored.
+        snap_len = int.from_bytes(body[4:8], byte_order)
+        options = _parse_options(body[8:], byte_order)
+        return InterfaceDescriptionBlock(
+            link_type=link_type,
+            snap_len=snap_len,
+            options=options,
+        )
+
+    # ---------------------------------------------------------------- EPB
+
+    @staticmethod
+    def _parse_epb(body: bytes, byte_order: ByteOrder, block_start: int) -> EnhancedPacketBlock:
+        if len(body) < _MIN_EPB_BODY:
+            raise InvalidBlockError(f"at offset {block_start}: EPB body too small ({len(body)} bytes)")
+        interface_id = int.from_bytes(body[0:4], byte_order)
+        timestamp_high = int.from_bytes(body[4:8], byte_order)
+        timestamp_low = int.from_bytes(body[8:12], byte_order)
+        captured_len = int.from_bytes(body[12:16], byte_order)
+        original_len = int.from_bytes(body[16:20], byte_order)
+
+        data_start = 20
+        data_end = data_start + captured_len
+        if data_end > len(body):
+            raise InvalidBlockError(
+                f"at offset {block_start}: EPB captured_len {captured_len} "
+                f"exceeds remaining body size {len(body) - data_start}"
+            )
+
+        packet_data = bytes(body[data_start:data_end])
+        options_start = data_start + _pad4(captured_len)
+        if options_start > len(body):
+            raise InvalidBlockError(f"at offset {block_start}: EPB padding runs past block end")
+        options = _parse_options(body[options_start:], byte_order)
+
+        return EnhancedPacketBlock(
+            interface_id=interface_id,
+            timestamp_high=timestamp_high,
+            timestamp_low=timestamp_low,
+            captured_len=captured_len,
+            original_len=original_len,
+            packet_data=packet_data,
+            options=options,
+        )
+
+    # ---------------------------------------------------------------- SPB
+
+    @staticmethod
+    def _parse_spb(body: bytes, byte_order: ByteOrder, block_start: int) -> SimplePacketBlock:
+        if len(body) < _MIN_SPB_BODY:
+            raise InvalidBlockError(f"at offset {block_start}: SPB body too small ({len(body)} bytes)")
+        original_len = int.from_bytes(body[0:4], byte_order)
+        # The SPB does not record a separate captured length: the captured
+        # data simply fills the rest of the body, up to ``original_len``
+        # bytes (the body itself is padded to a multiple of 4).
+        captured = min(original_len, len(body) - 4)
+        packet_data = bytes(body[4 : 4 + captured])
+        return SimplePacketBlock(
+            original_len=original_len,
+            packet_data=packet_data,
+        )
+
+    # ---------------------------------------------------------------- ISB
+
+    @staticmethod
+    def _parse_isb(body: bytes, byte_order: ByteOrder, block_start: int) -> InterfaceStatisticsBlock:
+        if len(body) < _MIN_ISB_BODY:
+            raise InvalidBlockError(f"at offset {block_start}: ISB body too small ({len(body)} bytes)")
+        interface_id = int.from_bytes(body[0:4], byte_order)
+        timestamp_high = int.from_bytes(body[4:8], byte_order)
+        timestamp_low = int.from_bytes(body[8:12], byte_order)
+        options = _parse_options(body[12:], byte_order)
+        return InterfaceStatisticsBlock(
+            interface_id=interface_id,
+            timestamp_high=timestamp_high,
+            timestamp_low=timestamp_low,
+            options=options,
+        )

--- a/tests/unit/test_pcap_reader.py
+++ b/tests/unit/test_pcap_reader.py
@@ -1,8 +1,0 @@
-"""Tests for the pcap-ng reader module.
-
-Naming convention: one test file per module or concern.
-Name files after the module/feature being tested, not individual functions.
-
-Good: test_pcap_reader.py, test_urb_decoder.py, test_session.py
-Bad:  test_parse_block.py, test_single_function.py
-"""

--- a/tests/unit/test_pcapng_reader.py
+++ b/tests/unit/test_pcapng_reader.py
@@ -1,0 +1,451 @@
+"""Tests for the pcap-ng reader module.
+
+Naming convention: one test file per module or concern.
+Name files after the module/feature being tested, not individual functions.
+
+Good: test_pcap_reader.py, test_urb_decoder.py, test_session.py
+Bad:  test_parse_block.py, test_single_function.py
+
+These tests build pcap-ng byte streams by hand so the suite does not
+depend on any external capture files. Real-capture round-trips belong
+in tests/int/ once we have reference captures from the hardware.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Literal
+
+import pytest
+
+from bsu_tool.pcapng import (
+    EnhancedPacketBlock,
+    InterfaceDescriptionBlock,
+    InterfaceStatisticsBlock,
+    InvalidBlockError,
+    PcapNgReader,
+    SectionHeaderBlock,
+    SimplePacketBlock,
+    TruncatedFileError,
+    UnknownBlock,
+    UnsupportedVersionError,
+)
+
+ByteOrder = Literal["little", "big"]
+
+
+# --- Construction helpers --------------------------------------------------
+
+
+def _pad4(data: bytes) -> bytes:
+    pad = (-len(data)) & 3
+    return data + b"\x00" * pad
+
+
+def _u16(value: int, order: ByteOrder) -> bytes:
+    return value.to_bytes(2, order)
+
+
+def _u32(value: int, order: ByteOrder) -> bytes:
+    return value.to_bytes(4, order)
+
+
+def _i64(value: int, order: ByteOrder) -> bytes:
+    return value.to_bytes(8, order, signed=True)
+
+
+def _option(code: int, value: bytes, order: ByteOrder) -> bytes:
+    return _u16(code, order) + _u16(len(value), order) + _pad4(value)
+
+
+def _opt_endofopt(order: ByteOrder) -> bytes:
+    return _u16(0, order) + _u16(0, order)
+
+
+def _wrap(block_type: int, body: bytes, order: ByteOrder) -> bytes:
+    """Wrap a body in the standard pcap-ng block framing."""
+    body = _pad4(body)
+    total_length = 4 + 4 + len(body) + 4
+    return _u32(block_type, order) + _u32(total_length, order) + body + _u32(total_length, order)
+
+
+def _build_shb(
+    order: ByteOrder = "little",
+    *,
+    major: int = 1,
+    minor: int = 0,
+    section_length: int = -1,
+    options: bytes = b"",
+) -> bytes:
+    """Build a Section Header Block.
+
+    The SHB has its own framing rules (block type is the same in both byte
+    orders, length is BOM-dependent), so we don't go through ``_wrap``.
+    """
+    bom = b"\x4d\x3c\x2b\x1a" if order == "little" else b"\x1a\x2b\x3c\x4d"
+    body = bom + _u16(major, order) + _u16(minor, order) + _i64(section_length, order)
+    body = body + _pad4(options)
+    total_length = 4 + 4 + len(body) + 4
+    return b"\x0a\x0d\x0d\x0a" + _u32(total_length, order) + body + _u32(total_length, order)
+
+
+def _build_idb(
+    order: ByteOrder = "little",
+    *,
+    link_type: int = 189,  # LINKTYPE_USB_LINUX
+    snap_len: int = 65535,
+    options: bytes = b"",
+) -> bytes:
+    body = (
+        _u16(link_type, order)
+        + _u16(0, order)  # reserved
+        + _u32(snap_len, order)
+        + options
+    )
+    return _wrap(0x00000001, body, order)
+
+
+def _build_epb(
+    order: ByteOrder = "little",
+    *,
+    interface_id: int = 0,
+    timestamp_high: int = 0,
+    timestamp_low: int = 0,
+    packet_data: bytes = b"\xde\xad\xbe\xef",
+    original_len: int | None = None,
+    options: bytes = b"",
+) -> bytes:
+    if original_len is None:
+        original_len = len(packet_data)
+    body = (
+        _u32(interface_id, order)
+        + _u32(timestamp_high, order)
+        + _u32(timestamp_low, order)
+        + _u32(len(packet_data), order)
+        + _u32(original_len, order)
+        + _pad4(packet_data)
+        + options
+    )
+    return _wrap(0x00000006, body, order)
+
+
+# --- Tests: basic happy paths ---------------------------------------------
+
+
+@pytest.mark.parametrize("order", ["little", "big"])
+def test_shb_only(order: ByteOrder) -> None:
+    data = _build_shb(order)
+    reader = PcapNgReader(io.BytesIO(data))
+    blocks = list(reader)
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert isinstance(block, SectionHeaderBlock)
+    assert block.byte_order == order
+    assert block.major_version == 1
+    assert block.minor_version == 0
+    assert block.section_length == -1
+    assert block.options == ()
+    assert reader.byte_order == order
+
+
+@pytest.mark.parametrize("order", ["little", "big"])
+def test_shb_idb_epb_minimal(order: ByteOrder) -> None:
+    payload = b"\x12\x34\x56\x78\x9a"
+    data = _build_shb(order) + _build_idb(order) + _build_epb(order, packet_data=payload)
+    blocks = list(PcapNgReader(io.BytesIO(data)))
+
+    assert len(blocks) == 3
+    shb, idb, epb = blocks
+    assert isinstance(shb, SectionHeaderBlock)
+    assert isinstance(idb, InterfaceDescriptionBlock)
+    assert isinstance(epb, EnhancedPacketBlock)
+
+    assert idb.link_type == 189
+    assert idb.snap_len == 65535
+    assert epb.interface_id == 0
+    assert epb.captured_len == len(payload)
+    assert epb.original_len == len(payload)
+    assert epb.packet_data == payload
+
+
+def test_options_parsing() -> None:
+    # Build an SHB with two options: shb_hardware (2) and shb_os (3).
+    options = _option(2, b"x86_64", "little") + _option(3, b"Linux 6.8", "little") + _opt_endofopt("little")
+    data = _build_shb("little", options=options)
+    blocks = list(PcapNgReader(io.BytesIO(data)))
+    assert len(blocks) == 1
+    shb = blocks[0]
+    assert isinstance(shb, SectionHeaderBlock)
+    assert len(shb.options) == 2
+    assert shb.options[0].code == 2
+    assert shb.options[0].value == b"x86_64"
+    assert shb.options[1].code == 3
+    assert shb.options[1].value == b"Linux 6.8"
+
+
+def test_options_no_endofopt() -> None:
+    # Options list that ends at the buffer boundary with no opt_endofopt record.
+    # Exercises the implicit-termination path (reader.py line 140).
+    options = _option(2, b"x86_64", "little") + _option(3, b"Linux 6.8", "little")
+    data = _build_shb("little", options=options)
+    blocks = list(PcapNgReader(io.BytesIO(data)))
+    shb = blocks[0]
+    assert isinstance(shb, SectionHeaderBlock)
+    assert len(shb.options) == 2
+    assert shb.options[0].value == b"x86_64"
+    assert shb.options[1].value == b"Linux 6.8"
+
+
+def test_reader_offset_advances() -> None:
+    # Verify the offset property is updated after reading blocks.
+    # Exercises the offset property getter (reader.py line 177).
+    data = _build_shb("little") + _build_idb("little")
+    reader = PcapNgReader(io.BytesIO(data))
+    assert reader.offset == 0
+    next(reader)
+    assert reader.offset == len(_build_shb("little"))
+    next(reader)
+    assert reader.offset == len(data)
+
+
+def test_unknown_block_preserved() -> None:
+    # Use block type 0xDEADBEEF (not one we model).
+    body = b"\xab\xcd\xef\x00"
+    data = _build_shb("little") + _wrap(0xDEADBEEF, body, "little")
+    blocks = list(PcapNgReader(io.BytesIO(data)))
+    assert len(blocks) == 2
+    unknown = blocks[1]
+    assert isinstance(unknown, UnknownBlock)
+    assert unknown.block_type == 0xDEADBEEF
+    assert unknown.body == body
+
+
+def test_isb_block() -> None:
+    body = (
+        _u32(0, "little")
+        + _u32(0x12345678, "little")
+        + _u32(0x9ABCDEF0, "little")
+        + _option(2, b"\x05\x00\x00\x00\x00\x00\x00\x00", "little")
+        + _opt_endofopt("little")
+    )
+    data = _build_shb("little") + _wrap(0x00000005, body, "little")
+    blocks = list(PcapNgReader(io.BytesIO(data)))
+    assert len(blocks) == 2
+    isb = blocks[1]
+    assert isinstance(isb, InterfaceStatisticsBlock)
+    assert isb.interface_id == 0
+    assert isb.timestamp_high == 0x12345678
+    assert isb.timestamp_low == 0x9ABCDEF0
+    assert len(isb.options) == 1
+
+
+def test_spb_block() -> None:
+    payload = b"hello!"
+    body = _u32(len(payload), "little") + _pad4(payload)
+    data = _build_shb("little") + _wrap(0x00000003, body, "little")
+    blocks = list(PcapNgReader(io.BytesIO(data)))
+    assert len(blocks) == 2
+    spb = blocks[1]
+    assert isinstance(spb, SimplePacketBlock)
+    assert spb.original_len == len(payload)
+    assert spb.packet_data == payload
+
+
+def test_multiple_sections_switch_byte_order() -> None:
+    # Section 1: little-endian, contains an IDB.
+    # Section 2: big-endian, contains an IDB with a different link_type.
+    data = (
+        _build_shb("little")
+        + _build_idb("little", link_type=189)
+        + _build_shb("big")
+        + _build_idb("big", link_type=220)
+    )
+    blocks = list(PcapNgReader(io.BytesIO(data)))
+    assert len(blocks) == 4
+    assert isinstance(blocks[0], SectionHeaderBlock)
+    assert blocks[0].byte_order == "little"
+    assert isinstance(blocks[1], InterfaceDescriptionBlock)
+    assert blocks[1].link_type == 189
+    assert isinstance(blocks[2], SectionHeaderBlock)
+    assert blocks[2].byte_order == "big"
+    assert isinstance(blocks[3], InterfaceDescriptionBlock)
+    assert blocks[3].link_type == 220
+
+
+# --- Tests: error paths ----------------------------------------------------
+
+
+def test_empty_stream_yields_nothing() -> None:
+    blocks = list(PcapNgReader(io.BytesIO(b"")))
+    assert blocks == []
+
+
+def test_first_block_must_be_shb() -> None:
+    # A bare IDB at offset 0, no SHB — must raise.
+    data = _build_idb("little")
+    with pytest.raises(InvalidBlockError, match="not a Section Header Block"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_invalid_byte_order_magic() -> None:
+    # Build something that looks like an SHB but has a corrupt BOM.
+    bad = (
+        b"\x0a\x0d\x0d\x0a"  # SHB type
+        + b"\x1c\x00\x00\x00"  # total length = 28, little-endian-ish
+        + b"\xff\xff\xff\xff"  # bogus BOM
+        + b"\x01\x00\x00\x00"  # major/minor
+        + b"\xff\xff\xff\xff\xff\xff\xff\xff"  # section_length = -1
+        + b"\x1c\x00\x00\x00"  # trailing length
+    )
+    with pytest.raises(InvalidBlockError, match="invalid byte-order magic"):
+        list(PcapNgReader(io.BytesIO(bad)))
+
+
+def test_unsupported_major_version() -> None:
+    data = _build_shb("little", major=2)
+    with pytest.raises(UnsupportedVersionError):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_truncated_block_header() -> None:
+    data = _build_shb("little") + b"\x01\x00"  # 2 bytes of a new block
+    with pytest.raises(TruncatedFileError):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_truncated_block_body() -> None:
+    # Build a valid SHB, then a block whose declared length is more than
+    # the bytes that follow.
+    valid = _build_shb("little")
+    # Block type 0x00000001, declared total length 100, but only 8 bytes follow.
+    truncated = b"\x01\x00\x00\x00" + b"\x64\x00\x00\x00" + b"\x00" * 8
+    with pytest.raises(TruncatedFileError):
+        list(PcapNgReader(io.BytesIO(valid + truncated)))
+
+
+def test_mismatched_trailing_length() -> None:
+    # Build a manually corrupted IDB: leading length 20, trailing length 24.
+    body = _u16(189, "little") + _u16(0, "little") + _u32(65535, "little")
+    body = _pad4(body)
+    bad = (
+        _u32(0x00000001, "little")
+        + _u32(20, "little")  # leading
+        + body
+        + _u32(24, "little")  # trailing — wrong on purpose
+    )
+    data = _build_shb("little") + bad
+    with pytest.raises(InvalidBlockError, match="trailing length"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_misaligned_block_length() -> None:
+    # Block total length not a multiple of 4.
+    bad = _u32(0x00000001, "little") + _u32(21, "little") + b"\x00" * 13
+    data = _build_shb("little") + bad
+    with pytest.raises(InvalidBlockError, match="multiple of 4"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_option_length_overruns_block() -> None:
+    # IDB with an option whose declared length exceeds the remaining bytes.
+    options = _u16(2, "little") + _u16(99, "little") + b"\x00" * 4
+    body = _u16(189, "little") + _u16(0, "little") + _u32(65535, "little") + options
+    data = _build_shb("little") + _wrap(0x00000001, body, "little")
+    with pytest.raises(InvalidBlockError, match="option"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_epb_captured_len_overruns_body() -> None:
+    # EPB declares captured_len = 100 but provides 4 bytes of payload.
+    body = (
+        _u32(0, "little")  # interface_id
+        + _u32(0, "little")  # ts_high
+        + _u32(0, "little")  # ts_low
+        + _u32(100, "little")  # captured_len (lie)
+        + _u32(100, "little")  # original_len
+        + b"\xaa\xbb\xcc\xdd"
+    )
+    data = _build_shb("little") + _wrap(0x00000006, body, "little")
+    with pytest.raises(InvalidBlockError, match="captured_len"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_shb_total_length_below_minimum() -> None:
+    """SHB whose declared total length is below the 28-byte minimum must raise."""
+    data = (
+        b"\x0a\x0d\x0d\x0a"
+        + _u32(16, "little")  # total length = 16 (below 28)
+        + b"\x4d\x3c\x2b\x1a"  # BOM
+    )
+    with pytest.raises(InvalidBlockError, match="below minimum"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_shb_total_length_not_aligned() -> None:
+    """SHB whose declared total length is not a multiple of 4 must raise."""
+    data = (
+        b"\x0a\x0d\x0d\x0a"
+        + _u32(29, "little")  # not divisible by 4
+        + b"\x4d\x3c\x2b\x1a"
+    )
+    with pytest.raises(InvalidBlockError, match="multiple of 4"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_shb_trailing_length_mismatch() -> None:
+    """SHB whose trailing length disagrees with its leading length must raise."""
+    data = (
+        b"\x0a\x0d\x0d\x0a"
+        + _u32(28, "little")  # leading length
+        + b"\x4d\x3c\x2b\x1a"  # BOM
+        + _u16(1, "little")  # major
+        + _u16(0, "little")  # minor
+        + _i64(-1, "little")  # section_length
+        + _u32(99, "little")  # trailing length (wrong)
+    )
+    with pytest.raises(InvalidBlockError, match="SHB trailing length"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_generic_block_total_length_below_minimum() -> None:
+    """A non-SHB block whose total length is below 12 must raise."""
+    bad = _u32(0x00000001, "little") + _u32(8, "little")  # length = 8
+    data = _build_shb("little") + bad
+    with pytest.raises(InvalidBlockError, match="below minimum"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_idb_body_too_small() -> None:
+    """IDB whose body is shorter than the fixed-header size must raise."""
+    # total_length = 16 → body = 4 bytes, less than _MIN_IDB_BODY (8)
+    bad = _u32(0x00000001, "little") + _u32(16, "little") + b"\x00" * 4 + _u32(16, "little")
+    data = _build_shb("little") + bad
+    with pytest.raises(InvalidBlockError, match="IDB body too small"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_epb_body_too_small() -> None:
+    """EPB whose body is shorter than the fixed-header size must raise."""
+    # total_length = 24 → body = 12 bytes, less than _MIN_EPB_BODY (20)
+    bad = _u32(0x00000006, "little") + _u32(24, "little") + b"\x00" * 12 + _u32(24, "little")
+    data = _build_shb("little") + bad
+    with pytest.raises(InvalidBlockError, match="EPB body too small"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_spb_body_too_small() -> None:
+    """SPB with an empty body must raise."""
+    # total_length = 12 → body = 0 bytes, less than _MIN_SPB_BODY (4)
+    bad = _u32(0x00000003, "little") + _u32(12, "little") + _u32(12, "little")
+    data = _build_shb("little") + bad
+    with pytest.raises(InvalidBlockError, match="SPB body too small"):
+        list(PcapNgReader(io.BytesIO(data)))
+
+
+def test_isb_body_too_small() -> None:
+    """ISB whose body is shorter than the fixed-header size must raise."""
+    # total_length = 20 → body = 8 bytes, less than _MIN_ISB_BODY (12)
+    bad = _u32(0x00000005, "little") + _u32(20, "little") + b"\x00" * 8 + _u32(20, "little")
+    data = _build_shb("little") + bad
+    with pytest.raises(InvalidBlockError, match="ISB body too small"):
+        list(PcapNgReader(io.BytesIO(data)))


### PR DESCRIPTION
## What does this PR do?

Adds the pcap-ng reader — a block-by-block parser for pcap-ng capture files. Foundation for everything that follows: URB decoding, session model, analysis tools.

New package `bsu_tool/pcapng/` (layout mirrors `bsu_tool/mcp/`):

- `blocks.py` — frozen dataclasses for SHB, IDB, EPB, SPB, ISB, plus `UnknownBlock` fallback for unrecognized types
- `errors.py` — exception hierarchy rooted at `PcapNgError`
- `reader.py` — `PcapNgReader`, a stream-based iterator over a binary file-like
- `__init__.py` — public API re-exports

Design choices worth flagging for review:

- **Structural decoding only.** URB-level decoding of `EnhancedPacketBlock.packet_data` is deferred to a future module so the two parsing layers stay independently testable. URB decoder is the next PR.
- **No cross-block validation.** The parser doesn't verify that an EPB's `interface_id` corresponds to a known IDB — that belongs in the session model (Milestone 2).
- **Endianness from SHB.** Verified against the pcap-ng spec point by point: BOM resolution, signed `section_length`, 4-byte alignment, trailing length validation, option TLV parsing, padding handling, unknown-block fallback. Multiple sections with different byte orders in one file are supported and tested.

Also adjusts `pyproject.toml` to scope strict pyright to `bsu_tool/` only — `pytest.raises` and `@pytest.mark.parametrize` aren't strictly-typed upstream and were failing every test that used them. Adds `pytest` as `additional_dependencies` for the pyright pre-commit hook so the hook environment can resolve the import.

Out of scope: URB decoding, cross-block validation, real-capture integration tests (waiting on hardware), Name Resolution Block / obsolete Packet Block type (round-trip as `UnknownBlock`).

closes #17

## How was it tested?

```
ruff check .         # clean
ruff format .        # clean
pyright              # clean
pytest               # 29 passed
```

Tests in `tests/unit/test_pcapng_reader.py` build pcap-ng byte streams by hand — no dependency on external capture files. **99% coverage** on `bsu_tool/pcapng/reader.py`; the one uncovered line (line 361, `EPB padding runs past block end`) is unreachable through the public API given the 4-byte alignment invariants enforced upstream. Kept as defense-in-depth against future refactors rather than removed or marked `# pragma: no cover`.

Integration tests against real captures from team hardware will land separately in `tests/int/` once reference captures are checked in.

## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR