### PR TITLE
16/list devices mcp tool

### DIFF
--- a/bsu_tool/mcp/interfaces.py
+++ b/bsu_tool/mcp/interfaces.py
@@ -1,8 +1,10 @@
-"""Typed capture models used by MCP session and tools."""
+"""Typed models used by MCP session and tools."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+
+from bsu_tool.urb_decoder import TransferType
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,3 +38,20 @@ class CaptureMetadata:
     packet_count: int
     capture_duration_seconds: float | None
     interfaces_seen: tuple[CaptureInterface, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceSummary:
+    """A USB device observed in a loaded capture."""
+
+    device_id: str
+    bus_num: int
+    dev_num: int
+    packet_count: int
+    endpoints_seen: tuple[str, ...]
+    transfer_types_seen: tuple[TransferType, ...]
+    vendor_id: str | None = None
+    product_id: str | None = None
+    manufacturer: str | None = None
+    product: str | None = None
+    descriptor_summary: str | None = None

--- a/bsu_tool/mcp/session.py
+++ b/bsu_tool/mcp/session.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final
 
-from bsu_tool.mcp.interfaces import CaptureInterface, CaptureMetadata, CapturePacket
+from bsu_tool.mcp.interfaces import CaptureInterface, CaptureMetadata, CapturePacket, DeviceSummary
 from bsu_tool.pcapng_reader import (
     EnhancedPacketBlock,
     InterfaceDescriptionBlock,
@@ -16,6 +16,7 @@ from bsu_tool.pcapng_reader import (
     SimplePacketBlock,
 )
 from bsu_tool.urb_decoder import (
+    TransferType,
     UnsupportedTransferTypeError,
     UrbRecord,
     UrbTransaction,
@@ -28,6 +29,11 @@ _IF_TSRESOL_OPTION: Final[int] = 9
 _DEFAULT_TIMESTAMP_RESOLUTION_SECONDS: Final[float] = 1 / 1_000_000
 _BINARY_RESOLUTION_FLAG: Final[int] = 0x80
 _RESOLUTION_VALUE_MASK: Final[int] = 0x7F
+_GET_DESCRIPTOR_REQUEST: Final[int] = 0x06
+_DEVICE_DESCRIPTOR_TYPE: Final[int] = 0x01
+_STRING_DESCRIPTOR_TYPE: Final[int] = 0x03
+_ENDPOINT_IN_FLAG: Final[int] = 0x80
+_TRANSFER_TYPE_ORDER: Final[tuple[TransferType, ...]] = ("control", "bulk")
 
 
 @dataclass(frozen=True)
@@ -43,6 +49,18 @@ def _empty_markers() -> list[Marker]:
     return []
 
 
+def _empty_endpoint_addresses() -> set[int]:
+    return set()
+
+
+def _empty_transfer_types() -> set[TransferType]:
+    return set()
+
+
+def _empty_string_descriptors() -> dict[int, str]:
+    return {}
+
+
 @dataclass
 class Capture:
     """Loaded state for a single pcap-ng file."""
@@ -53,6 +71,22 @@ class Capture:
     records: tuple[UrbRecord, ...]
     transactions: tuple[UrbTransaction, ...]
     markers: list[Marker] = field(default_factory=_empty_markers)
+
+
+@dataclass
+class _DeviceAccumulator:
+    bus_num: int
+    dev_num: int
+    packet_count: int = 0
+    endpoint_addresses: set[int] = field(default_factory=_empty_endpoint_addresses)
+    transfer_types: set[TransferType] = field(default_factory=_empty_transfer_types)
+    vendor_id: str | None = None
+    product_id: str | None = None
+    manufacturer: str | None = None
+    product: str | None = None
+    manufacturer_index: int | None = None
+    product_index: int | None = None
+    string_descriptors: dict[int, str] = field(default_factory=_empty_string_descriptors)
 
 
 @dataclass
@@ -114,6 +148,12 @@ class Session:
         marker = Marker(name=name, timestamp=timestamp, note=note)
         self.capture.markers.append(marker)
         return marker
+
+    def list_devices(self) -> tuple[DeviceSummary, ...]:
+        """Return USB devices observed in the active capture."""
+        if self.capture is None:
+            raise RuntimeError("No capture loaded. Call load_capture() first.")
+        return _summarize_devices(self.capture.records, self.capture.transactions)
 
 
 def _validate_capture_path(path: Path) -> Path:
@@ -203,3 +243,158 @@ def _decode_supported_packets(packets: list[CapturePacket]) -> tuple[UrbRecord, 
         except UnsupportedTransferTypeError:
             continue
     return tuple(records)
+
+
+def _summarize_devices(
+    records: tuple[UrbRecord, ...],
+    transactions: tuple[UrbTransaction, ...],
+) -> tuple[DeviceSummary, ...]:
+    devices: dict[tuple[int, int], _DeviceAccumulator] = {}
+    for record in records:
+        accumulator = _device_accumulator(devices, record.bus_num, record.dev_num)
+        accumulator.packet_count += 1
+        accumulator.endpoint_addresses.add(_endpoint_address(record))
+        accumulator.transfer_types.add(record.transfer_type)
+
+    for transaction in transactions:
+        _apply_descriptor_info(devices, transaction)
+
+    return tuple(
+        _device_summary(accumulator)
+        for _, accumulator in sorted(devices.items(), key=lambda item: (item[0][0], item[0][1]))
+    )
+
+
+def _device_accumulator(
+    devices: dict[tuple[int, int], _DeviceAccumulator],
+    bus_num: int,
+    dev_num: int,
+) -> _DeviceAccumulator:
+    key = (bus_num, dev_num)
+    accumulator = devices.get(key)
+    if accumulator is None:
+        accumulator = _DeviceAccumulator(bus_num=bus_num, dev_num=dev_num)
+        devices[key] = accumulator
+    return accumulator
+
+
+def _endpoint_address(record: UrbRecord) -> int:
+    if record.endpoint == 0:
+        return 0
+    if record.direction == "in":
+        return record.endpoint | _ENDPOINT_IN_FLAG
+    return record.endpoint
+
+
+def _apply_descriptor_info(
+    devices: dict[tuple[int, int], _DeviceAccumulator],
+    transaction: UrbTransaction,
+) -> None:
+    submission = transaction.submission
+    completion = transaction.completion
+    if submission is None or completion is None or submission.setup is None:
+        return
+    accumulator = devices.get((submission.bus_num, submission.dev_num))
+    if accumulator is None:
+        return
+
+    descriptor_type = _requested_descriptor_type(submission.setup)
+    descriptor_index = submission.setup[2]
+    if descriptor_type == _DEVICE_DESCRIPTOR_TYPE:
+        _apply_device_descriptor(accumulator, completion.data)
+        return
+    if descriptor_type == _STRING_DESCRIPTOR_TYPE and descriptor_index > 0:
+        descriptor = _decode_string_descriptor(completion.data)
+        if descriptor is not None:
+            accumulator.string_descriptors[descriptor_index] = descriptor
+
+
+def _requested_descriptor_type(setup: bytes) -> int | None:
+    if len(setup) != 8 or setup[1] != _GET_DESCRIPTOR_REQUEST:
+        return None
+    return setup[3]
+
+
+def _apply_device_descriptor(accumulator: _DeviceAccumulator, data: bytes) -> None:
+    if len(data) < 18 or data[1] != _DEVICE_DESCRIPTOR_TYPE:
+        return
+    accumulator.vendor_id = _format_usb_id(data[8], data[9])
+    accumulator.product_id = _format_usb_id(data[10], data[11])
+    accumulator.manufacturer_index = _descriptor_string_index(data[14])
+    accumulator.product_index = _descriptor_string_index(data[15])
+
+
+def _format_usb_id(low: int, high: int) -> str:
+    return f"0x{((high << 8) | low):04x}"
+
+
+def _descriptor_string_index(value: int) -> int | None:
+    if value == 0:
+        return None
+    return value
+
+
+def _decode_string_descriptor(data: bytes) -> str | None:
+    if len(data) < 2 or data[1] != _STRING_DESCRIPTOR_TYPE:
+        return None
+    descriptor_length = min(data[0], len(data))
+    if descriptor_length <= 2:
+        return None
+    payload = data[2:descriptor_length]
+    if len(payload) % 2 != 0:
+        payload = payload[:-1]
+    try:
+        decoded = payload.decode("utf-16-le")
+    except UnicodeDecodeError:
+        return None
+    decoded = decoded.rstrip("\x00")
+    if decoded == "":
+        return None
+    return decoded
+
+
+def _device_summary(accumulator: _DeviceAccumulator) -> DeviceSummary:
+    manufacturer = _descriptor_string(accumulator, accumulator.manufacturer_index)
+    product = _descriptor_string(accumulator, accumulator.product_index)
+    return DeviceSummary(
+        device_id=_device_id(accumulator.bus_num, accumulator.dev_num),
+        bus_num=accumulator.bus_num,
+        dev_num=accumulator.dev_num,
+        packet_count=accumulator.packet_count,
+        endpoints_seen=tuple(f"0x{endpoint:02x}" for endpoint in sorted(accumulator.endpoint_addresses)),
+        transfer_types_seen=_sorted_transfer_types(accumulator.transfer_types),
+        vendor_id=accumulator.vendor_id,
+        product_id=accumulator.product_id,
+        manufacturer=manufacturer,
+        product=product,
+        descriptor_summary=_descriptor_summary(accumulator, manufacturer, product),
+    )
+
+
+def _descriptor_string(accumulator: _DeviceAccumulator, index: int | None) -> str | None:
+    if index is None:
+        return None
+    return accumulator.string_descriptors.get(index)
+
+
+def _sorted_transfer_types(transfer_types: set[TransferType]) -> tuple[TransferType, ...]:
+    return tuple(transfer_type for transfer_type in _TRANSFER_TYPE_ORDER if transfer_type in transfer_types)
+
+
+def _device_id(bus_num: int, dev_num: int) -> str:
+    return f"dev_{bus_num:03d}_{dev_num:03d}"
+
+
+def _descriptor_summary(
+    accumulator: _DeviceAccumulator,
+    manufacturer: str | None,
+    product: str | None,
+) -> str | None:
+    if accumulator.vendor_id is None and accumulator.product_id is None:
+        return None
+    label = "USB device"
+    if manufacturer is not None and product is not None:
+        label = f"{manufacturer} {product}"
+    elif product is not None:
+        label = product
+    return f"{label} ({accumulator.vendor_id}:{accumulator.product_id})"

--- a/bsu_tool/mcp/tools/__init__.py
+++ b/bsu_tool/mcp/tools/__init__.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 from mcp.server.fastmcp import FastMCP
 
 from bsu_tool.mcp.session import Session
-from bsu_tool.mcp.tools import capture
+from bsu_tool.mcp.tools import capture, devices
 
 
 def register_all(mcp: FastMCP, session: Session) -> None:
     """Register every MCP tool group against the FastMCP instance."""
     capture.register(mcp, session)
-    return
+    devices.register(mcp, session)

--- a/bsu_tool/mcp/tools/devices.py
+++ b/bsu_tool/mcp/tools/devices.py
@@ -1,0 +1,60 @@
+"""Device-enumeration MCP tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Final
+
+from mcp.server.fastmcp import FastMCP
+
+from bsu_tool.mcp.interfaces import DeviceSummary
+from bsu_tool.mcp.session import Session
+
+_DEFAULT_LIMIT: Final[int] = 100
+_MAX_LIMIT: Final[int] = 1000
+
+
+@dataclass(frozen=True, slots=True)
+class ListDevicesResult:
+    """Devices returned by list_devices."""
+
+    devices: tuple[DeviceSummary, ...]
+    total_count: int
+    offset: int
+    limit: int
+    returned_count: int
+    has_more: bool
+
+
+def register(mcp: FastMCP, session: Session) -> None:
+    """Register device-enumeration tools on the FastMCP instance."""
+
+    @mcp.tool()
+    def list_devices(  # pyright: ignore[reportUnusedFunction]
+        include_descriptor_summary: bool = True,
+        offset: int = 0,
+        limit: int = _DEFAULT_LIMIT,
+    ) -> ListDevicesResult:
+        """List USB devices observed in the active capture."""
+        _validate_pagination(offset, limit)
+        devices = session.list_devices()
+        page = devices[offset : offset + limit]
+        if not include_descriptor_summary:
+            page = tuple(replace(device, descriptor_summary=None) for device in page)
+        return ListDevicesResult(
+            devices=page,
+            total_count=len(devices),
+            offset=offset,
+            limit=limit,
+            returned_count=len(page),
+            has_more=offset + len(page) < len(devices),
+        )
+
+
+def _validate_pagination(offset: int, limit: int) -> None:
+    if offset < 0:
+        raise ValueError("offset must be greater than or equal to 0")
+    if limit < 1:
+        raise ValueError("limit must be greater than or equal to 1")
+    if limit > _MAX_LIMIT:
+        raise ValueError(f"limit must be less than or equal to {_MAX_LIMIT}")

