### PR TITLE
43/get packets mcp tool

### DIFF
--- a/bsu_tool/mcp/interfaces.py
+++ b/bsu_tool/mcp/interfaces.py
@@ -82,11 +82,11 @@ class PacketRecord:
     device_id: str
     bus_num: int
     dev_num: int
-    endpoint_address: str
+    endpoint_address: str  # full USB address incl. direction bit, e.g. "0x83" (EP3 IN)
+    endpoint_number: int  # bare endpoint number 0-15
     status: int
-    length: int
-    captured_length: int
-    data_length: int
+    length: int  # URB-reported full data length; exceeds data_length when truncated
+    data_length: int  # bytes actually captured
     data_preview: str | None
     setup: str | None
     timestamp: float

--- a/bsu_tool/mcp/interfaces.py
+++ b/bsu_tool/mcp/interfaces.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from bsu_tool.urb_decoder import TransferType
+from bsu_tool.urb_decoder import Direction, EventType, TransferType
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,3 +63,42 @@ class DeviceSummary:
     manufacturer: str | None = None
     product: str | None = None
     descriptor_summary: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PacketRecord:
+    """A decoded URB packet exposed by get_packets.
+
+    This is a flat, self-contained view built from a :class:`~bsu_tool.urb_decoder.UrbRecord`.
+    It intentionally does not extend ``UrbRecord``; binary payloads are rendered as
+    hex strings so the record is trivially serializable over MCP.
+    """
+
+    index: int
+    urb_id: int
+    event_type: EventType
+    transfer_type: TransferType
+    direction: Direction
+    device_id: str
+    bus_num: int
+    dev_num: int
+    endpoint_address: str
+    status: int
+    length: int
+    captured_length: int
+    data_length: int
+    data_preview: str | None
+    setup: str | None
+    timestamp: float
+
+
+@dataclass(frozen=True, slots=True)
+class PacketSelection:
+    """All decoded packets matching a get_packets filter, plus the capture total.
+
+    ``total_count`` counts every decoded record in the capture, independent of the
+    filter, so it can differ from ``len(matches)``.
+    """
+
+    matches: tuple[PacketRecord, ...]
+    total_count: int

--- a/bsu_tool/mcp/tools/__init__.py
+++ b/bsu_tool/mcp/tools/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from bsu_tool.mcp.tools import capture, devices
+from bsu_tool.mcp.tools import capture, devices, packets
 from bsu_tool.session import Session
 
 
@@ -16,3 +16,4 @@ def register_all(mcp: FastMCP, session: Session) -> None:
     """Register every MCP tool group against the FastMCP instance."""
     capture.register(mcp, session)
     devices.register(mcp, session)
+    packets.register(mcp, session)

--- a/bsu_tool/mcp/tools/devices.py
+++ b/bsu_tool/mcp/tools/devices.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Final
 
 from mcp.server.fastmcp import FastMCP
 
 from bsu_tool.mcp.interfaces import DeviceSummary
+from bsu_tool.mcp.tools.pagination import DEFAULT_LIMIT, validate_pagination
 from bsu_tool.session import Session
-
-_DEFAULT_LIMIT: Final[int] = 100
-_MAX_LIMIT: Final[int] = 1000
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,10 +30,10 @@ def register(mcp: FastMCP, session: Session) -> None:
     def list_devices(  # pyright: ignore[reportUnusedFunction]
         include_descriptor_summary: bool = True,
         offset: int = 0,
-        limit: int = _DEFAULT_LIMIT,
+        limit: int = DEFAULT_LIMIT,
     ) -> ListDevicesResult:
         """List USB devices observed in the active capture."""
-        _validate_pagination(offset, limit)
+        validate_pagination(offset, limit)
         devices = session.list_devices()
         page = devices[offset : offset + limit]
         if not include_descriptor_summary:
@@ -49,12 +46,3 @@ def register(mcp: FastMCP, session: Session) -> None:
             returned_count=len(page),
             has_more=offset + len(page) < len(devices),
         )
-
-
-def _validate_pagination(offset: int, limit: int) -> None:
-    if offset < 0:
-        raise ValueError("offset must be greater than or equal to 0")
-    if limit < 1:
-        raise ValueError("limit must be greater than or equal to 1")
-    if limit > _MAX_LIMIT:
-        raise ValueError(f"limit must be less than or equal to {_MAX_LIMIT}")

