### PR TITLE
Add named markers to capture sessions

### DIFF
--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -1,11 +1,17 @@
 """In-memory data structures for parsed USB capture sessions."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
 class USBDevice:
-    """A USB device observed in a parsed capture."""
+    """A USB device observed in a parsed capture.
+
+    Attributes:
+        bus_num: USB bus number reported by the capture source.
+        dev_num: Device number assigned on the USB bus.
+        endpoints: Endpoint numbers observed for this device.
+    """
 
     bus_num: int
     dev_num: int
@@ -13,9 +19,47 @@ class USBDevice:
 
 
 @dataclass
+class Marker:
+    """A named point of interest within a parsed capture.
+
+    Attributes:
+        name: Human-readable marker label, such as "button_press".
+        packet_index: Packet number this marker points to in the capture.
+        note: Optional analyst note describing the marked event.
+    """
+
+    name: str
+    packet_index: int
+    note: str = ""
+
+
+def _new_marker_list() -> list[Marker]:
+    """Return a new marker list for a CaptureSession instance."""
+    return []
+
+
+@dataclass
 class CaptureSession:
-    """A parsed USB capture held in memory for later analysis."""
+    """A parsed USB capture held in memory for later analysis.
+
+    Attributes:
+        filepath: Path to the original pcap-ng capture file.
+        devices: USB devices observed in the capture.
+        packet_count: Total number of packets in the capture.
+        markers: Analyst-defined labels tied to packet indexes.
+    """
 
     filepath: str
     devices: list[USBDevice]
     packet_count: int
+    markers: list[Marker] = field(default_factory=_new_marker_list)
+
+    def add_marker(self, name: str, packet_index: int, note: str = "") -> None:
+        """Add a named marker at a packet index in the capture.
+
+        Args:
+            name: Human-readable marker label, such as "button_press".
+            packet_index: Packet number the marker should reference.
+            note: Optional analyst note describing the marked event.
+        """
+        self.markers.append(Marker(name=name, packet_index=packet_index, note=note))

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -18,3 +18,40 @@ def test_capture_session_stores_capture_metadata() -> None:
     assert session.devices[0].bus_num == 1
     assert session.devices[0].dev_num == 7
     assert session.devices[0].endpoints == [0, 1, 129]
+
+
+def test_capture_session_adds_marker() -> None:
+    """CaptureSession can add a marker at a packet index."""
+    session = CaptureSession(filepath="/captures/sample.pcapng", devices=[], packet_count=42)
+
+    session.add_marker(name="button_press", packet_index=12)
+
+    assert len(session.markers) == 1
+    assert session.markers[0].name == "button_press"
+    assert session.markers[0].packet_index == 12
+    assert session.markers[0].note == ""
+
+
+def test_capture_session_adds_marker_with_note() -> None:
+    """CaptureSession can add a marker with an optional note."""
+    session = CaptureSession(filepath="/captures/sample.pcapng", devices=[], packet_count=42)
+
+    session.add_marker(name="button_press", packet_index=12, note="Pressed relay toggle")
+
+    assert session.markers[0].name == "button_press"
+    assert session.markers[0].packet_index == 12
+    assert session.markers[0].note == "Pressed relay toggle"
+
+
+def test_capture_session_adds_multiple_markers() -> None:
+    """CaptureSession preserves multiple markers in insertion order."""
+    session = CaptureSession(filepath="/captures/sample.pcapng", devices=[], packet_count=42)
+
+    session.add_marker(name="button_press_start", packet_index=12)
+    session.add_marker(name="button_press_end", packet_index=18)
+
+    assert len(session.markers) == 2
+    assert session.markers[0].name == "button_press_start"
+    assert session.markers[0].packet_index == 12
+    assert session.markers[1].name == "button_press_end"
+    assert session.markers[1].packet_index == 18


### PR DESCRIPTION
Adds a named marker system to `CaptureSession` 

This PR adds:
- A `Marker` dataclass for labeling specific packet indexes
- A `markers` list on `CaptureSession`
- An `add_marker()` method for appending markers
- Unit tests for adding one marker, adding a marker with a note, and adding multiple markers

Closes #21


Ran locally to test:

- `./venv/bin/ruff check .`
- `./venv/bin/ruff format --check .`
- `./venv/bin/pyright`
- `pytest`

All checks passed from what I can tell!