--- a/tests/int/test_mcp_list_devices_goodix.py
+++ b/tests/int/test_mcp_list_devices_goodix.py
@@ -1,0 +1,30 @@
+"""Integration tests for MCP device listing on a real Goodix capture."""
+
+from __future__ import annotations
+
+import pathlib
+
+from bsu_tool.mcp.session import Session
+
+_CAPTURE = (
+    pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures" / "goodix_enum_and_enroll_sanitized.pcapng"
+)
+
+
+def test_list_devices_goodix_capture() -> None:
+    """Session.list_devices enumerates multiple devices from the Goodix capture."""
+    session = Session()
+    capture = session.load(_CAPTURE)
+
+    devices = session.list_devices()
+
+    assert capture.metadata.packet_count == 253
+    assert len(capture.records) == 249
+    assert [device.device_id for device in devices] == ["dev_001_000", "dev_001_001", "dev_001_011"]
+    assert [device.packet_count for device in devices] == [8, 74, 167]
+    assert devices[2].endpoints_seen == ("0x00", "0x01", "0x83")
+    assert devices[2].transfer_types_seen == ("control", "bulk")
+    assert devices[2].vendor_id == "0x27c6"
+    assert devices[2].product_id == "0x63ac"
+    assert devices[2].manufacturer == "Goodix Technology Co., Ltd."
+    assert devices[2].product == "Goodix Fingerprint USB Device"