--- a/bsu_tool/mcp/tools/packets.py
+++ b/bsu_tool/mcp/tools/packets.py
@@ -1,0 +1,63 @@
+"""Packet-retrieval MCP tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from bsu_tool.mcp.interfaces import PacketRecord
+from bsu_tool.mcp.tools.pagination import DEFAULT_LIMIT, validate_pagination
+from bsu_tool.session import Session
+from bsu_tool.urb_decoder import Direction, EventType, TransferType
+
+
+@dataclass(frozen=True, slots=True)
+class GetPacketsResult:
+    """A page of decoded packets returned by get_packets."""
+
+    packets: tuple[PacketRecord, ...]
+    total_count: int
+    match_count: int
+    offset: int
+    limit: int
+    returned_count: int
+    has_more: bool
+
+
+def register(mcp: FastMCP, session: Session) -> None:
+    """Register packet-retrieval tools on the FastMCP instance."""
+
+    @mcp.tool()
+    def get_packets(  # pyright: ignore[reportUnusedFunction]
+        device_id: str | None = None,
+        endpoint: str | None = None,
+        direction: Direction | None = None,
+        transfer_type: TransferType | None = None,
+        event_type: EventType | None = None,
+        offset: int = 0,
+        limit: int = DEFAULT_LIMIT,
+    ) -> GetPacketsResult:
+        """Retrieve decoded Control and Bulk URB packets from the active capture.
+
+        Filters (device_id, endpoint, direction, transfer_type, event_type) narrow
+        the result; pagination (offset, limit) selects a slice of the matches.
+        """
+        validate_pagination(offset, limit)
+        selection = session.get_packets(
+            device_id=device_id,
+            endpoint=endpoint,
+            direction=direction,
+            transfer_type=transfer_type,
+            event_type=event_type,
+        )
+        page = selection.matches[offset : offset + limit]
+        return GetPacketsResult(
+            packets=page,
+            total_count=selection.total_count,
+            match_count=len(selection.matches),
+            offset=offset,
+            limit=limit,
+            returned_count=len(page),
+            has_more=offset + len(page) < len(selection.matches),
+        )

--- a/bsu_tool/mcp/tools/packets.py
+++ b/bsu_tool/mcp/tools/packets.py
@@ -40,8 +40,19 @@ def register(mcp: FastMCP, session: Session) -> None:
     ) -> GetPacketsResult:
         """Retrieve decoded Control and Bulk URB packets from the active capture.
 
