### PR TITLE
Fix .mcp.json cross-platform adaptation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ htmlcov/
 # Claude config
 .claude/
 
+# MCP config — generated per-OS by setup.sh (command path differs by platform)
+.mcp.json
+
 # VSCode
 .vscode/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "bsu-tool": {
-      "command": ".venv/Scripts/bsu-tool.exe",
-      "args": ["mcp"]
-    }
-  }
-}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ source .venv/bin/activate        # Linux / Mac
 source .venv/Scripts/activate    # Git Bash (Windows)
 ```
 
+The MCP server config (`.mcp.json`) is generated per-OS by `setup.sh` and is gitignored, since the launch command differs between platforms (`.venv/bin/python` vs `.venv/Scripts/python.exe`). In Claude Code, run `/mcp` to connect.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow, branching conventions, code standards, and testing guide.
 
 ## Documentation

--- a/setup.sh
+++ b/setup.sh
@@ -145,6 +145,33 @@ elif [[ -f ".env" ]]; then
     ok ".env already exists."
 fi
 
+# ── MCP config (.mcp.json) — generated per-OS ─────────────────────────────────
+# .mcp.json is gitignored because the launch command differs by platform
+# (.venv/bin/python vs .venv/Scripts/python.exe). Generate it from $VENV_PYTHON
+# so Claude Code can start the bundled MCP server on any OS.
+write_mcp_config() {
+    cat > ".mcp.json" <<EOF
+{
+  "mcpServers": {
+    "bsu-tool": {
+      "command": "$VENV_PYTHON",
+      "args": ["-m", "bsu_tool", "mcp"]
+    }
+  }
+}
+EOF
+}
+
+if [[ -f ".mcp.json" && "$FORCE" -ne 1 ]] && grep -qF "\"$VENV_PYTHON\"" ".mcp.json"; then
+    ok ".mcp.json already targets this platform, leaving as-is."
+else
+    if [[ -f ".mcp.json" && "$FORCE" -ne 1 ]]; then
+        warn ".mcp.json targets another platform or is stale — regenerating."
+    fi
+    write_mcp_config
+    ok ".mcp.json generated → $VENV_PYTHON -m bsu_tool mcp"
+fi
+
 # ── Smoke test ────────────────────────────────────────────────────────────────
 info "Verifying install..."
 if "$VENV_PYTHON" -c "import bsu_tool" 2>/dev/null; then
@@ -158,5 +185,7 @@ echo ""
 ok "Setup complete."
 info "Activate your environment:"
 info "  source $ACTIVATE"
+info ""
+info "In Claude Code, run /mcp to (re)connect the bsu-tool MCP server."
 info ""
 info "To force a clean reinstall: ./setup.sh --force"


### PR DESCRIPTION
## What does this PR do?

Fix MCP config generation for cross-platform development setup

## Summary

This PR updates the MCP setup so `.mcp.json` is generated locally by `setup.sh` instead of being committed with a platform-specific path.

The previous committed config used a Windows-specific virtual environment path, which could break MCP setup on macOS/Linux.

## Changes

* Remove the committed `.mcp.json` file from the repository.
* Add `.mcp.json` to `.gitignore` because it is generated per local environment.
* Update `setup.sh` to generate `.mcp.json` using the detected virtual environment Python path.
* Launch the MCP server through the detected venv Python with `-m bsu_tool mcp`.
* Update the README to explain that `.mcp.json` is generated by `setup.sh` and that users can run `/mcp` in Claude Code to connect the server.

## Notes / Future Work

This change improves development setup across macOS, Linux, and Windows/Git Bash, but we may still want to narrow the official supported target platform later, likely around Ubuntu/Linux.