--- a/tests/unit/mcp/test_interfaces.py
+++ b/tests/unit/mcp/test_interfaces.py
@@ -1,6 +1,6 @@
 """Tests for MCP typed capture models."""
 
-from bsu_tool.mcp.interfaces import CaptureInterface, CaptureMetadata, CapturePacket
+from bsu_tool.mcp.interfaces import CaptureInterface, CaptureMetadata, CapturePacket, DeviceSummary
 
 
 def test_capture_metadata_contains_load_capture_fields() -> None:
@@ -43,3 +43,27 @@ def test_capture_packet_retains_packet_block_bytes() -> None:
     assert packet.pcap_captured_length == 3
     assert packet.pcap_original_length == 4
     assert packet.packet_data == b"abc"
+
+
+def test_device_summary_contains_list_devices_fields() -> None:
+    """DeviceSummary carries the Issue #16 list_devices result fields."""
+    device = DeviceSummary(
+        device_id="dev_001_004",
+        bus_num=1,
+        dev_num=4,
+        packet_count=5,
+        endpoints_seen=("0x00", "0x81"),
+        transfer_types_seen=("control", "bulk"),
+        vendor_id="0x27c6",
+        product_id="0x533c",
+        manufacturer="Goodix",
+        product="Fingerprint Reader",
+        descriptor_summary="Goodix Fingerprint Reader (0x27c6:0x533c)",
+    )
+
+    assert device.bus_num == 1
+    assert device.dev_num == 4
+    assert device.packet_count == 5
+    assert device.endpoints_seen == ("0x00", "0x81")
+    assert device.transfer_types_seen == ("control", "bulk")
+    assert device.vendor_id == "0x27c6"

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -1,6 +1,10 @@
 """Smoke tests for the MCP server bootstrap."""
 