-        Filters (device_id, endpoint, direction, transfer_type, event_type) narrow
-        the result; pagination (offset, limit) selects a slice of the matches.
+        Filters compose — a packet must satisfy all that are given. Two need
+        explaining beyond their schema:
+
+        - device_id: a ``dev_bbb_ddd`` id from list_devices.
+        - endpoint: a decimal endpoint number such as ``"3"`` or ``"15"``. A
+          ``0x``-prefixed address like ``"0x83"`` is also accepted (its endpoint
+          number is used; direction bit ignored). Direction is orthogonal — use
+          ``direction`` for IN/OUT.
+
+        Pagination (offset, limit) slices the matches. The result reports both
+        ``match_count`` (packets passing the filter) and ``total_count`` (all
+        decoded packets). Each returned packet's ``endpoint_address`` is the full
+        USB address, whereas ``endpoint`` filters by number.
         """
         validate_pagination(offset, limit)
         selection = session.get_packets(
@@ -51,13 +62,14 @@ def register(mcp: FastMCP, session: Session) -> None:
             transfer_type=transfer_type,
             event_type=event_type,
         )
+        match_count = len(selection.matches)
         page = selection.matches[offset : offset + limit]
         return GetPacketsResult(
             packets=page,
             total_count=selection.total_count,
-            match_count=len(selection.matches),
+            match_count=match_count,
             offset=offset,
             limit=limit,
             returned_count=len(page),
-            has_more=offset + len(page) < len(selection.matches),
+            has_more=offset + len(page) < match_count,
         )

--- a/bsu_tool/mcp/tools/pagination.py
+++ b/bsu_tool/mcp/tools/pagination.py
@@ -1,0 +1,18 @@
+"""Shared offset/limit pagination validation for MCP tools."""
+
+from __future__ import annotations
+
+from typing import Final
+
+DEFAULT_LIMIT: Final[int] = 100
+MAX_LIMIT: Final[int] = 1000
+
+
+def validate_pagination(offset: int, limit: int) -> None:
+    """Validate the offset/limit arguments common to paginated MCP tools."""
+    if offset < 0:
+        raise ValueError("offset must be greater than or equal to 0")
+    if limit < 1:
+        raise ValueError("limit must be greater than or equal to 1")
+    if limit > MAX_LIMIT:
+        raise ValueError(f"limit must be less than or equal to {MAX_LIMIT}")

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -6,7 +6,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final
 
-from bsu_tool.mcp.interfaces import CaptureInterface, CaptureMetadata, CapturePacket, DeviceSummary, EndpointSummary
+from bsu_tool.mcp.interfaces import (
+    CaptureInterface,
+    CaptureMetadata,
+    CapturePacket,
+    DeviceSummary,
+    EndpointSummary,
+    PacketRecord,
+    PacketSelection,
+)
 from bsu_tool.pcapng_reader import (
     EnhancedPacketBlock,
     InterfaceDescriptionBlock,
@@ -16,6 +24,8 @@ from bsu_tool.pcapng_reader import (
     SimplePacketBlock,
 )
 from bsu_tool.urb_decoder import (
+    Direction,
+    EventType,
     TransferType,
     UnsupportedTransferTypeError,
     UrbRecord,
@@ -34,6 +44,7 @@ _DEVICE_DESCRIPTOR_TYPE: Final[int] = 0x01
 _STRING_DESCRIPTOR_TYPE: Final[int] = 0x03
 _ENDPOINT_IN_FLAG: Final[int] = 0x80
 _TRANSFER_TYPE_ORDER: Final[tuple[TransferType, ...]] = ("control", "bulk")
+_DATA_PREVIEW_BYTES: Final[int] = 32
 
 
 @dataclass(frozen=True)
@@ -156,6 +167,54 @@ class Session:
             raise RuntimeError("No capture loaded. Call load_capture() first.")
         return _summarize_devices(self.capture.records, self.capture.transactions)
 
+    def get_packets(
+        self,
+        *,
+        device_id: str | None = None,
+        endpoint: str | None = None,
+        direction: Direction | None = None,
+        transfer_type: TransferType | None = None,
+        event_type: EventType | None = None,
+    ) -> PacketSelection:
+        """Return decoded URB packets from the active capture, filtered in place.
+
+        Every keyword narrows the result independently; ``None`` disables that
+        criterion. Only Control and Bulk packets exist in the decoded stream —
+        Interrupt and Isochronous records were dropped at load time.
+
+        Args:
+            device_id: Restrict to one device by its ``dev_bbb_ddd`` id.
+            endpoint: Restrict to one endpoint address, e.g. ``"0x81"`` or ``"1"``.
+            direction: Restrict to ``"in"`` or ``"out"`` transfers.
+            transfer_type: Restrict to ``"control"`` or ``"bulk"`` transfers.
+            event_type: Restrict to ``"submission"``, ``"completion"``, or ``"error"``.
+
+        Returns:
+            A :class:`PacketSelection` whose ``matches`` satisfy every filter and
+            whose ``total_count`` is the number of decoded records in the capture.
+
+        Raises:
+            RuntimeError: No capture has been loaded.
+            ValueError: ``endpoint`` is not a valid endpoint address.
+        """
+        if self.capture is None:
+            raise RuntimeError("No capture loaded. Call load_capture() first.")
+        endpoint_address = _normalize_endpoint(endpoint)
+        records = self.capture.records
+        matches = tuple(
+            _packet_record(index, record)
+            for index, record in enumerate(records)
+            if _record_matches(
+                record,
+                device_id=device_id,
+                endpoint_address=endpoint_address,
+                direction=direction,
+                transfer_type=transfer_type,
+                event_type=event_type,
+            )
+        )
+        return PacketSelection(matches=matches, total_count=len(records))
+
 
 def _validate_capture_path(path: Path) -> Path:
     source = path.expanduser().resolve()
@@ -244,6 +303,67 @@ def _decode_supported_packets(packets: list[CapturePacket]) -> tuple[UrbRecord, 
         except UnsupportedTransferTypeError:
             continue
     return tuple(records)
+
+
+def _packet_record(index: int, record: UrbRecord) -> PacketRecord:
+    return PacketRecord(
+        index=index,
+        urb_id=record.urb_id,
+        event_type=record.event_type,
+        transfer_type=record.transfer_type,
+        direction=record.direction,
+        device_id=_device_id(record.bus_num, record.dev_num),
+        bus_num=record.bus_num,
+        dev_num=record.dev_num,
+        endpoint_address=f"0x{_endpoint_address(record):02x}",
+        status=record.status,
+        length=record.length,
+        captured_length=record.captured_length,
+        data_length=len(record.data),
+        data_preview=_data_preview(record.data),
+        setup=record.setup.hex() if record.setup is not None else None,
+        timestamp=record.timestamp,
+    )
+
+
+def _data_preview(data: bytes) -> str | None:
+    if not data:
+        return None
+    return data[:_DATA_PREVIEW_BYTES].hex()
+
+
+def _normalize_endpoint(endpoint: str | None) -> str | None:
+    if endpoint is None:
+        return None
+    try:
+        value = int(endpoint, 16)
+    except ValueError as error:
+        raise ValueError(f"endpoint must be a hexadecimal address, got {endpoint!r}") from error
+    if not 0 <= value <= 0xFF:
+        raise ValueError(f"endpoint must be a single-byte address in 0x00-0xff, got {endpoint!r}")
+    return f"0x{value:02x}"
+
+
+def _record_matches(
+    record: UrbRecord,
+    *,
+    device_id: str | None,
+    endpoint_address: str | None,
+    direction: Direction | None,
+    transfer_type: TransferType | None,
+    event_type: EventType | None,
+) -> bool:
+    if device_id is not None and _device_id(record.bus_num, record.dev_num) != device_id:
+        return False
+    if endpoint_address is not None and f"0x{_endpoint_address(record):02x}" != endpoint_address:
+        return False
+    if direction is not None and record.direction != direction:
+        return False
+    if transfer_type is not None and record.transfer_type != transfer_type:
+        return False
+    if event_type is not None and record.event_type != event_type:
+        return False
+    return True
 
 
 def _summarize_devices(

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -43,6 +43,7 @@ _GET_DESCRIPTOR_REQUEST: Final[int] = 0x06
 _DEVICE_DESCRIPTOR_TYPE: Final[int] = 0x01
 _STRING_DESCRIPTOR_TYPE: Final[int] = 0x03
 _ENDPOINT_IN_FLAG: Final[int] = 0x80
+_ENDPOINT_NUMBER_MASK: Final[int] = 0x0F
 _TRANSFER_TYPE_ORDER: Final[tuple[TransferType, ...]] = ("control", "bulk")
 _DATA_PREVIEW_BYTES: Final[int] = 32
 
@@ -184,7 +185,10 @@ class Session:
 
         Args:
             device_id: Restrict to one device by its ``dev_bbb_ddd`` id.
-            endpoint: Restrict to one endpoint address, e.g. ``"0x81"`` or ``"1"``.
+            endpoint: Restrict to one endpoint number in decimal, e.g. ``"3"`` or
+                ``"15"``. A ``0x``-prefixed full address such as ``"0x83"`` is also
+                accepted — only its endpoint number (low nibble) is used, the
+                direction bit is ignored. Use ``direction`` to select IN or OUT.
             direction: Restrict to ``"in"`` or ``"out"`` transfers.
             transfer_type: Restrict to ``"control"`` or ``"bulk"`` transfers.
             event_type: Restrict to ``"submission"``, ``"completion"``, or ``"error"``.
@@ -195,11 +199,11 @@ class Session:
 
         Raises:
             RuntimeError: No capture has been loaded.
-            ValueError: ``endpoint`` is not a valid endpoint address.
+            ValueError: ``endpoint`` is not a valid endpoint number or address.
         """
         if self.capture is None:
             raise RuntimeError("No capture loaded. Call load_capture() first.")
