### PR TITLE
Added a section for the session model in overview.md

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -13,3 +13,27 @@
 ## Diagram
 
 <!-- Add a diagram here if helpful (ASCII or linked image) -->
+
+## Session Model
+<!-- In-memory data model that holds a parsed USB capture -->
+
+The session model is built around three dataclasses that represent a parsed USB
+capture held in memory.
+
+**`CaptureSession`** is the top-level container for a recording. It holds the
+path to the original `.pcapng` file, the total packet count, and the list of
+USB devices observed during the session.
+
+**`USBDevice`** represents a single USB device seen during a capture. It stores
+the bus number, the device number on that bus, and the list of endpoint numbers
+that were active. A session can contain multiple `USBDevice` objects if more
+than one device was present at the same time.
+
+**`Marker`** is an analyst-supplied label tied to a specific timestamp in the
+capture. Markers exist so that reviewers can flag moments of interest — for
+example, the instant a relay switched — without scrubbing through raw packet data.
+
+**Example:** a capture of a USB relay board might produce one `CaptureSession`
+referencing `relay_board.pcapng`, containing one `USBDevice` (bus 1, device 3)
+with three endpoints, and two `Marker` objects — one when the relay turned on
+and one when it turned off.


### PR DESCRIPTION
## What does this PR do?

Added a new section in the bottom of overview.md for the session model description

## How was it tested?

I wrote my finding looking through session.py in both the mcp file and in the original bsu-tool file. After a brief check of  wording and simplification using Claude, I think that this is a reasonable explanation of the session model in our code.

## Checklist

- [X] PR description includes `closes #N`
- [x] No unintended files included in this PR