+import asyncio
+
+import pytest
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 
 from bsu_tool.mcp.server import build_server
 from bsu_tool.mcp.session import Session
@@ -17,3 +21,31 @@ def test_build_server_accepts_injected_session() -> None:
     session = Session()
     server = build_server(session=session)
     assert isinstance(server, FastMCP)
+
+
+def test_build_server_registers_list_devices_tool() -> None:
+    """build_server registers the Issue #16 list_devices tool."""
+
+    async def tool_names() -> set[str]:
+        tools = await build_server().list_tools()
+        return {tool.name for tool in tools}
+
+    assert "list_devices" in asyncio.run(tool_names())
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        ({"offset": -1}, "offset must be greater than or equal to 0"),
+        ({"limit": 0}, "limit must be greater than or equal to 1"),
+        ({"limit": 1001}, "limit must be less than or equal to 1000"),
+    ],
+)
+def test_list_devices_rejects_invalid_pagination(arguments: dict[str, int], message: str) -> None:
+    """list_devices validates pagination arguments before querying the session."""
+
+    async def call_tool() -> None:
+        await build_server().call_tool("list_devices", arguments)
+
+    with pytest.raises(ToolError, match=message):
+        asyncio.run(call_tool())

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -6,10 +6,12 @@ from pathlib import Path
 import pytest
 
 from bsu_tool.mcp.session import Marker, Session