-        endpoint_address = _normalize_endpoint(endpoint)
+        endpoint_number = _normalize_endpoint(endpoint)
         records = self.capture.records
         matches = tuple(
             _packet_record(index, record)
@@ -207,7 +211,7 @@ class Session:
             if _record_matches(
                 record,
                 device_id=device_id,
-                endpoint_address=endpoint_address,
+                endpoint_number=endpoint_number,
                 direction=direction,
                 transfer_type=transfer_type,
                 event_type=event_type,
@@ -316,9 +320,9 @@ def _packet_record(index: int, record: UrbRecord) -> PacketRecord:
         bus_num=record.bus_num,
         dev_num=record.dev_num,
         endpoint_address=f"0x{_endpoint_address(record):02x}",
+        endpoint_number=record.endpoint,
         status=record.status,
         length=record.length,
-        captured_length=record.captured_length,
         data_length=len(record.data),
         data_preview=_data_preview(record.data),
         setup=record.setup.hex() if record.setup is not None else None,
@@ -332,30 +336,41 @@ def _data_preview(data: bytes) -> str | None:
     return data[:_DATA_PREVIEW_BYTES].hex()
 
 
-def _normalize_endpoint(endpoint: str | None) -> str | None:
+def _normalize_endpoint(endpoint: str | None) -> int | None:
     if endpoint is None:
         return None
+    text = endpoint.lower()
+    if text.startswith("0x"):  # full USB address; keep the endpoint number (low nibble)
+        try:
+            address = int(text, 16)
+        except ValueError as error:
+            raise ValueError(f"endpoint address must be hexadecimal, got {endpoint!r}") from error
+        if not 0 <= address <= 0xFF:
+            raise ValueError(f"endpoint address must be in 0x00-0xff, got {endpoint!r}")
+        return address & _ENDPOINT_NUMBER_MASK
     try:
-        value = int(endpoint, 16)
+        number = int(text, 10)
     except ValueError as error:
-        raise ValueError(f"endpoint must be a hexadecimal address, got {endpoint!r}") from error
-    if not 0 <= value <= 0xFF:
-        raise ValueError(f"endpoint must be a single-byte address in 0x00-0xff, got {endpoint!r}")
-    return f"0x{value:02x}"
+        raise ValueError(
+            f"endpoint must be a decimal number 0-15 or a 0x-prefixed address, got {endpoint!r}"
+        ) from error
+    if not 0 <= number <= _ENDPOINT_NUMBER_MASK:
+        raise ValueError(f"endpoint number must be 0-15, got {endpoint!r}")
+    return number
 
 
 def _record_matches(
     record: UrbRecord,
     *,
     device_id: str | None,
-    endpoint_address: str | None,
+    endpoint_number: int | None,
     direction: Direction | None,
     transfer_type: TransferType | None,
     event_type: EventType | None,
 ) -> bool:
     if device_id is not None and _device_id(record.bus_num, record.dev_num) != device_id:
         return False
-    if endpoint_address is not None and f"0x{_endpoint_address(record):02x}" != endpoint_address:
+    if endpoint_number is not None and record.endpoint != endpoint_number:
         return False
     if direction is not None and record.direction != direction:
         return False

--- a/tests/int/test_mcp_get_packets_goodix.py
+++ b/tests/int/test_mcp_get_packets_goodix.py
@@ -1,0 +1,34 @@
+"""Integration tests for MCP packet retrieval on a real Goodix capture."""
+
+from __future__ import annotations
+
+import pathlib
+
+from bsu_tool.session import Session
+
+_CAPTURE = (
+    pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures" / "goodix_enum_and_enroll_sanitized.pcapng"
+)
+
+
+def test_get_packets_goodix_capture() -> None:
+    """Session.get_packets returns decoded packets and filters a multi-device capture."""
+    session = Session()
+    capture = session.load(_CAPTURE)
+
+    everything = session.get_packets()
+    assert everything.total_count == len(capture.records) == 249
+    assert len(everything.matches) == 249
+    assert [packet.index for packet in everything.matches[:3]] == [0, 1, 2]
+
+    device = session.get_packets(device_id="dev_001_011")
+    assert device.total_count == 249
+    assert 0 < len(device.matches) < everything.total_count
+    assert {packet.device_id for packet in device.matches} == {"dev_001_011"}
+
+    bulk_in = session.get_packets(device_id="dev_001_011", transfer_type="bulk", direction="in")
+    assert bulk_in.matches
+    for packet in bulk_in.matches:
+        assert packet.transfer_type == "bulk"
+        assert packet.direction == "in"
+        assert packet.endpoint_address == "0x83"

--- a/tests/int/test_mcp_get_packets_goodix.py
+++ b/tests/int/test_mcp_get_packets_goodix.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import pathlib
 
+from mcp.types import TextContent
+
+from bsu_tool.mcp.server import build_server
 from bsu_tool.session import Session
 
 _CAPTURE = (
@@ -32,3 +37,30 @@ def test_get_packets_goodix_capture() -> None:
         assert packet.transfer_type == "bulk"
         assert packet.direction == "in"
         assert packet.endpoint_address == "0x83"
+
+    # Endpoint filters by number: "3" and full address "0x83" both reach EP3 IN
+    # once direction is pinned.
+    by_number = session.get_packets(device_id="dev_001_011", endpoint="3", direction="in")
+    assert by_number.matches == bulk_in.matches
+    assert session.get_packets(device_id="dev_001_011", endpoint="0x83", direction="in").matches == bulk_in.matches
+
+
+def test_get_packets_tool_assembles_paginated_result() -> None:
+    """The get_packets MCP tool paginates and reports match vs total counts end to end."""
+    session = Session()
+    session.load(_CAPTURE)
+    server = build_server(session=session)
+
+    content = asyncio.run(server.call_tool("get_packets", {"transfer_type": "control", "limit": 5}))
+    assert isinstance(content, list)
+    block = content[0]
+    assert isinstance(block, TextContent)
+    payload = json.loads(block.text)
+
+    assert payload["total_count"] == 249
+    assert 0 < payload["match_count"] < payload["total_count"]
+    assert payload["returned_count"] == 5
+    assert payload["limit"] == 5
+    assert payload["has_more"] is True
+    assert len(payload["packets"]) == 5
+    assert all(packet["transfer_type"] == "control" for packet in payload["packets"])

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -49,3 +49,33 @@ def test_list_devices_rejects_invalid_pagination(arguments: dict[str, int], mess
 
     with pytest.raises(ToolError, match=message):
         asyncio.run(call_tool())
+
+
+def test_build_server_registers_get_packets_tool() -> None:
+    """build_server registers the Issue #43 get_packets tool."""
+
+    async def tool_names() -> set[str]:
+        tools = await build_server().list_tools()
+        return {tool.name for tool in tools}
+
+    assert "get_packets" in asyncio.run(tool_names())
+
+
+def test_get_packets_rejects_invalid_pagination() -> None:
+    """get_packets is wired to the shared pagination validator (exhaustively tested above)."""
+
+    async def call_tool() -> None:
+        await build_server().call_tool("get_packets", {"offset": -1})
+
+    with pytest.raises(ToolError, match="offset must be greater than or equal to 0"):
+        asyncio.run(call_tool())
+
+
+def test_get_packets_without_capture_reports_error() -> None:
+    """get_packets fails gracefully when no capture has been loaded."""
+
+    async def call_tool() -> None:
+        await build_server().call_tool("get_packets", {})
+
+    with pytest.raises(ToolError, match="No capture loaded"):
+        asyncio.run(call_tool())

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -328,6 +328,128 @@ def test_list_devices_summarizes_multiple_devices(tmp_path: Path) -> None:
     assert device_summaries[1].descriptor_summary == "Goodix Fingerprint Reader (0x27c6:0x533c)"
 
 
+def _multi_device_packets() -> tuple[bytes, ...]:
+    return (
+        _usbmon_packet(urb_id=1, endpoint=0x01, dev_num=4, data=b"a"),
+        _usbmon_packet(urb_id=1, event=_COMPLETION, endpoint=0x81, dev_num=4, data=b"bc"),
+        _usbmon_packet(
+            urb_id=2, transfer_type=_CONTROL, endpoint=0x80, dev_num=7, setup=b"\x80\x06\x00\x01\x00\x00\x12\x00"
+        ),
+        _usbmon_packet(urb_id=2, event=_COMPLETION, transfer_type=_CONTROL, endpoint=0x80, dev_num=7, data=b"xyz"),
+        _usbmon_packet(urb_id=3, endpoint=0x02, dev_num=7, data=b"d"),
+    )
+
+
+def test_get_packets_requires_loaded_capture() -> None:
+    """get_packets raises RuntimeError if no capture has been loaded."""
+    with pytest.raises(RuntimeError):
+        Session().get_packets()
+
+
+def test_get_packets_returns_typed_records(tmp_path: Path) -> None:
+    """get_packets returns typed PacketRecord objects with decoded fields and previews."""
+    path = tmp_path / "packets.pcapng"
+    path.write_bytes(_capture_bytes(_multi_device_packets()))
+    session = Session()
+    session.load(path)
+
+    selection = session.get_packets()
+
+    assert selection.total_count == 5
+    assert len(selection.matches) == 5
+    first = selection.matches[0]
+    assert first.index == 0
+    assert first.device_id == "dev_001_004"
+    assert first.transfer_type == "bulk"
+    assert first.direction == "out"
+    assert first.endpoint_address == "0x01"
+    assert first.event_type == "submission"
+    assert first.data_length == 1
+    assert first.data_preview == b"a".hex()
+    assert first.setup is None
+    control = selection.matches[2]
+    assert control.transfer_type == "control"
+    assert control.endpoint_address == "0x00"
+    assert control.setup == b"\x80\x06\x00\x01\x00\x00\x12\x00".hex()
+
+
+def test_get_packets_empty_data_has_no_preview(tmp_path: Path) -> None:
+    """A packet with no captured data reports data_preview None."""
+    path = tmp_path / "empty.pcapng"
+    path.write_bytes(_capture_bytes((_usbmon_packet(urb_id=1, endpoint=0x01, dev_num=4, data=b""),)))
+    session = Session()
+    session.load(path)
+
+    (packet,) = session.get_packets().matches
+    assert packet.data_length == 0
+    assert packet.data_preview is None
+
+
+def test_get_packets_filters_by_device(tmp_path: Path) -> None:
+    """device_id narrows matches while total_count stays at the full decoded count."""
+    path = tmp_path / "multi.pcapng"
+    path.write_bytes(_capture_bytes(_multi_device_packets()))
+    session = Session()
+    session.load(path)
+
+    selection = session.get_packets(device_id="dev_001_007")
+
+    assert selection.total_count == 5
+    assert len(selection.matches) == 3
+    assert {packet.device_id for packet in selection.matches} == {"dev_001_007"}
+
+
+def test_get_packets_filters_by_endpoint_direction_and_type(tmp_path: Path) -> None:
+    """Endpoint, direction, transfer-type, and event filters compose."""
+    path = tmp_path / "multi.pcapng"
+    path.write_bytes(_capture_bytes(_multi_device_packets()))
+    session = Session()
+    session.load(path)
+
+    assert len(session.get_packets(endpoint="0x81").matches) == 1
+    assert len(session.get_packets(endpoint="81").matches) == 1
+    assert len(session.get_packets(direction="in").matches) == 3
+    assert len(session.get_packets(transfer_type="control").matches) == 2
+    assert len(session.get_packets(event_type="completion").matches) == 2
+    combined = session.get_packets(device_id="dev_001_007", transfer_type="bulk", direction="out")
+    assert len(combined.matches) == 1
+    assert combined.matches[0].endpoint_address == "0x02"
+
+
+def test_get_packets_rejects_invalid_endpoint(tmp_path: Path) -> None:
+    """A non-hexadecimal endpoint filter raises ValueError."""
+    path = tmp_path / "multi.pcapng"
+    path.write_bytes(_capture_bytes(_multi_device_packets()))
+    session = Session()
+    session.load(path)
+
+    with pytest.raises(ValueError, match="hexadecimal"):
+        session.get_packets(endpoint="zz")
+    with pytest.raises(ValueError, match="single-byte"):
+        session.get_packets(endpoint="0x181")
+    with pytest.raises(ValueError, match="single-byte"):
+        session.get_packets(endpoint="-1")
+
+
+def test_get_packets_excludes_interrupt(tmp_path: Path) -> None:
+    """Interrupt packets never appear in the decoded record stream."""
+    path = tmp_path / "interrupt.pcapng"
+    path.write_bytes(
+        _capture_bytes(
+            (
+                _usbmon_packet(urb_id=1, endpoint=0x01, dev_num=4, data=b"a"),
+                _usbmon_packet(urb_id=2, transfer_type=_INTERRUPT, endpoint=0x83, dev_num=4, data=b"z"),
+            )
+        )
+    )
+    session = Session()
+    session.load(path)
+
+    selection = session.get_packets()
+    assert selection.total_count == 1
+    assert selection.matches[0].transfer_type == "bulk"
+
+
 def test_add_marker_requires_loaded_capture() -> None:
     """add_marker raises RuntimeError if no capture has been loaded."""
     session = Session()

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -363,6 +363,7 @@ def test_get_packets_returns_typed_records(tmp_path: Path) -> None:
     assert first.transfer_type == "bulk"
     assert first.direction == "out"
     assert first.endpoint_address == "0x01"
+    assert first.endpoint_number == 1
     assert first.event_type == "submission"
     assert first.data_length == 1
     assert first.data_preview == b"a".hex()
@@ -406,8 +407,16 @@ def test_get_packets_filters_by_endpoint_direction_and_type(tmp_path: Path) -> N
     session = Session()
     session.load(path)
 
-    assert len(session.get_packets(endpoint="0x81").matches) == 1
-    assert len(session.get_packets(endpoint="81").matches) == 1
+    # endpoint 1 appears as an OUT submission and an IN completion, so filtering
+    # by number matches both; a full address filters by number too; direction narrows.
+    assert len(session.get_packets(endpoint="1").matches) == 2
+    assert len(session.get_packets(endpoint="0x81").matches) == 2
+    in_packet = session.get_packets(endpoint="1", direction="in")
+    assert len(in_packet.matches) == 1
+    assert in_packet.matches[0].endpoint_address == "0x81"
+    out_packet = session.get_packets(endpoint="0x81", direction="out")
+    assert len(out_packet.matches) == 1
+    assert out_packet.matches[0].endpoint_address == "0x01"
     assert len(session.get_packets(direction="in").matches) == 3
     assert len(session.get_packets(transfer_type="control").matches) == 2
     assert len(session.get_packets(event_type="completion").matches) == 2
@@ -416,19 +425,19 @@ def test_get_packets_filters_by_endpoint_direction_and_type(tmp_path: Path) -> N
     assert combined.matches[0].endpoint_address == "0x02"
 
 
-def test_get_packets_rejects_invalid_endpoint(tmp_path: Path) -> None:
-    """A non-hexadecimal endpoint filter raises ValueError."""
-    path = tmp_path / "multi.pcapng"
-    path.write_bytes(_capture_bytes(_multi_device_packets()))
+def test_get_packets_endpoint_number_is_decimal(tmp_path: Path) -> None:
+    """endpoint "15" means endpoint 15 (decimal), not 0x15 (=21 -> 5); addresses use 0x."""
+    path = tmp_path / "ep15.pcapng"
+    path.write_bytes(_capture_bytes((_usbmon_packet(endpoint=0x0F, dev_num=4, data=b"z"),)))
     session = Session()
     session.load(path)
 
-    with pytest.raises(ValueError, match="hexadecimal"):
-        session.get_packets(endpoint="zz")
-    with pytest.raises(ValueError, match="single-byte"):
-        session.get_packets(endpoint="0x181")
-    with pytest.raises(ValueError, match="single-byte"):
-        session.get_packets(endpoint="-1")
+    assert len(session.get_packets(endpoint="15").matches) == 1  # decimal 15 -> endpoint 15
+    assert len(session.get_packets(endpoint="0x8f").matches) == 1  # address low nibble = 15
+    assert len(session.get_packets(endpoint="5").matches) == 0  # not misparsed as 0x15 -> 5
+    for bad in ("zz", "0xzz", "16", "0x1ff"):
+        with pytest.raises(ValueError):
+            session.get_packets(endpoint=bad)
 
 
 def test_get_packets_excludes_interrupt(tmp_path: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

Implements the MCP `get_packets` tool for loaded USB captures.

* Adds `PacketRecord` and `PacketSelection` models
* Registers the `get_packets` MCP tool
* Returns decoded URB packet records after `load_capture`
* Supports filtering by device, endpoint number, direction, transfer type, and event type
* Supports pagination with `offset` and `limit`
* Adds tests for unloaded sessions, pagination, endpoint/direction filtering, and a real Goodix capture

`get_packets` currently returns packet records derived from decoded `UrbRecord` values. Unsupported transfer types remain invisible until supported by the decoder.

Closes #43

## How was it tested?

```bash
ruff check .
ruff format --check .
pyright
pytest
```

## Notes

Endpoint filtering is based on endpoint number only. For example, `endpoint="3"` matches EP3, and `endpoint="0x83"` is normalized to endpoint number 3. Use `direction="in"` or `direction="out"` to filter direction.

Small follow-up: inputs like `0xff` currently take the low endpoint bits. We may later validate endpoint addresses more strictly, allowing only forms like `0x00`-`0x0f` and `0x80`-`0x8f`.

## Checklist

* PR description includes `Closes #N`
* No unintended files included