+from bsu_tool.pcapng_reader import PcapNgError
 
 _USBMON_HEADER_FORMAT = "<QBBBBHBBqiiII8s"
 _SUBMISSION = 0x53
 _COMPLETION = 0x43
+_CONTROL = 2
 _BULK = 3
 _INTERRUPT = 1
 
@@ -66,6 +68,10 @@ def _usbmon_packet(
     event: int = _SUBMISSION,
     transfer_type: int = _BULK,
     endpoint: int = 0x01,
+    dev_num: int = 4,
+    bus_num: int = 1,
+    flag_setup: int = 0,
+    setup: bytes = b"\x00" * 8,
     data: bytes = b"",
 ) -> bytes:
     header = struct.pack(
@@ -74,18 +80,52 @@ def _usbmon_packet(
         event,
         transfer_type,
         endpoint,
-        4,
-        1,
-        0,
+        dev_num,
+        bus_num,
+        flag_setup,
         0,
         100,
         0,
         0,
         len(data),
         len(data),
-        b"\x00" * 8,
+        setup,
     )
     return header + data
+
+
+def _get_descriptor_setup(descriptor_type: int, descriptor_index: int, length: int) -> bytes:
+    return bytes((0x80, 0x06, descriptor_index, descriptor_type, 0x09, 0x04, length & 0xFF, length >> 8))
+
+
+def _device_descriptor(*, vendor_id: int, product_id: int, manufacturer_index: int, product_index: int) -> bytes:
+    return bytes(
+        (
+            18,
+            1,
+            0,
+            2,
+            0xFF,
+            0,
+            0,
+            64,
+            vendor_id & 0xFF,
+            vendor_id >> 8,
+            product_id & 0xFF,
+            product_id >> 8,
+            0,
+            1,
+            manufacturer_index,
+            product_index,
+            0,
+            1,
+        )
+    )
+
+
+def _string_descriptor(value: str) -> bytes:
+    payload = value.encode("utf-16-le")
+    return bytes((len(payload) + 2, 3)) + payload
 
 
 def _capture_bytes(packet_data: tuple[bytes, ...] | None = None) -> bytes:
@@ -160,6 +200,32 @@ def test_load_rejects_missing_file(tmp_path: Path) -> None:
         Session().load(tmp_path / "missing.pcapng")
 
 
+def test_load_rejects_malformed_pcapng_without_replacing_capture(tmp_path: Path) -> None:
+    """Session.load leaves the active capture untouched when parsing fails."""
+    session = Session()
+    first = session.load(_write_capture(tmp_path, "first.pcapng"))
+    malformed = tmp_path / "malformed.pcapng"
+    malformed.write_bytes(b"nope")
+
+    with pytest.raises(PcapNgError):
+        session.load(malformed)
+
+    assert session.capture is first
+
+
+def test_load_rejects_packet_with_unknown_interface(tmp_path: Path) -> None:
+    """Session.load rejects packet blocks that reference a missing interface."""
+    path = tmp_path / "bad-interface.pcapng"
+    path.write_bytes(
+        _build_shb()
+        + _build_idb(snap_len=64)
+        + _build_epb(timestamp_low=1_000_000, packet_data=_usbmon_packet(), interface_id=1)
+    )
+
+    with pytest.raises(ValueError, match="unknown interface_id 1"):
+        Session().load(path)
+
+
 def test_load_skips_unsupported_transfers(tmp_path: Path) -> None:
     """Session.load keeps metadata while skipping unsupported decoded records."""
     path = tmp_path / "interrupt.pcapng"
@@ -170,6 +236,89 @@ def test_load_skips_unsupported_transfers(tmp_path: Path) -> None:
     assert capture.metadata.packet_count == 1
     assert len(capture.records) == 0
     assert len(capture.transactions) == 0
+
+
+def test_list_devices_returns_empty_for_unsupported_only_capture(tmp_path: Path) -> None:
+    """list_devices returns an empty tuple when no packets decode into records."""
+    path = tmp_path / "interrupt-only.pcapng"
+    path.write_bytes(_capture_bytes((_usbmon_packet(transfer_type=_INTERRUPT),)))
+    session = Session()
+    session.load(path)
+
+    assert session.list_devices() == ()
+
+
+def test_list_devices_requires_loaded_capture() -> None:
+    """list_devices raises RuntimeError if no capture has been loaded."""
+    with pytest.raises(RuntimeError):
+        Session().list_devices()
+
+
+def test_list_devices_summarizes_multiple_devices(tmp_path: Path) -> None:
+    """Session.list_devices returns typed summaries for multiple devices."""
+    setup_device = _get_descriptor_setup(descriptor_type=1, descriptor_index=0, length=18)
+    setup_manufacturer = _get_descriptor_setup(descriptor_type=3, descriptor_index=1, length=255)
+    setup_product = _get_descriptor_setup(descriptor_type=3, descriptor_index=2, length=255)
+    descriptor = _device_descriptor(vendor_id=0x27C6, product_id=0x533C, manufacturer_index=1, product_index=2)
+    path = tmp_path / "multi-device.pcapng"
+    path.write_bytes(
+        _capture_bytes(
+            (
+                _usbmon_packet(urb_id=1, endpoint=0x01, dev_num=4, data=b"a"),
+                _usbmon_packet(urb_id=1, event=_COMPLETION, endpoint=0x81, dev_num=4, data=b"bc"),
+                _usbmon_packet(urb_id=2, endpoint=0x02, dev_num=7, data=b"d"),
+                _usbmon_packet(urb_id=3, transfer_type=_CONTROL, endpoint=0x80, dev_num=7, setup=setup_device),
+                _usbmon_packet(
+                    urb_id=3,
+                    event=_COMPLETION,
+                    transfer_type=_CONTROL,
+                    endpoint=0x80,
+                    dev_num=7,
+                    flag_setup=0x3E,
+                    data=descriptor,
+                ),
+                _usbmon_packet(urb_id=4, transfer_type=_CONTROL, endpoint=0x80, dev_num=7, setup=setup_manufacturer),
+                _usbmon_packet(
+                    urb_id=4,
+                    event=_COMPLETION,
+                    transfer_type=_CONTROL,
+                    endpoint=0x80,
+                    dev_num=7,
+                    flag_setup=0x3E,
+                    data=_string_descriptor("Goodix"),
+                ),
+                _usbmon_packet(urb_id=5, transfer_type=_CONTROL, endpoint=0x80, dev_num=7, setup=setup_product),
+                _usbmon_packet(
+                    urb_id=5,
+                    event=_COMPLETION,
+                    transfer_type=_CONTROL,
+                    endpoint=0x80,
+                    dev_num=7,
+                    flag_setup=0x3E,
+                    data=_string_descriptor("Fingerprint Reader"),
+                ),
+            )
+        )
+    )
+
+    session = Session()
+    capture = session.load(path)
+    device_summaries = session.list_devices()
+
+    assert len(capture.records) == 9
+    assert capture.metadata.packet_count == 9
+    assert [device.device_id for device in device_summaries] == ["dev_001_004", "dev_001_007"]
+    assert device_summaries[0].packet_count == 2
+    assert device_summaries[0].endpoints_seen == ("0x01", "0x81")
+    assert device_summaries[0].transfer_types_seen == ("bulk",)
+    assert device_summaries[1].packet_count == 7
+    assert device_summaries[1].endpoints_seen == ("0x00", "0x02")
+    assert device_summaries[1].transfer_types_seen == ("control", "bulk")
+    assert device_summaries[1].vendor_id == "0x27c6"
+    assert device_summaries[1].product_id == "0x533c"
+    assert device_summaries[1].manufacturer == "Goodix"
+    assert device_summaries[1].product == "Fingerprint Reader"
+    assert device_summaries[1].descriptor_summary == "Goodix Fingerprint Reader (0x27c6:0x533c)"
 
 
 def test_add_marker_requires_loaded_capture() -> None:


### PR DESCRIPTION
## What does this PR do?

Implements the MCP `list_devices` tool for loaded USB captures.

- Adds typed `DeviceSummary` and `ListDevicesResult` models
- Registers a new MCP `list_devices` tool
- Enumerates devices from the active MCP session after `load_capture`
- Groups decoded URB records by `bus_num` and `dev_num`
- Returns packet count, endpoints seen, transfer types seen, and best-effort descriptor details
- Supports `include_descriptor_summary`, `offset`, and `limit`
- Validates pagination arguments
- Adds coverage for multiple devices, unsupported-only captures, malformed load behavior, and a real Goodix capture

`list_devices` currently reports devices from decoded `UrbRecord` values. Interrupt-only devices remain invisible until interrupt decoding is supported by the decoder.

closes #16

## How was it tested?

Ran the local check suite:

```
ruff check .
ruff format --check .
pyright
pytest
```

Also manually verified the MCP flow with the checked-in Goodix capture:

```
test_data/captures/goodix_enum_and_enroll_sanitized.pcapng
```

The flow `load_capture -> list_devices` returned 3 devices:

- `dev_001_000`
- `dev_001_001`
- `dev_001_011`

## Notes

FastMCP currently emits output schema warnings for dataclass return types. The tools are callable and tested, but formal `outputSchema` alignment should be handled as a follow-up MCP interface cleanup, likely under #14.

## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR