### PR TITLE
50/live capture

### DIFF
--- a/bsu_tool/__main__.py
+++ b/bsu_tool/__main__.py
@@ -205,6 +205,27 @@ def main(argv: list[str] | None = None) -> None:
         help="Path to the .pcapng capture file",
     )
 
+    sniff_cmd = subparsers.add_parser(
+        "sniff",
+        help="Capture USB traffic from one device to a pcap-ng file (Linux only)",
+    )
+    sniff_cmd.add_argument(
+        "--bus",
+        type=int,
+        required=True,
+        help="usbmon bus number (the N in /dev/usbmonN), as shown by lsusb",
+    )
+    sniff_cmd.add_argument(
+        "--device",
+        type=int,
+        default=None,
+        help="USB device number on that bus, as shown by lsusb; omit to capture all devices on the bus (bus-only)",
+    )
+    sniff_cmd.add_argument(
+        "output",
+        help="Destination .pcapng file (must not already exist)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "mcp":
@@ -215,6 +236,16 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.command == "parse":
         sys.exit(_cmd_parse(args.capture))
+
+    if args.command == "sniff":
+        # Lazy import: sniff_command pulls in usbmon_source, whose top-level
+        # `import fcntl` is Linux-only. Importing it here rather than at module
+        # top keeps the `parse` and `mcp` commands working on non-Linux
+        # machines, where fcntl is absent.
+        from bsu_tool.sniff_command import run_sniff
+
+        run_sniff(args.bus, args.device, Path(args.output))
+        return
 
     parser.print_help()
 

--- a/bsu_tool/pcapng_writer.py
+++ b/bsu_tool/pcapng_writer.py
@@ -33,10 +33,9 @@ Design choices
   A SIGINT mid-capture leaves a structurally valid file with every block
   that completed before the signal.
 
-The byte order is little-endian on the wire. The pcap-ng spec permits
-big-endian sections, but every modern tool (tshark, Wireshark, scapy)
-writes little-endian and there is no reason to do otherwise on the
-platforms bsu-tool targets.
+Byte order is little-endian on the wire. The spec permits big-endian
+sections, but every modern tool (tshark, Wireshark, scapy) writes
+little-endian, so we do too.
 """
 
 from __future__ import annotations

--- a/bsu_tool/pcapng_writer.py
+++ b/bsu_tool/pcapng_writer.py
@@ -1,0 +1,289 @@
+"""pcap-ng block writer for bsu-tool.
+
+Counterpart to :mod:`bsu_tool.pcapng_reader`. The split mirrors the
+read path: this module handles pcap-ng *block* structure; URB-level
+encoding of packet payloads is the caller's responsibility (the
+sniffer passes through raw bytes received from the kernel's usbmon
+interface).
+
+Typical use::
+
+    from bsu_tool.pcapng_writer import PcapNgWriter
+    from bsu_tool.urb_decoder import LINKTYPE_USB_LINUX_MMAPPED
+
+    with open("capture.pcapng", "xb") as fp:
+        writer = PcapNgWriter(fp)
+        writer.write_section_header()
+        iface = writer.write_interface_description(
+            link_type=LINKTYPE_USB_LINUX_MMAPPED,
+        )
+        for hdr_plus_data, timestamp_us in events:
+            writer.write_enhanced_packet(iface, timestamp_us, hdr_plus_data)
+
+Design choices
+--------------
+* The stream is owned by the caller. The writer never opens, closes,
+  or flushes the stream; the caller's ``with`` block handles that.
+* Interface IDs are auto-assigned in registration order, starting at 0.
+  Callers reference interfaces by the returned ID when writing EPBs.
+* Timestamps are passed as a single integer count of ``tsresol`` ticks
+  (microseconds by default). The 64-bit-as-two-32-bit-words split that
+  pcap-ng requires is internal to this module.
+* All blocks are written to the stream immediately; nothing is buffered.
+  A SIGINT mid-capture leaves a structurally valid file with every block
+  that completed before the signal.
+
+The byte order is little-endian on the wire. The pcap-ng spec permits
+big-endian sections, but every modern tool (tshark, Wireshark, scapy)
+writes little-endian and there is no reason to do otherwise on the
+platforms bsu-tool targets.
+"""
+
+from __future__ import annotations
+
+from typing import BinaryIO, Final
+
+# ---------------------------------------------------------------------------
+# Block-type identifiers (must match pcapng_reader.py)
+# ---------------------------------------------------------------------------
+
+_BLOCK_TYPE_SHB: Final[int] = 0x0A0D0D0A
+_BLOCK_TYPE_IDB: Final[int] = 0x00000001
+_BLOCK_TYPE_EPB: Final[int] = 0x00000006
+
+# Byte-order magic for a little-endian section.
+_BOM_LITTLE: Final[int] = 0x1A2B3C4D
+
+# pcap-ng version we write. The format has been at 1.0 since 2004 and the
+# draft RFC keeps it pinned at 1.x.
+_VERSION_MAJOR: Final[int] = 1
+_VERSION_MINOR: Final[int] = 0
+
+# Section length = -1 means "unknown" (live capture, no rewind). pcap-ng
+# permits this and every streaming writer uses it.
+_SECTION_LENGTH_UNKNOWN: Final[int] = -1
+
+# Default snap length: 65535 matches tshark's default and is large enough
+# for any single USB transfer we expect to see.
+_DEFAULT_SNAP_LEN: Final[int] = 65535
+
+# Option code for if_tsresol on an IDB. Value is a single byte: low 7 bits
+# are the exponent, high bit selects power-of-10 (0) vs power-of-2 (1).
+# 0x06 = 10^-6 seconds = microseconds, matching usbmon's native resolution.
+_OPT_IF_TSRESOL: Final[int] = 9
+_OPT_ENDOFOPT: Final[int] = 0
+
+#: Endianness used for all multi-byte fields in written blocks.
+_BYTE_ORDER: Final[str] = "little"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _pad4(n: int) -> int:
+    """Round ``n`` up to the next multiple of 4."""
+    return (n + 3) & ~3
+
+
+def _padding(n: int) -> bytes:
+    """Return the zero bytes needed to pad ``n`` up to a 4-byte boundary."""
+    return b"\x00" * (_pad4(n) - n)
+
+
+def _u16(value: int) -> bytes:
+    return value.to_bytes(2, _BYTE_ORDER, signed=False)
+
+
+def _u32(value: int) -> bytes:
+    return value.to_bytes(4, _BYTE_ORDER, signed=False)
+
+
+def _i64(value: int) -> bytes:
+    return value.to_bytes(8, _BYTE_ORDER, signed=True)
+
+
+def _option(code: int, value: bytes) -> bytes:
+    """Encode one TLV option, including trailing pad-to-4 alignment."""
+    return _u16(code) + _u16(len(value)) + value + _padding(len(value))
+
+
+def _end_of_options() -> bytes:
+    """Encode the opt_endofopt terminator (code 0, length 0)."""
+    return _u16(_OPT_ENDOFOPT) + _u16(0)
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+class PcapNgWriter:
+    """Writes pcap-ng blocks to a binary stream.
+
+    The writer is stateful in exactly one way: it tracks the number of
+    interfaces registered so far, so that :meth:`write_interface_description`
+    can return the auto-assigned interface ID. EPBs reference interfaces
+    by this ID.
+
+    Parameters
+    ----------
+    stream:
+        A binary, writable file-like object. The writer does not seek
+        and does not close the stream.
+    """
+
+    __slots__ = ("_interface_count", "_stream")
+
+    def __init__(self, stream: BinaryIO) -> None:
+        self._stream = stream
+        self._interface_count = 0
+
+    @property
+    def interface_count(self) -> int:
+        """Number of IDBs written so far in the current section."""
+        return self._interface_count
+
+    # -- SHB ---------------------------------------------------------------
+
+    def write_section_header(self) -> None:
+        """Write a Section Header Block.
+
+        Must be the first block in the file. A section length of -1 is
+        written, indicating "unknown" — appropriate for a live capture
+        where the writer cannot know the final size in advance.
+
+        Calling this method again starts a new section; the interface
+        counter resets to 0.
+        """
+        # Body layout: BOM(4) + major(2) + minor(2) + section_length(8)
+        body = _u32(_BOM_LITTLE) + _u16(_VERSION_MAJOR) + _u16(_VERSION_MINOR) + _i64(_SECTION_LENGTH_UNKNOWN)
+        self._write_block(_BLOCK_TYPE_SHB, body)
+        self._interface_count = 0
+
+    # -- IDB ---------------------------------------------------------------
+
+    def write_interface_description(
+        self,
+        link_type: int,
+        snap_len: int = _DEFAULT_SNAP_LEN,
+        *,
+        tsresol_exponent: int = 6,
+    ) -> int:
+        """Write an Interface Description Block.
+
+        Parameters
+        ----------
+        link_type:
+            LINKTYPE_* value identifying the link-layer format of packets
+            on this interface. For usbmon captures, use
+            :data:`bsu_tool.urb_decoder.LINKTYPE_USB_LINUX_MMAPPED`.
+        snap_len:
+            Maximum captured packet size in bytes. Defaults to 65535,
+            matching tshark.
+        tsresol_exponent:
+            Timestamp resolution exponent. ``6`` means 10^-6 seconds
+            (microseconds), which matches the resolution of the
+            usbmon header's ``ts_sec``/``ts_usec`` fields.
+
+        Returns
+        -------
+        int
+            The interface ID assigned to this interface (0 for the first
+            IDB in a section, 1 for the second, and so on). Callers pass
+            this ID to :meth:`write_enhanced_packet`.
+        """
+        # IDB body: link_type(2) + reserved(2) + snap_len(4) + options
+        body = (
+            _u16(link_type)
+            + _u16(0)  # reserved, must be zero
+            + _u32(snap_len)
+            + _option(_OPT_IF_TSRESOL, bytes([tsresol_exponent]))
+            + _end_of_options()
+        )
+        self._write_block(_BLOCK_TYPE_IDB, body)
+        assigned_id = self._interface_count
+        self._interface_count += 1
+        return assigned_id
+
+    # -- EPB ---------------------------------------------------------------
+
+    def write_enhanced_packet(
+        self,
+        interface_id: int,
+        timestamp_us: int,
+        packet_data: bytes,
+        *,
+        original_length: int | None = None,
+    ) -> None:
+        """Write an Enhanced Packet Block.
+
+        Parameters
+        ----------
+        interface_id:
+            ID returned by a prior :meth:`write_interface_description`
+            call in the current section.
+        timestamp_us:
+            Microseconds since the Unix epoch. For usbmon events,
+            compute as ``ts_sec * 1_000_000 + ts_usec``.
+        packet_data:
+            The raw packet bytes — for usbmon, the complete header plus
+            captured data, exactly as obtained from the kernel.
+        original_length:
+            Length on the wire before any snap-len truncation. Defaults
+            to ``len(packet_data)``; callers that truncate must pass the
+            untruncated length explicitly.
+
+        Raises
+        ------
+        ValueError
+            If ``interface_id`` references an interface that has not been
+            registered, or if ``timestamp_us`` does not fit in 64 bits.
+        """
+        if interface_id < 0 or interface_id >= self._interface_count:
+            raise ValueError(f"interface_id {interface_id} not registered (have {self._interface_count} interface(s))")
+        if timestamp_us < 0 or timestamp_us >= (1 << 64):
+            raise ValueError(f"timestamp_us {timestamp_us} out of 64-bit range")
+
+        captured_length = len(packet_data)
+        if original_length is None:
+            original_length = captured_length
+
+        ts_high = (timestamp_us >> 32) & 0xFFFFFFFF
+        ts_low = timestamp_us & 0xFFFFFFFF
+
+        # EPB body: interface_id(4) + ts_high(4) + ts_low(4) +
+        #           captured_len(4) + original_len(4) +
+        #           packet_data + pad-to-4 + options
+        body = (
+            _u32(interface_id)
+            + _u32(ts_high)
+            + _u32(ts_low)
+            + _u32(captured_length)
+            + _u32(original_length)
+            + packet_data
+            + _padding(captured_length)
+            + _end_of_options()
+        )
+        self._write_block(_BLOCK_TYPE_EPB, body)
+
+    # -- block framing -----------------------------------------------------
+
+    def _write_block(self, block_type: int, body: bytes) -> None:
+        """Wrap ``body`` in pcap-ng block framing and write it to the stream.
+
+        Each block is::
+
+            block_type(4) + total_length(4) + body + total_length(4)
+
+        where ``total_length`` is the size of the entire block including
+        the type, both length fields, and the body. The body has already
+        been padded to a 4-byte boundary by the caller.
+        """
+        total_length = 4 + 4 + len(body) + 4
+        framed = _u32(block_type) + _u32(total_length) + body + _u32(total_length)
+        self._stream.write(framed)
+
+
+__all__ = ["PcapNgWriter"]

--- a/bsu_tool/sniff_command.py
+++ b/bsu_tool/sniff_command.py
@@ -77,9 +77,8 @@ def run_sniff(bus: int, device: int | None, output: Path) -> None:
     except UsbmonIoctlError as exc:
         _die(str(exc))
 
-    # Clear the progress line before printing the final stats, since
-    # the progress line is a single carriage-return-overwritten line
-    # and the final stats are multi-line.
+    # End the carriage-return-overwritten progress line before the
+    # multi-line final stats.
     print(file=sys.stderr)
     _print_final_stats(stats)
 

--- a/bsu_tool/sniff_command.py
+++ b/bsu_tool/sniff_command.py
@@ -1,0 +1,147 @@
+"""CLI handler for the ``sniff`` subcommand.
+
+Lives separately from ``__main__.py`` so the argparse dispatcher stays
+a thin one-liner-per-command file. Handles three things the library
+``capture()`` function deliberately doesn't:
+
+* SIGINT → set the stop event (capture is interruptible by Ctrl+C).
+* Progress ticks → an in-place stderr counter that overwrites itself.
+* Final stats → a multi-line summary printed after the capture stops.
+
+The MCP server in Milestone 2 will skip this entire module and call
+:func:`bsu_tool.sniffer.capture` directly with its own stop event and
+progress callback.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+import threading
+from pathlib import Path
+from types import FrameType
+from typing import NoReturn
+
+from bsu_tool.sniffer import CaptureStats, capture
+from bsu_tool.usbmon_source import (
+    UsbmonBusNotAvailableError,
+    UsbmonIoctlError,
+    UsbmonPermissionError,
+)
+
+
+def run_sniff(bus: int, device: int | None, output: Path) -> None:
+    """Run a capture from the CLI. Prints progress and stats to stderr.
+
+    ``device`` is a USB device address to filter on, or ``None`` for
+    bus-only capture (every device on the bus). Translates the library's
+    structured exceptions into ``bsu-tool: ...`` error messages and clean
+    exit codes. Does not return on error.
+    """
+    stop_event = threading.Event()
+
+    def _handle_sigint(_signum: int, _frame: FrameType | None) -> None:
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _handle_sigint)
+
+    target = "all devices" if device is None else f"device {device}"
+    print(
+        f"Capturing bus {bus} {target} to {output}. Press Ctrl+C to stop.",
+        file=sys.stderr,
+    )
+
+    if bus == 0 and device is None:
+        # /dev/usbmon0 spans every bus; with no device filter this records
+        # the entire host, and device addresses are not unique across buses.
+        print(
+            "  Warning: bus 0 captures all buses. With no --device filter this "
+            "records the whole host, and device addresses collide across buses.",
+            file=sys.stderr,
+        )
+
+    try:
+        stats = capture(
+            bus=bus,
+            device=device,
+            output_path=output,
+            stop_event=stop_event,
+            on_progress=_print_progress,
+        )
+    except FileExistsError:
+        _die(f"output file already exists: {output}")
+    except UsbmonBusNotAvailableError as exc:
+        _die(str(exc))
+    except UsbmonPermissionError as exc:
+        _die(str(exc))
+    except UsbmonIoctlError as exc:
+        _die(str(exc))
+
+    # Clear the progress line before printing the final stats, since
+    # the progress line is a single carriage-return-overwritten line
+    # and the final stats are multi-line.
+    print(file=sys.stderr)
+    _print_final_stats(stats)
+
+
+def _print_progress(stats: CaptureStats) -> None:
+    """Write a single-line progress update to stderr, overwriting in place.
+
+    Carriage return without newline so each tick replaces the previous
+    one. Padded with spaces so a shorter line doesn't leave debris from
+    a longer earlier line.
+    """
+    line = (
+        f"  seen={stats.seen:>7d}  matched={stats.matched:>7d}  "
+        f"elapsed={stats.elapsed_seconds:>6.1f}s  "
+        f"size={_format_bytes(stats.output_bytes)}"
+    )
+    print(f"\r{line:<78}", end="", file=sys.stderr, flush=True)
+
+
+def _print_final_stats(stats: CaptureStats) -> None:
+    """Print the multi-line summary that follows the progress counter."""
+    rate = stats.matched / stats.elapsed_seconds if stats.elapsed_seconds > 0 else 0.0
+    print("Capture stopped.", file=sys.stderr)
+    print(f"  Events seen:       {stats.seen}", file=sys.stderr)
+    print(f"  Events matched:    {stats.matched}", file=sys.stderr)
+    print(f"  Elapsed:           {stats.elapsed_seconds:.2f}s", file=sys.stderr)
+    print(f"  Average rate:      {rate:.1f} matched/sec", file=sys.stderr)
+    print(f"  Output:            {stats.output_path}", file=sys.stderr)
+    print(
+        f"  Output size:       {_format_bytes(stats.output_bytes)} ({stats.output_bytes} bytes)",
+        file=sys.stderr,
+    )
+
+    if stats.matched == 0:
+        print(file=sys.stderr)
+        if stats.seen == 0:
+            print(
+                "  Note: no events were seen on this bus. Is the device generating traffic?",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"  Note: {stats.seen} events were seen on the bus, but none "
+                f"matched device number. Check the device number with `lsusb`.",
+                file=sys.stderr,
+            )
+
+
+def _format_bytes(n: int) -> str:
+    """Compact human-readable byte size: '512 B', '1.4 KB', '23.7 MB'."""
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    if n < 1024 * 1024 * 1024:
+        return f"{n / (1024 * 1024):.1f} MB"
+    return f"{n / (1024 * 1024 * 1024):.2f} GB"
+
+
+def _die(message: str) -> NoReturn:
+    print(f"bsu-tool: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+__all__ = ["run_sniff"]

--- a/bsu_tool/sniffer.py
+++ b/bsu_tool/sniffer.py
@@ -1,31 +1,15 @@
-"""Orchestration layer for USB traffic capture to pcap-ng files.
+"""Orchestrate USB traffic capture to pcap-ng files.
 
-Wires three modules together:
+Wires :class:`~bsu_tool.usbmon_source.UsbmonSource` (raw events from one
+``/dev/usbmonN``) to :class:`~bsu_tool.pcapng_writer.PcapNgWriter`
+(Enhanced Packet Blocks), filtering by device number and tracking stats.
 
-* :class:`bsu_tool.usbmon_source.UsbmonSource` produces raw events
-  from one ``/dev/usbmonN`` device.
-* :class:`bsu_tool.pcapng_writer.PcapNgWriter` encodes those events as
-  pcap-ng Enhanced Packet Blocks.
-* This module filters by device number and tracks per-capture stats.
-
-The public entry point, :func:`capture`, takes everything by argument —
-no globals, no signal handling, no printing. The CLI ties stop to SIGINT
-and progress to stderr; the MCP server (Milestone 2) will tie them to
-its own stop tool call and notification channel. Same library function,
-two drivers.
-
-The output file is opened with mode ``"xb"``: the OS atomically refuses
-the open if the path already exists, so two concurrent captures cannot
-race and clobber each other. If the path exists, :class:`FileExistsError`
-propagates to the caller; translating that to a CLI error message is
-the caller's concern.
-
-:func:`capture` blocks until its stop event is set — the right shape for
-a CLI bound to Ctrl+C, the wrong shape for an interactive driver (an MCP
-tool call, say) that must start the capture, return so the user can be
-told to act, then stop it later. :class:`CaptureController` bridges the
-two: it runs ``capture`` on a daemon thread and exposes :meth:`start`
-and :meth:`stop`, so both drivers share the same underlying function.
+:func:`capture` takes everything by argument — no globals, signals, or
+printing — and blocks until its stop event is set. That fits a CLI bound
+to Ctrl+C but not an interactive driver (an MCP tool) that must start,
+return so the user can act, then stop later. :class:`CaptureController`
+bridges the gap by running ``capture`` on a daemon thread. Same library
+function, two drivers.
 """
 
 from __future__ import annotations
@@ -44,8 +28,8 @@ from bsu_tool.usbmon_source import UsbmonSource
 # Constants
 # ---------------------------------------------------------------------------
 
-#: Offset of the device-number byte in the 64-byte usbmon header.
-#: Matches the layout documented in urb_decoder.py.
+#: Offset of the device-number byte in the 64-byte usbmon header
+#: (layout documented in urb_decoder.py).
 _DEVNUM_OFFSET: int = 11
 
 # ---------------------------------------------------------------------------
@@ -57,27 +41,18 @@ _DEVNUM_OFFSET: int = 11
 class CaptureStats:
     """Running statistics for a capture session.
 
-    A single :class:`CaptureStats` instance is created at the start of a
-    capture and mutated in place as events arrive. The optional progress
-    callback receives the *same* instance on every tick, so observers
-    see live values rather than stale snapshots — useful for a CLI
-    counter that overwrites the same line, less useful if the observer
-    wants to compare two points in time (which would need a manual copy).
+    Created once at the start of a capture and mutated in place as events
+    arrive. The progress callback receives the *same* instance every tick,
+    so it sees live values, not snapshots (copy manually to compare two
+    points in time).
 
-    Field meanings:
-
-    * ``seen`` — events delivered by the kernel and not dropped as
-      filler. Includes events from devices the user did not ask for.
-    * ``matched`` — events that passed the device-number filter and
-      were written to the output file.
-    * ``elapsed_seconds`` — wall-clock seconds since the capture began.
-      Updated on every progress tick and on final stats; not updated
-      between ticks.
-    * ``output_path`` and ``output_bytes`` — where the file ended up
-      and how big it is. ``output_bytes`` is the writer's running byte
-      total; for an interrupted capture, this is approximate (the OS
-      may have buffered writes), but it's correct after the file is
-      closed.
+    * ``seen`` — non-filler events from the kernel, including devices the
+      user did not ask for.
+    * ``matched`` — events that passed the device filter and were written.
+    * ``elapsed_seconds`` — wall-clock since start; updated each tick.
+    * ``output_path`` / ``output_bytes`` — the file and its size.
+      ``output_bytes`` is the writer's running total (approximate mid-
+      capture due to buffering; exact once the file is closed).
     """
 
     output_path: Path
@@ -87,9 +62,8 @@ class CaptureStats:
     output_bytes: int = 0
 
 
-# Type alias for the optional progress callback. Called periodically
-# during capture with the running stats. The callback runs on the
-# capture thread, so it must be cheap and non-blocking.
+# Optional progress callback: invoked periodically with running stats.
+# Runs on the capture thread, so it must be cheap and non-blocking.
 ProgressCallback = Callable[[CaptureStats], None]
 
 
@@ -98,10 +72,9 @@ ProgressCallback = Callable[[CaptureStats], None]
 # ---------------------------------------------------------------------------
 
 
-#: Minimum wall-clock interval between progress callback invocations.
-#: A capture under heavy load can produce thousands of events per second;
-#: calling the progress callback on every event would dominate the hot
-#: path with formatting/printing work that nobody wants done 10,000x/sec.
+#: Minimum interval between progress callbacks. Heavy captures produce
+#: thousands of events per second; calling back on every one would swamp
+#: the hot path with formatting/printing work.
 _PROGRESS_INTERVAL_SECONDS: float = 0.2
 
 
@@ -116,53 +89,41 @@ def capture(
 ) -> CaptureStats:
     """Capture USB traffic from one bus (optionally one device) to a pcap-ng file.
 
-    Reads events from ``/dev/usbmon{bus}``, keeps those whose device
-    number matches ``device`` (or *all* of them in bus-only mode), and
-    writes them to ``output_path`` as Enhanced Packet Blocks. Runs until
-    ``stop_event`` is set.
+    Reads events from ``/dev/usbmon{bus}``, keeps those matching ``device``
+    (or all of them in bus-only mode), and writes them to ``output_path``
+    as Enhanced Packet Blocks. Runs until ``stop_event`` is set.
 
     Parameters
     ----------
     bus:
         usbmon bus number (the N in ``/dev/usbmonN``).
     device:
-        USB device number on that bus, as shown by ``lsusb``. Pass
-        ``None`` for *bus-only* capture: every non-filler event on the
-        bus is written, regardless of device address. Bus-only is the
-        right choice when the device's address is unknown or will change
-        during the capture — enumeration (a device answers at address 0
-        before ``SET_ADDRESS``, then at its assigned address), a
-        replug/reset, or a mode switch into a bootloader. Note that
-        ``0`` is a real address (the default address during enumeration),
-        *not* a wildcard; only ``None`` means "all devices". In bus-only
-        mode ``matched`` equals ``seen`` (the device-address mismatch is
-        the only reason an event is skipped).
+        USB device number on that bus (as shown by ``lsusb``), or ``None``
+        for *bus-only* capture (write every non-filler event regardless of
+        address). Use bus-only when the address is unknown or will change —
+        enumeration, replug/reset, or a switch into a bootloader. ``0`` is
+        a real address (the enumeration default), *not* a wildcard; only
+        ``None`` means "all devices". In bus-only mode ``matched == seen``.
     output_path:
-        Destination file. Opened with ``"xb"`` — the open fails if the
-        file already exists. Resolved against the current working
-        directory at open time.
+        Destination file, opened with ``"xb"`` — the open fails if it
+        already exists. Resolved against the cwd at open time.
     stop_event:
-        Set by the caller to stop the capture. Stop latency is bounded
-        by ``UsbmonSource``'s poll timeout (~100 ms).
+        Set by the caller to stop the capture. Latency is bounded by
+        ``UsbmonSource``'s poll timeout (~100 ms).
     ready_event:
-        Optional event set once the output file is open and the usbmon
-        device is being polled — i.e. the moment the capture is actually
-        live and will not miss subsequent traffic. A caller running this
-        function on a background thread can wait on it to learn when it
-        is safe to tell the user to operate the device. Because it is set
-        only *after* the open and the ``UsbmonSource`` enter succeed, a
-        caller that sees it set knows no startup exception was raised;
-        conversely, if the function returns or raises before setting it,
-        the capture never went live.
+        Optional event set once the file is open and the device is being
+        polled — i.e. the capture is live and will not miss traffic. Set
+        only *after* startup succeeds, so a caller that sees it set knows
+        no startup exception was raised; if this returns or raises before
+        setting it, the capture never went live.
     on_progress:
-        Optional callback invoked periodically with running stats.
-        Runs on the capture thread; should not block.
+        Optional callback invoked periodically with running stats. Runs on
+        the capture thread; should not block.
 
     Returns
     -------
     CaptureStats
-        Final stats, with ``elapsed_seconds`` and ``output_bytes``
-        reflecting the completed capture.
+        Final stats for the completed capture.
 
     Raises
     ------
@@ -177,9 +138,8 @@ def capture(
     start_time = time.monotonic()
     last_progress_time = start_time
 
-    # Open with "xb": fails atomically if the path already exists. This
-    # is the entire reason the caller doesn't need to do its own check —
-    # an existence test followed by an open would race.
+    # "xb" fails atomically if the path exists, so the caller needn't do
+    # its own check-then-open (which would race).
     with output_path.open("xb") as out_fp:
         writer = PcapNgWriter(out_fp)
         writer.write_section_header()
@@ -188,10 +148,8 @@ def capture(
         )
 
         with UsbmonSource(bus_number=bus, stop_event=stop_event) as source:
-            # The file is open and the usbmon device is registered for
-            # polling: the capture is live. Signal any waiter (e.g. a
-            # controller running this on a background thread) that it is
-            # now safe to instruct the user to operate the device.
+            # File open and device polling: the capture is live. Signal any
+            # waiter that it's now safe to tell the user to operate the device.
             if ready_event is not None:
                 ready_event.set()
 
@@ -199,11 +157,8 @@ def capture(
                 stats.seen += 1
 
                 if device is not None and header[_DEVNUM_OFFSET] != device:
-                    # Different device on the same bus (skipped only when a
-                    # specific device was requested; bus-only capture keeps
-                    # everything). Maybe update the progress UI so a wrong
-                    # --device shows a climbing "seen" against a stuck
-                    # "matched", then move on.
+                    # Another device on the bus. Still tick progress so a wrong
+                    # --device shows climbing "seen" against stuck "matched".
                     now = time.monotonic()
                     if on_progress is not None and now - last_progress_time >= _PROGRESS_INTERVAL_SECONDS:
                         stats.elapsed_seconds = now - start_time
@@ -212,12 +167,9 @@ def capture(
                         last_progress_time = now
                     continue
 
-                # The pcap-ng EPB timestamp and the usbmon header's
-                # ts_sec/ts_usec are independent fields. They should
-                # agree, so we compute the EPB timestamp from the
-                # usbmon header rather than calling time.time() —
-                # that way a downstream reader sees consistent values
-                # whether it reads the EPB header or the URB header.
+                # Derive the EPB timestamp from the usbmon header rather than
+                # time.time(), so a reader sees consistent values whether it
+                # reads the EPB header or the URB header.
                 ts_sec = int.from_bytes(header[16:24], "little", signed=True)
                 ts_usec = int.from_bytes(header[24:28], "little", signed=True)
                 timestamp_us = ts_sec * 1_000_000 + ts_usec
@@ -237,8 +189,8 @@ def capture(
                     on_progress(stats)
                     last_progress_time = now
 
-    # Final update happens after the file is closed so output_bytes
-    # reflects the true file size, not a possibly-still-buffered tell().
+    # Final update after close, so output_bytes is the true file size
+    # rather than a possibly-still-buffered tell().
     stats.elapsed_seconds = time.monotonic() - start_time
     stats.output_bytes = output_path.stat().st_size
     return stats
@@ -248,41 +200,25 @@ def capture(
 # Start/stop controller
 # ---------------------------------------------------------------------------
 #
-# :func:`capture` runs a loop until its stop event is set and only returns
-# afterward. That is the right shape for a CLI bound to Ctrl+C, but the wrong
-# shape for an interactive driver — an MCP tool call, say — that must:
+# :class:`CaptureController` adapts :func:`capture` (which blocks until stopped)
+# to an interactive driver that must start the capture, return so the user can
+# act, then stop it and collect stats. It runs ``capture`` on a daemon thread,
+# owns the stop and readiness events, and exposes :meth:`start`/:meth:`stop`.
 #
-#   1. start the capture, then *return* so the user can be told to act,
-#   2. let the user operate the device,
-#   3. stop the capture and collect the stats and output path.
-#
-# :class:`CaptureController` bridges the two. It runs ``capture`` on a daemon
-# thread, owns the stop and readiness events, and exposes :meth:`start` and
-# :meth:`stop`. :meth:`start` does not return until the capture is verifiably
-# live (so the caller never instructs the user to act on a capture that has not
-# begun, or that already failed to begin); :meth:`stop` sets the stop event,
-# joins the thread, and returns the final :class:`CaptureStats`.
-#
-# Startup errors raised inside ``capture`` — :class:`FileExistsError`,
-# :class:`~bsu_tool.usbmon_source.UsbmonPermissionError`,
-# :class:`~bsu_tool.usbmon_source.UsbmonBusNotAvailableError` — happen on the
-# capture thread. :meth:`start` re-raises them in the caller's thread before
-# returning, so the caller sees the same exceptions it would from a direct
-# ``capture`` call. Errors raised *after* the capture went live (a mid-capture
-# ``ENODEV``, for instance) surface from :meth:`stop` instead.
-#
-# The controller drives a single capture per instance. Call :meth:`start`
-# once; calling it again — before or after :meth:`stop` — raises
+# :meth:`start` returns only once the capture is verifiably live, so the caller
+# never tells the user to act on a capture that hasn't begun. Startup errors
+# (FileExistsError, UsbmonPermissionError, UsbmonBusNotAvailableError) are
+# re-raised from :meth:`start`; errors after the capture went live surface from
+# :meth:`stop`. One capture per instance — a second :meth:`start` raises
 # :class:`CaptureStateError`.
 
 #: Default ceiling on how long :meth:`CaptureController.start` waits for the
-#: capture to go live. Opening ``/dev/usbmonN`` (``O_RDONLY``) and the file
-#: (``"xb"``) should take milliseconds; this only guards against a pathological
-#: hang so the caller is never blocked indefinitely.
+#: capture to go live. Startup should take milliseconds; this only guards
+#: against a pathological hang.
 _DEFAULT_READY_TIMEOUT_SECONDS: float = 5.0
 
-#: Granularity of the start-time wait loop. Small enough that a fast startup
-#: failure is noticed promptly, large enough not to busy-spin.
+#: Poll granularity of the start-time wait loop: prompt enough to notice a fast
+#: startup failure, coarse enough not to busy-spin.
 _READY_POLL_SECONDS: float = 0.05
 
 
@@ -345,28 +281,26 @@ class CaptureController:
         """Start the capture and return once it is live.
 
         Spawns a daemon thread running :func:`capture` and blocks until the
-        capture has opened its output file and begun polling the usbmon
-        device — at which point it is safe to instruct the user to operate the
-        device. If the capture fails to start (file exists, permission denied,
-        bus unavailable, ...), the original exception is re-raised here.
+        output file is open and the device is being polled — the point at
+        which it is safe to tell the user to operate the device. Startup
+        failures are re-raised here.
 
         Parameters
         ----------
         bus:
             usbmon bus number (the N in ``/dev/usbmonN``).
         device:
-            USB device number on that bus, as shown by ``lsusb``, or
-            ``None`` for bus-only capture (keep every device on the bus).
-            See :func:`capture` for when bus-only is the right choice.
+            USB device number on that bus (as shown by ``lsusb``), or ``None``
+            for bus-only capture. See :func:`capture`.
         output_path:
             Destination pcap-ng file. Must not already exist.
         on_progress:
-            Optional progress callback, forwarded to ``capture``. Runs on the
+            Optional progress callback forwarded to ``capture``. Runs on the
             capture thread; must not block.
         ready_timeout:
-            Maximum seconds to wait for the capture to go live before giving
-            up. Exceeding it raises :class:`TimeoutError` (the background
-            thread is left running; call :meth:`stop` to wind it down).
+            Max seconds to wait for the capture to go live; exceeding it raises
+            :class:`TimeoutError` (the thread keeps running — call :meth:`stop`
+            to wind it down).
 
         Raises
         ------
@@ -400,9 +334,9 @@ class CaptureController:
         self._thread = Thread(target=_run, name="bsu-capture", daemon=True)
         self._thread.start()
 
-        # Wait for whichever happens first: the capture goes live (_ready), or
-        # the thread finishes (_finished) — the latter means it failed before
-        # going live, since a live capture only finishes once stopped.
+        # Wait for whichever comes first: the capture goes live (_ready), or
+        # the thread finishes (_finished) — finishing first means it failed
+        # before going live, since a live capture only finishes once stopped.
         deadline_reached = not self._wait_ready(ready_timeout)
         if self._ready.is_set():
             return
@@ -416,8 +350,7 @@ class CaptureController:
     def stop(self) -> CaptureStats:
         """Stop the capture, wait for the thread, and return final stats.
 
-        Signals the capture to stop, joins the background thread, and returns
-        the :class:`CaptureStats` the capture produced. If the capture raised
+        Signals the capture to stop and joins the thread. If the capture raised
         after going live, that exception is re-raised here.
 
         Raises

--- a/bsu_tool/sniffer.py
+++ b/bsu_tool/sniffer.py
@@ -1,0 +1,465 @@
+"""Orchestration layer for USB traffic capture to pcap-ng files.
+
+Wires three modules together:
+
+* :class:`bsu_tool.usbmon_source.UsbmonSource` produces raw events
+  from one ``/dev/usbmonN`` device.
+* :class:`bsu_tool.pcapng_writer.PcapNgWriter` encodes those events as
+  pcap-ng Enhanced Packet Blocks.
+* This module filters by device number and tracks per-capture stats.
+
+The public entry point, :func:`capture`, takes everything by argument —
+no globals, no signal handling, no printing. The CLI ties stop to SIGINT
+and progress to stderr; the MCP server (Milestone 2) will tie them to
+its own stop tool call and notification channel. Same library function,
+two drivers.
+
+The output file is opened with mode ``"xb"``: the OS atomically refuses
+the open if the path already exists, so two concurrent captures cannot
+race and clobber each other. If the path exists, :class:`FileExistsError`
+propagates to the caller; translating that to a CLI error message is
+the caller's concern.
+
+:func:`capture` blocks until its stop event is set — the right shape for
+a CLI bound to Ctrl+C, the wrong shape for an interactive driver (an MCP
+tool call, say) that must start the capture, return so the user can be
+told to act, then stop it later. :class:`CaptureController` bridges the
+two: it runs ``capture`` on a daemon thread and exposes :meth:`start`
+and :meth:`stop`, so both drivers share the same underlying function.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Event, Thread
+
+from bsu_tool.pcapng_writer import PcapNgWriter
+from bsu_tool.urb_decoder import LINKTYPE_USB_LINUX_MMAPPED
+from bsu_tool.usbmon_source import UsbmonSource
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Offset of the device-number byte in the 64-byte usbmon header.
+#: Matches the layout documented in urb_decoder.py.
+_DEVNUM_OFFSET: int = 11
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class CaptureStats:
+    """Running statistics for a capture session.
+
+    A single :class:`CaptureStats` instance is created at the start of a
+    capture and mutated in place as events arrive. The optional progress
+    callback receives the *same* instance on every tick, so observers
+    see live values rather than stale snapshots — useful for a CLI
+    counter that overwrites the same line, less useful if the observer
+    wants to compare two points in time (which would need a manual copy).
+
+    Field meanings:
+
+    * ``seen`` — events delivered by the kernel and not dropped as
+      filler. Includes events from devices the user did not ask for.
+    * ``matched`` — events that passed the device-number filter and
+      were written to the output file.
+    * ``elapsed_seconds`` — wall-clock seconds since the capture began.
+      Updated on every progress tick and on final stats; not updated
+      between ticks.
+    * ``output_path`` and ``output_bytes`` — where the file ended up
+      and how big it is. ``output_bytes`` is the writer's running byte
+      total; for an interrupted capture, this is approximate (the OS
+      may have buffered writes), but it's correct after the file is
+      closed.
+    """
+
+    output_path: Path
+    seen: int = 0
+    matched: int = 0
+    elapsed_seconds: float = 0.0
+    output_bytes: int = 0
+
+
+# Type alias for the optional progress callback. Called periodically
+# during capture with the running stats. The callback runs on the
+# capture thread, so it must be cheap and non-blocking.
+ProgressCallback = Callable[[CaptureStats], None]
+
+
+# ---------------------------------------------------------------------------
+# Capture
+# ---------------------------------------------------------------------------
+
+
+#: Minimum wall-clock interval between progress callback invocations.
+#: A capture under heavy load can produce thousands of events per second;
+#: calling the progress callback on every event would dominate the hot
+#: path with formatting/printing work that nobody wants done 10,000x/sec.
+_PROGRESS_INTERVAL_SECONDS: float = 0.2
+
+
+def capture(
+    bus: int,
+    device: int | None,
+    output_path: Path,
+    *,
+    stop_event: Event,
+    ready_event: Event | None = None,
+    on_progress: ProgressCallback | None = None,
+) -> CaptureStats:
+    """Capture USB traffic from one bus (optionally one device) to a pcap-ng file.
+
+    Reads events from ``/dev/usbmon{bus}``, keeps those whose device
+    number matches ``device`` (or *all* of them in bus-only mode), and
+    writes them to ``output_path`` as Enhanced Packet Blocks. Runs until
+    ``stop_event`` is set.
+
+    Parameters
+    ----------
+    bus:
+        usbmon bus number (the N in ``/dev/usbmonN``).
+    device:
+        USB device number on that bus, as shown by ``lsusb``. Pass
+        ``None`` for *bus-only* capture: every non-filler event on the
+        bus is written, regardless of device address. Bus-only is the
+        right choice when the device's address is unknown or will change
+        during the capture — enumeration (a device answers at address 0
+        before ``SET_ADDRESS``, then at its assigned address), a
+        replug/reset, or a mode switch into a bootloader. Note that
+        ``0`` is a real address (the default address during enumeration),
+        *not* a wildcard; only ``None`` means "all devices". In bus-only
+        mode ``matched`` equals ``seen`` (the device-address mismatch is
+        the only reason an event is skipped).
+    output_path:
+        Destination file. Opened with ``"xb"`` — the open fails if the
+        file already exists. Resolved against the current working
+        directory at open time.
+    stop_event:
+        Set by the caller to stop the capture. Stop latency is bounded
+        by ``UsbmonSource``'s poll timeout (~100 ms).
+    ready_event:
+        Optional event set once the output file is open and the usbmon
+        device is being polled — i.e. the moment the capture is actually
+        live and will not miss subsequent traffic. A caller running this
+        function on a background thread can wait on it to learn when it
+        is safe to tell the user to operate the device. Because it is set
+        only *after* the open and the ``UsbmonSource`` enter succeed, a
+        caller that sees it set knows no startup exception was raised;
+        conversely, if the function returns or raises before setting it,
+        the capture never went live.
+    on_progress:
+        Optional callback invoked periodically with running stats.
+        Runs on the capture thread; should not block.
+
+    Returns
+    -------
+    CaptureStats
+        Final stats, with ``elapsed_seconds`` and ``output_bytes``
+        reflecting the completed capture.
+
+    Raises
+    ------
+    FileExistsError
+        ``output_path`` already exists.
+    UsbmonBusNotAvailableError
+        ``/dev/usbmon{bus}`` does not exist.
+    UsbmonPermissionError
+        Insufficient permission to open ``/dev/usbmon{bus}``.
+    """
+    stats = CaptureStats(output_path=output_path)
+    start_time = time.monotonic()
+    last_progress_time = start_time
+
+    # Open with "xb": fails atomically if the path already exists. This
+    # is the entire reason the caller doesn't need to do its own check —
+    # an existence test followed by an open would race.
+    with output_path.open("xb") as out_fp:
+        writer = PcapNgWriter(out_fp)
+        writer.write_section_header()
+        interface_id = writer.write_interface_description(
+            link_type=LINKTYPE_USB_LINUX_MMAPPED,
+        )
+
+        with UsbmonSource(bus_number=bus, stop_event=stop_event) as source:
+            # The file is open and the usbmon device is registered for
+            # polling: the capture is live. Signal any waiter (e.g. a
+            # controller running this on a background thread) that it is
+            # now safe to instruct the user to operate the device.
+            if ready_event is not None:
+                ready_event.set()
+
+            for header, data in source:
+                stats.seen += 1
+
+                if device is not None and header[_DEVNUM_OFFSET] != device:
+                    # Different device on the same bus (skipped only when a
+                    # specific device was requested; bus-only capture keeps
+                    # everything). Maybe update the progress UI so a wrong
+                    # --device shows a climbing "seen" against a stuck
+                    # "matched", then move on.
+                    now = time.monotonic()
+                    if on_progress is not None and now - last_progress_time >= _PROGRESS_INTERVAL_SECONDS:
+                        stats.elapsed_seconds = now - start_time
+                        stats.output_bytes = out_fp.tell()
+                        on_progress(stats)
+                        last_progress_time = now
+                    continue
+
+                # The pcap-ng EPB timestamp and the usbmon header's
+                # ts_sec/ts_usec are independent fields. They should
+                # agree, so we compute the EPB timestamp from the
+                # usbmon header rather than calling time.time() —
+                # that way a downstream reader sees consistent values
+                # whether it reads the EPB header or the URB header.
+                ts_sec = int.from_bytes(header[16:24], "little", signed=True)
+                ts_usec = int.from_bytes(header[24:28], "little", signed=True)
+                timestamp_us = ts_sec * 1_000_000 + ts_usec
+
+                packet_data = header + data
+                writer.write_enhanced_packet(
+                    interface_id=interface_id,
+                    timestamp_us=timestamp_us,
+                    packet_data=packet_data,
+                )
+                stats.matched += 1
+
+                now = time.monotonic()
+                if on_progress is not None and now - last_progress_time >= _PROGRESS_INTERVAL_SECONDS:
+                    stats.elapsed_seconds = now - start_time
+                    stats.output_bytes = out_fp.tell()
+                    on_progress(stats)
+                    last_progress_time = now
+
+    # Final update happens after the file is closed so output_bytes
+    # reflects the true file size, not a possibly-still-buffered tell().
+    stats.elapsed_seconds = time.monotonic() - start_time
+    stats.output_bytes = output_path.stat().st_size
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Start/stop controller
+# ---------------------------------------------------------------------------
+#
+# :func:`capture` runs a loop until its stop event is set and only returns
+# afterward. That is the right shape for a CLI bound to Ctrl+C, but the wrong
+# shape for an interactive driver — an MCP tool call, say — that must:
+#
+#   1. start the capture, then *return* so the user can be told to act,
+#   2. let the user operate the device,
+#   3. stop the capture and collect the stats and output path.
+#
+# :class:`CaptureController` bridges the two. It runs ``capture`` on a daemon
+# thread, owns the stop and readiness events, and exposes :meth:`start` and
+# :meth:`stop`. :meth:`start` does not return until the capture is verifiably
+# live (so the caller never instructs the user to act on a capture that has not
+# begun, or that already failed to begin); :meth:`stop` sets the stop event,
+# joins the thread, and returns the final :class:`CaptureStats`.
+#
+# Startup errors raised inside ``capture`` — :class:`FileExistsError`,
+# :class:`~bsu_tool.usbmon_source.UsbmonPermissionError`,
+# :class:`~bsu_tool.usbmon_source.UsbmonBusNotAvailableError` — happen on the
+# capture thread. :meth:`start` re-raises them in the caller's thread before
+# returning, so the caller sees the same exceptions it would from a direct
+# ``capture`` call. Errors raised *after* the capture went live (a mid-capture
+# ``ENODEV``, for instance) surface from :meth:`stop` instead.
+#
+# The controller drives a single capture per instance. Call :meth:`start`
+# once; calling it again — before or after :meth:`stop` — raises
+# :class:`CaptureStateError`.
+
+#: Default ceiling on how long :meth:`CaptureController.start` waits for the
+#: capture to go live. Opening ``/dev/usbmonN`` (``O_RDONLY``) and the file
+#: (``"xb"``) should take milliseconds; this only guards against a pathological
+#: hang so the caller is never blocked indefinitely.
+_DEFAULT_READY_TIMEOUT_SECONDS: float = 5.0
+
+#: Granularity of the start-time wait loop. Small enough that a fast startup
+#: failure is noticed promptly, large enough not to busy-spin.
+_READY_POLL_SECONDS: float = 0.05
+
+
+class CaptureStateError(RuntimeError):
+    """Raised when a controller method is called in the wrong lifecycle state.
+
+    For example, calling :meth:`CaptureController.start` twice, or calling
+    :meth:`CaptureController.stop` before :meth:`CaptureController.start`.
+    """
+
+
+class CaptureController:
+    """Run :func:`capture` as a start/stop-able background job.
+
+    A single controller manages one capture. Typical use::
+
+        controller = CaptureController()
+        controller.start(bus=3, device=5, output_path=Path("out.pcapng"))
+        # ... tell the user to operate the device, wait for them to finish ...
+        stats = controller.stop()
+
+    The controller is not reusable: construct a new one for each capture.
+    """
+
+    __slots__ = (
+        "_exc",
+        "_finished",
+        "_output_path",
+        "_ready",
+        "_started",
+        "_stats",
+        "_stop",
+        "_thread",
+    )
+
+    def __init__(self) -> None:
+        self._stop: Event = Event()
+        self._ready: Event = Event()
+        self._finished: Event = Event()
+        self._thread: Thread | None = None
+        self._started: bool = False
+        self._stats: CaptureStats | None = None
+        self._exc: BaseException | None = None
+        self._output_path: Path | None = None
+
+    @property
+    def is_running(self) -> bool:
+        """Whether a capture is live (started, gone ready, not yet finished)."""
+        return self._ready.is_set() and not self._finished.is_set()
+
+    def start(
+        self,
+        bus: int,
+        device: int | None,
+        output_path: Path,
+        *,
+        on_progress: ProgressCallback | None = None,
+        ready_timeout: float = _DEFAULT_READY_TIMEOUT_SECONDS,
+    ) -> None:
+        """Start the capture and return once it is live.
+
+        Spawns a daemon thread running :func:`capture` and blocks until the
+        capture has opened its output file and begun polling the usbmon
+        device — at which point it is safe to instruct the user to operate the
+        device. If the capture fails to start (file exists, permission denied,
+        bus unavailable, ...), the original exception is re-raised here.
+
+        Parameters
+        ----------
+        bus:
+            usbmon bus number (the N in ``/dev/usbmonN``).
+        device:
+            USB device number on that bus, as shown by ``lsusb``, or
+            ``None`` for bus-only capture (keep every device on the bus).
+            See :func:`capture` for when bus-only is the right choice.
+        output_path:
+            Destination pcap-ng file. Must not already exist.
+        on_progress:
+            Optional progress callback, forwarded to ``capture``. Runs on the
+            capture thread; must not block.
+        ready_timeout:
+            Maximum seconds to wait for the capture to go live before giving
+            up. Exceeding it raises :class:`TimeoutError` (the background
+            thread is left running; call :meth:`stop` to wind it down).
+
+        Raises
+        ------
+        CaptureStateError
+            If :meth:`start` has already been called on this controller.
+        TimeoutError
+            If the capture does not go live within ``ready_timeout`` seconds.
+        FileExistsError, UsbmonError
+            Any startup error raised by ``capture`` is propagated unchanged.
+        """
+        if self._started:
+            raise CaptureStateError("capture already started; use a new CaptureController per capture")
+        self._started = True
+        self._output_path = output_path
+
+        def _run() -> None:
+            try:
+                self._stats = capture(
+                    bus=bus,
+                    device=device,
+                    output_path=output_path,
+                    stop_event=self._stop,
+                    ready_event=self._ready,
+                    on_progress=on_progress,
+                )
+            except BaseException as exc:  # noqa: BLE001 — re-raised to the caller from start()/stop()
+                self._exc = exc
+            finally:
+                self._finished.set()
+
+        self._thread = Thread(target=_run, name="bsu-capture", daemon=True)
+        self._thread.start()
+
+        # Wait for whichever happens first: the capture goes live (_ready), or
+        # the thread finishes (_finished) — the latter means it failed before
+        # going live, since a live capture only finishes once stopped.
+        deadline_reached = not self._wait_ready(ready_timeout)
+        if self._ready.is_set():
+            return
+        if self._exc is not None:
+            raise self._exc
+        if deadline_reached:
+            raise TimeoutError(f"capture did not go live within {ready_timeout:.1f}s")
+        # _finished set, no exception, never went ready: capture returned
+        # immediately (e.g. stop_event somehow pre-set). Nothing to wait on.
+
+    def stop(self) -> CaptureStats:
+        """Stop the capture, wait for the thread, and return final stats.
+
+        Signals the capture to stop, joins the background thread, and returns
+        the :class:`CaptureStats` the capture produced. If the capture raised
+        after going live, that exception is re-raised here.
+
+        Raises
+        ------
+        CaptureStateError
+            If called before :meth:`start`, or if the capture produced neither
+            stats nor an exception (should not happen).
+        Exception
+            Any error raised by ``capture`` after the capture went live.
+        """
+        if not self._started or self._thread is None:
+            raise CaptureStateError("stop() called before start()")
+
+        self._stop.set()
+        self._thread.join()
+
+        if self._exc is not None:
+            raise self._exc
+        if self._stats is None:
+            raise CaptureStateError("capture finished without producing stats")
+        return self._stats
+
+    def _wait_ready(self, timeout: float) -> bool:
+        """Block until the capture goes live or its thread finishes.
+
+        Returns ``True`` if either event fired within ``timeout``, ``False``
+        if the timeout elapsed first.
+        """
+        remaining = timeout
+        while remaining > 0:
+            if self._ready.is_set() or self._finished.is_set():
+                return True
+            wait = min(_READY_POLL_SECONDS, remaining)
+            self._finished.wait(wait)
+            remaining -= wait
+        return self._ready.is_set() or self._finished.is_set()
+
+
+__all__ = [
+    "CaptureController",
+    "CaptureStateError",
+    "CaptureStats",
+    "ProgressCallback",
+    "capture",
+]

--- a/bsu_tool/usbmon_source.py
+++ b/bsu_tool/usbmon_source.py
@@ -1,38 +1,30 @@
 """Raw event source for Linux usbmon character devices.
 
 Wraps ``/dev/usbmonN`` for one USB bus and yields ``(header, data)``
-tuples of raw bytes — one per URB event delivered by the kernel.
-Does no parsing, no filtering by transfer type, and no pcap-ng
-encoding; those are upper layers' concerns.
+tuples of raw bytes — one per URB event. No parsing, filtering, or
+pcap-ng encoding; those are upper layers' concerns.
 
-Three behaviors worth understanding before reading the code:
+Three behaviors worth knowing:
 
-1. **Filler packets are dropped here.** The kernel emits events with
-   ``event_type == 0x40`` ('@') as ring-buffer slot padding. They are
-   not real URBs and would fail to decode downstream. This module is
-   the single gatekeeper that drops them.
+1. **Filler packets are dropped here.** The kernel emits ``0x40`` ('@')
+   events as ring-buffer padding; they aren't real URBs and fail to
+   decode downstream. This module is the sole gatekeeper that drops them.
 
-2. **Iteration blocks but is interruptible.** Each ``__next__`` waits
-   up to ``poll_timeout_ms`` for the kernel to produce an event. If
-   the caller's ``stop_event`` is set during a wait, iteration stops
-   cleanly at the next timeout boundary — so worst-case stop latency
-   is bounded by ``poll_timeout_ms`` regardless of bus activity.
+2. **Iteration blocks but is interruptible.** Each ``__next__`` waits up
+   to ``poll_timeout_ms`` for an event; if ``stop_event`` is set during a
+   wait, iteration stops at the next timeout boundary, so stop latency is
+   bounded by ``poll_timeout_ms`` regardless of bus traffic.
 
-3. **Errors are mapped to typed exceptions at open time.** A missing
-   device node (common on WSL2 where bus numbers shift between
-   reboots) raises :class:`UsbmonBusNotAvailableError` with a hint
-   about which buses *are* available. Permission failures raise
-   :class:`UsbmonPermissionError` with the conventional fix.
+3. **Open errors map to typed exceptions.** A missing node (common on
+   WSL2) raises :class:`UsbmonBusNotAvailableError` listing available
+   buses; permission failures raise :class:`UsbmonPermissionError`.
 
-The kernel-side ABI is documented in ``Documentation/usb/usbmon.rst``
-in the Linux source tree. The relevant pieces:
+Kernel ABI (``Documentation/usb/usbmon.rst``):
 
-* ``MON_IOCX_GETX`` (ioctl request ``_IOW(0x92, 10, struct mon_get_arg)``)
-  fetches one event, copying 64 bytes of header into ``hdr`` and up to
-  ``alloc`` bytes of captured data into ``data``. Returns 0 on success
-  or sets errno on failure (EINTR is the common non-fatal case).
-* ``struct mon_get_arg { struct mon_bin_hdr *hdr; void *data; size_t alloc; }``
-  — three pointer/size_t fields, native alignment.
+* ``MON_IOCX_GETX`` = ``_IOW(0x92, 10, struct mon_get_arg)`` fetches one
+  event, copying 64 header bytes into ``hdr`` and up to ``alloc`` data
+  bytes into ``data``. EINTR is the common non-fatal failure.
+* ``struct mon_get_arg { struct mon_bin_hdr *hdr; void *data; size_t alloc; }``.
 """
 
 from __future__ import annotations
@@ -51,16 +43,16 @@ from typing import Final
 # Constants — usbmon ABI
 # ---------------------------------------------------------------------------
 
-#: Header size returned by MON_IOCX_GETX. Matches struct mon_bin_hdr in
-#: the kernel; also matches HEADER_SIZE_USB_LINUX_MMAPPED in urb_decoder.
+#: Header size from MON_IOCX_GETX. Matches struct mon_bin_hdr and
+#: HEADER_SIZE_USB_LINUX_MMAPPED in urb_decoder.
 _HEADER_SIZE: Final = 64
 
-#: Maximum captured data per event. 65535 matches tshark's snap-len
-#: default and is larger than any single USB transfer we expect.
+#: Max captured data per event. Matches tshark's default snap-len and
+#: exceeds any single USB transfer we expect.
 _DATA_BUFFER_SIZE: Final = 65535
 
-#: usbmon event-type byte for ring-buffer filler. Real events use
-#: 0x53/0x43/0x45 ('S'/'C'/'E'). Anything else is junk to be dropped.
+#: Event-type byte for ring-buffer filler. Real events use 'S'/'C'/'E'
+#: (0x53/0x43/0x45); anything else is junk to drop.
 _FILLER_EVENT_BYTE: Final = 0x40  # '@'
 
 #: Offset of the event-type byte within the header.
@@ -70,18 +62,16 @@ _EVENT_TYPE_OFFSET: Final = 8
 # Constants — ioctl encoding
 # ---------------------------------------------------------------------------
 #
-# Linux ioctl request numbers pack direction, type, command, and size
-# into a 32-bit integer. The encoding (from include/uapi/asm-generic/ioctl.h):
+# Linux ioctl request numbers pack direction, size, type, and command into a
+# 32-bit integer (include/uapi/asm-generic/ioctl.h):
 #
 #     bits 31-30: direction (00 none, 01 write, 10 read, 11 read/write)
 #     bits 29-16: argument size in bytes
 #     bits 15-8:  type ("magic" byte, 0x92 for usbmon)
 #     bits 7-0:   command number
 #
-# MON_IOCX_GETX is defined as _IOW(MON_IOC_MAGIC, 10, struct mon_get_arg).
-# _IOW means direction=01 (write: userspace → kernel passes the arg).
-# The size is sizeof(struct mon_get_arg), which on 64-bit Linux is 24
-# bytes (two pointers + size_t).
+# MON_IOCX_GETX = _IOW(0x92, 10, struct mon_get_arg): direction=write (arg
+# passed userspace → kernel), size = sizeof(mon_get_arg) = 24 on 64-bit.
 
 _IOC_NRBITS: Final = 8
 _IOC_TYPEBITS: Final = 8
@@ -102,9 +92,8 @@ class _MonGetArg(ctypes.Structure):
     """ctypes layout of ``struct mon_get_arg``.
 
     Field order and types must match the kernel's UAPI header exactly.
-    On 64-bit Linux, ``c_void_p`` is 8 bytes and ``c_size_t`` is 8 bytes,
-    giving a struct size of 24 bytes — which is what gets encoded into
-    the ioctl request number.
+    On 64-bit Linux this is 24 bytes (two 8-byte pointers + 8-byte size_t),
+    the size encoded into the ioctl request number.
     """
 
     _fields_ = [
@@ -138,17 +127,16 @@ class UsbmonError(Exception):
 class UsbmonBusNotAvailableError(UsbmonError):
     """Raised when ``/dev/usbmonN`` does not exist for the requested bus.
 
-    On WSL2 and other dynamic environments, bus numbers can shift between
-    reboots or when devices are attached/detached. The error message
-    includes the list of currently-available bus numbers as a hint.
+    Bus numbers can shift between reboots or replugs (notably on WSL2);
+    the message lists the currently-available bus numbers as a hint.
     """
 
 
 class UsbmonPermissionError(UsbmonError):
     """Raised when the user lacks permission to open ``/dev/usbmonN``.
 
-    The device is conventionally owned by ``root:usbmon`` with mode 0640;
-    fix by running as root or by adding the user to the ``usbmon`` group.
+    The node is conventionally ``root:usbmon`` mode 0640; fix by running as
+    root or adding the user to the ``usbmon`` group.
     """
 
 
@@ -169,21 +157,16 @@ class UsbmonIoctlError(UsbmonError):
 class UsbmonSource:
     """Iterable over raw events from one usbmon character device.
 
-    Use as a context manager so the underlying file descriptor is closed
-    on exit::
+    Use as a context manager so the file descriptor is closed on exit::
 
         with UsbmonSource(bus_number=3, stop_event=stop) as source:
             for header, data in source:
                 ...
 
-    Each iteration of ``__next__`` blocks for up to ``poll_timeout_ms``
-    waiting for an event. If ``stop_event`` is set during a wait, the
-    iterator raises ``StopIteration`` at the next timeout boundary —
-    so worst-case stop latency is bounded by ``poll_timeout_ms``
-    regardless of bus traffic.
-
-    Filler events (kernel ring-buffer padding) are silently dropped;
-    they are not real URBs.
+    Each ``__next__`` blocks up to ``poll_timeout_ms`` for an event; if
+    ``stop_event`` is set during a wait, iteration ends (``StopIteration``)
+    at the next timeout boundary, bounding stop latency by
+    ``poll_timeout_ms``. Filler events (ring-buffer padding) are dropped.
     """
 
     __slots__ = (
@@ -211,15 +194,13 @@ class UsbmonSource:
         self._stop_event = stop_event
         self._poll_timeout_ms = poll_timeout_ms
 
-        # File descriptor is opened in __enter__, not __init__. Construct-
-        # ing a source object should not have system-level side effects.
+        # Opened in __enter__, not __init__: constructing a source should have
+        # no system-level side effects.
         self._fd: int | None = None
         self._poller: select.poll | None = None
 
-        # Persistent ctypes buffers — allocated once, reused for every
-        # ioctl call. The kernel writes into these buffers each call;
-        # we copy out the bytes we care about and hand the buffers
-        # back to the kernel on the next iteration.
+        # Persistent ctypes buffers, allocated once and reused for every ioctl.
+        # The kernel writes into them each call; we copy out the bytes we want.
         self._hdr_buf = (ctypes.c_ubyte * _HEADER_SIZE)()
         self._data_buf = (ctypes.c_ubyte * _DATA_BUFFER_SIZE)()
         self._hdr_ptr = ctypes.cast(self._hdr_buf, ctypes.c_void_p)
@@ -265,21 +246,19 @@ class UsbmonSource:
             if self._stop_event.is_set():
                 raise StopIteration
 
-            # poll() may itself be interrupted by EINTR; treat that as
-            # "wake up and check the stop flag", same as a timeout.
+            # EINTR from poll() means "wake and re-check the stop flag", same
+            # as a timeout.
             try:
                 ready = self._poller.poll(self._poll_timeout_ms)
             except InterruptedError:
                 continue
 
             if not ready:
-                # Timeout. Loop back to check the stop flag.
-                continue
+                continue  # timeout; re-check stop flag
 
             event = self._fetch_event()
             if event is None:
-                # Filler packet or EINTR during ioctl. Loop again.
-                continue
+                continue  # filler packet or EINTR during ioctl
             return event
 
     # -- internals ---------------------------------------------------------
@@ -287,11 +266,11 @@ class UsbmonSource:
     def _fetch_event(self) -> tuple[bytes, bytes] | None:
         """Issue one MON_IOCX_GETX ioctl and return its bytes, or None.
 
-        Returns None for filler packets (drop and retry) and for EINTR
-        (caller's stop-flag check will pick up Ctrl+C on the next loop).
-        Any other ioctl failure raises :class:`UsbmonIoctlError`.
+        Returns None for filler packets (drop and retry) and for EINTR (the
+        caller's stop-flag check picks up Ctrl+C next loop). Other ioctl
+        failures raise :class:`UsbmonIoctlError`.
         """
-        assert self._fd is not None  # invariant: only called between __enter__/__exit__
+        assert self._fd is not None  # only called between __enter__/__exit__
 
         arg = _MonGetArg(
             hdr=self._hdr_ptr,
@@ -310,16 +289,13 @@ class UsbmonSource:
                 f"MON_IOCX_GETX failed on {self._device_path}: {os.strerror(exc.errno) if exc.errno else exc}"
             ) from exc
 
-        # Drop ring-buffer filler events. These are not real URBs and
-        # would fail to decode downstream.
+        # Drop ring-buffer filler; not real URBs, would fail to decode.
         if self._hdr_buf[_EVENT_TYPE_OFFSET] == _FILLER_EVENT_BYTE:
             return None
 
         header_bytes = bytes(self._hdr_buf)
-        # The kernel populates `len_cap` (bytes 36-39 of the header) with
-        # the actual captured data length. Slice the data buffer to that
-        # length so callers never see uninitialized tail bytes from
-        # earlier events.
+        # Slice the data buffer to len_cap (header bytes 36-39, the captured
+        # length) so callers never see stale tail bytes from earlier events.
         len_cap = int.from_bytes(header_bytes[36:40], "little", signed=False)
         captured = min(len_cap, _DATA_BUFFER_SIZE)
         data_bytes = bytes(self._data_buf[:captured])
@@ -349,11 +325,10 @@ class UsbmonSource:
 
 
 def _list_available_buses() -> list[int]:
-    """Return sorted list of bus numbers with a /dev/usbmonN device node.
+    """Return sorted bus numbers that have a /dev/usbmonN node.
 
-    Used to make the "bus not found" error message actually useful.
-    Returns an empty list if /dev doesn't exist or no usbmon nodes are
-    present (which usually means the usbmon kernel module isn't loaded).
+    Feeds the "bus not found" error message. Empty if /dev is absent or has
+    no usbmon nodes (usually meaning the usbmon module isn't loaded).
     """
     buses: list[int] = []
     try:

--- a/bsu_tool/usbmon_source.py
+++ b/bsu_tool/usbmon_source.py
@@ -1,0 +1,378 @@
+"""Raw event source for Linux usbmon character devices.
+
+Wraps ``/dev/usbmonN`` for one USB bus and yields ``(header, data)``
+tuples of raw bytes — one per URB event delivered by the kernel.
+Does no parsing, no filtering by transfer type, and no pcap-ng
+encoding; those are upper layers' concerns.
+
+Three behaviors worth understanding before reading the code:
+
+1. **Filler packets are dropped here.** The kernel emits events with
+   ``event_type == 0x40`` ('@') as ring-buffer slot padding. They are
+   not real URBs and would fail to decode downstream. This module is
+   the single gatekeeper that drops them.
+
+2. **Iteration blocks but is interruptible.** Each ``__next__`` waits
+   up to ``poll_timeout_ms`` for the kernel to produce an event. If
+   the caller's ``stop_event`` is set during a wait, iteration stops
+   cleanly at the next timeout boundary — so worst-case stop latency
+   is bounded by ``poll_timeout_ms`` regardless of bus activity.
+
+3. **Errors are mapped to typed exceptions at open time.** A missing
+   device node (common on WSL2 where bus numbers shift between
+   reboots) raises :class:`UsbmonBusNotAvailableError` with a hint
+   about which buses *are* available. Permission failures raise
+   :class:`UsbmonPermissionError` with the conventional fix.
+
+The kernel-side ABI is documented in ``Documentation/usb/usbmon.rst``
+in the Linux source tree. The relevant pieces:
+
+* ``MON_IOCX_GETX`` (ioctl request ``_IOW(0x92, 10, struct mon_get_arg)``)
+  fetches one event, copying 64 bytes of header into ``hdr`` and up to
+  ``alloc`` bytes of captured data into ``data``. Returns 0 on success
+  or sets errno on failure (EINTR is the common non-fatal case).
+* ``struct mon_get_arg { struct mon_bin_hdr *hdr; void *data; size_t alloc; }``
+  — three pointer/size_t fields, native alignment.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import fcntl
+import os
+import select
+import threading
+from pathlib import Path
+from types import TracebackType
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Constants — usbmon ABI
+# ---------------------------------------------------------------------------
+
+#: Header size returned by MON_IOCX_GETX. Matches struct mon_bin_hdr in
+#: the kernel; also matches HEADER_SIZE_USB_LINUX_MMAPPED in urb_decoder.
+_HEADER_SIZE: Final = 64
+
+#: Maximum captured data per event. 65535 matches tshark's snap-len
+#: default and is larger than any single USB transfer we expect.
+_DATA_BUFFER_SIZE: Final = 65535
+
+#: usbmon event-type byte for ring-buffer filler. Real events use
+#: 0x53/0x43/0x45 ('S'/'C'/'E'). Anything else is junk to be dropped.
+_FILLER_EVENT_BYTE: Final = 0x40  # '@'
+
+#: Offset of the event-type byte within the header.
+_EVENT_TYPE_OFFSET: Final = 8
+
+# ---------------------------------------------------------------------------
+# Constants — ioctl encoding
+# ---------------------------------------------------------------------------
+#
+# Linux ioctl request numbers pack direction, type, command, and size
+# into a 32-bit integer. The encoding (from include/uapi/asm-generic/ioctl.h):
+#
+#     bits 31-30: direction (00 none, 01 write, 10 read, 11 read/write)
+#     bits 29-16: argument size in bytes
+#     bits 15-8:  type ("magic" byte, 0x92 for usbmon)
+#     bits 7-0:   command number
+#
+# MON_IOCX_GETX is defined as _IOW(MON_IOC_MAGIC, 10, struct mon_get_arg).
+# _IOW means direction=01 (write: userspace → kernel passes the arg).
+# The size is sizeof(struct mon_get_arg), which on 64-bit Linux is 24
+# bytes (two pointers + size_t).
+
+_IOC_NRBITS: Final = 8
+_IOC_TYPEBITS: Final = 8
+_IOC_SIZEBITS: Final = 14
+
+_IOC_NRSHIFT: Final = 0
+_IOC_TYPESHIFT: Final = _IOC_NRSHIFT + _IOC_NRBITS
+_IOC_SIZESHIFT: Final = _IOC_TYPESHIFT + _IOC_TYPEBITS
+_IOC_DIRSHIFT: Final = _IOC_SIZESHIFT + _IOC_SIZEBITS
+
+_IOC_WRITE: Final = 1
+
+_MON_IOC_MAGIC: Final = 0x92
+_MON_IOCX_GETX_NR: Final = 10
+
+
+class _MonGetArg(ctypes.Structure):
+    """ctypes layout of ``struct mon_get_arg``.
+
+    Field order and types must match the kernel's UAPI header exactly.
+    On 64-bit Linux, ``c_void_p`` is 8 bytes and ``c_size_t`` is 8 bytes,
+    giving a struct size of 24 bytes — which is what gets encoded into
+    the ioctl request number.
+    """
+
+    _fields_ = [
+        ("hdr", ctypes.c_void_p),
+        ("data", ctypes.c_void_p),
+        ("alloc", ctypes.c_size_t),
+    ]
+
+
+def _ioc(direction: int, magic: int, nr: int, size: int) -> int:
+    """Encode an ioctl request number — the Python equivalent of _IOC()."""
+    return (direction << _IOC_DIRSHIFT) | (magic << _IOC_TYPESHIFT) | (nr << _IOC_NRSHIFT) | (size << _IOC_SIZESHIFT)
+
+
+_MON_IOCX_GETX: Final = _ioc(
+    direction=_IOC_WRITE,
+    magic=_MON_IOC_MAGIC,
+    nr=_MON_IOCX_GETX_NR,
+    size=ctypes.sizeof(_MonGetArg),
+)
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class UsbmonError(Exception):
+    """Base class for all usbmon source errors."""
+
+
+class UsbmonBusNotAvailableError(UsbmonError):
+    """Raised when ``/dev/usbmonN`` does not exist for the requested bus.
+
+    On WSL2 and other dynamic environments, bus numbers can shift between
+    reboots or when devices are attached/detached. The error message
+    includes the list of currently-available bus numbers as a hint.
+    """
+
+
+class UsbmonPermissionError(UsbmonError):
+    """Raised when the user lacks permission to open ``/dev/usbmonN``.
+
+    The device is conventionally owned by ``root:usbmon`` with mode 0640;
+    fix by running as root or by adding the user to the ``usbmon`` group.
+    """
+
+
+class UsbmonIoctlError(UsbmonError):
+    """Raised when ``MON_IOCX_GETX`` fails with an unrecoverable error.
+
+    EINTR is handled internally and does not surface as this exception;
+    anything else (typically ENODEV when the bus disappears mid-capture)
+    does.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Source
+# ---------------------------------------------------------------------------
+
+
+class UsbmonSource:
+    """Iterable over raw events from one usbmon character device.
+
+    Use as a context manager so the underlying file descriptor is closed
+    on exit::
+
+        with UsbmonSource(bus_number=3, stop_event=stop) as source:
+            for header, data in source:
+                ...
+
+    Each iteration of ``__next__`` blocks for up to ``poll_timeout_ms``
+    waiting for an event. If ``stop_event`` is set during a wait, the
+    iterator raises ``StopIteration`` at the next timeout boundary —
+    so worst-case stop latency is bounded by ``poll_timeout_ms``
+    regardless of bus traffic.
+
+    Filler events (kernel ring-buffer padding) are silently dropped;
+    they are not real URBs.
+    """
+
+    __slots__ = (
+        "_bus_number",
+        "_data_buf",
+        "_data_ptr",
+        "_device_path",
+        "_fd",
+        "_hdr_buf",
+        "_hdr_ptr",
+        "_poll_timeout_ms",
+        "_poller",
+        "_stop_event",
+    )
+
+    def __init__(
+        self,
+        bus_number: int,
+        *,
+        stop_event: threading.Event,
+        poll_timeout_ms: int = 100,
+    ) -> None:
+        self._bus_number = bus_number
+        self._device_path = Path(f"/dev/usbmon{bus_number}")
+        self._stop_event = stop_event
+        self._poll_timeout_ms = poll_timeout_ms
+
+        # File descriptor is opened in __enter__, not __init__. Construct-
+        # ing a source object should not have system-level side effects.
+        self._fd: int | None = None
+        self._poller: select.poll | None = None
+
+        # Persistent ctypes buffers — allocated once, reused for every
+        # ioctl call. The kernel writes into these buffers each call;
+        # we copy out the bytes we care about and hand the buffers
+        # back to the kernel on the next iteration.
+        self._hdr_buf = (ctypes.c_ubyte * _HEADER_SIZE)()
+        self._data_buf = (ctypes.c_ubyte * _DATA_BUFFER_SIZE)()
+        self._hdr_ptr = ctypes.cast(self._hdr_buf, ctypes.c_void_p)
+        self._data_ptr = ctypes.cast(self._data_buf, ctypes.c_void_p)
+
+    # -- context manager ---------------------------------------------------
+
+    def __enter__(self) -> UsbmonSource:
+        try:
+            self._fd = os.open(str(self._device_path), os.O_RDONLY)
+        except FileNotFoundError as exc:
+            raise UsbmonBusNotAvailableError(self._not_available_message()) from exc
+        except PermissionError as exc:
+            raise UsbmonPermissionError(
+                f"permission denied opening {self._device_path}; run as root or add user to the 'usbmon' group"
+            ) from exc
+
+        self._poller = select.poll()
+        self._poller.register(self._fd, select.POLLIN)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        if self._fd is not None:
+            os.close(self._fd)
+            self._fd = None
+        self._poller = None
+
+    # -- iteration ---------------------------------------------------------
+
+    def __iter__(self) -> UsbmonSource:
+        return self
+
+    def __next__(self) -> tuple[bytes, bytes]:
+        if self._fd is None or self._poller is None:
+            raise RuntimeError("UsbmonSource must be used as a context manager")
+
+        while True:
+            if self._stop_event.is_set():
+                raise StopIteration
+
+            # poll() may itself be interrupted by EINTR; treat that as
+            # "wake up and check the stop flag", same as a timeout.
+            try:
+                ready = self._poller.poll(self._poll_timeout_ms)
+            except InterruptedError:
+                continue
+
+            if not ready:
+                # Timeout. Loop back to check the stop flag.
+                continue
+
+            event = self._fetch_event()
+            if event is None:
+                # Filler packet or EINTR during ioctl. Loop again.
+                continue
+            return event
+
+    # -- internals ---------------------------------------------------------
+
+    def _fetch_event(self) -> tuple[bytes, bytes] | None:
+        """Issue one MON_IOCX_GETX ioctl and return its bytes, or None.
+
+        Returns None for filler packets (drop and retry) and for EINTR
+        (caller's stop-flag check will pick up Ctrl+C on the next loop).
+        Any other ioctl failure raises :class:`UsbmonIoctlError`.
+        """
+        assert self._fd is not None  # invariant: only called between __enter__/__exit__
+
+        arg = _MonGetArg(
+            hdr=self._hdr_ptr,
+            data=self._data_ptr,
+            alloc=_DATA_BUFFER_SIZE,
+        )
+
+        try:
+            fcntl.ioctl(self._fd, _MON_IOCX_GETX, arg)
+        except InterruptedError:
+            return None
+        except OSError as exc:
+            if exc.errno == errno.EINTR:
+                return None
+            raise UsbmonIoctlError(
+                f"MON_IOCX_GETX failed on {self._device_path}: {os.strerror(exc.errno) if exc.errno else exc}"
+            ) from exc
+
+        # Drop ring-buffer filler events. These are not real URBs and
+        # would fail to decode downstream.
+        if self._hdr_buf[_EVENT_TYPE_OFFSET] == _FILLER_EVENT_BYTE:
+            return None
+
+        header_bytes = bytes(self._hdr_buf)
+        # The kernel populates `len_cap` (bytes 36-39 of the header) with
+        # the actual captured data length. Slice the data buffer to that
+        # length so callers never see uninitialized tail bytes from
+        # earlier events.
+        len_cap = int.from_bytes(header_bytes[36:40], "little", signed=False)
+        captured = min(len_cap, _DATA_BUFFER_SIZE)
+        data_bytes = bytes(self._data_buf[:captured])
+
+        return header_bytes, data_bytes
+
+    # -- error helpers -----------------------------------------------------
+
+    def _not_available_message(self) -> str:
+        available = _list_available_buses()
+        if not available:
+            return (
+                f"usbmon bus {self._bus_number} not available "
+                f"({self._device_path} does not exist). "
+                f"No /dev/usbmon* devices found — is the usbmon module loaded?"
+            )
+        return (
+            f"usbmon bus {self._bus_number} not available "
+            f"({self._device_path} does not exist). "
+            f"Available buses: {', '.join(str(n) for n in available)}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_available_buses() -> list[int]:
+    """Return sorted list of bus numbers with a /dev/usbmonN device node.
+
+    Used to make the "bus not found" error message actually useful.
+    Returns an empty list if /dev doesn't exist or no usbmon nodes are
+    present (which usually means the usbmon kernel module isn't loaded).
+    """
+    buses: list[int] = []
+    try:
+        for entry in Path("/dev").iterdir():
+            name = entry.name
+            if not name.startswith("usbmon"):
+                continue
+            suffix = name[len("usbmon") :]
+            if suffix.isdigit():
+                buses.append(int(suffix))
+    except (FileNotFoundError, PermissionError):
+        return []
+    return sorted(buses)
+
+
+__all__ = [
+    "UsbmonBusNotAvailableError",
+    "UsbmonError",
+    "UsbmonIoctlError",
+    "UsbmonPermissionError",
+    "UsbmonSource",
+]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,6 @@
 {
   "pythonVersion": "3.11",
+  "pythonPlatform": "Linux",
   "typeCheckingMode": "strict",
   "include": ["bsu_tool", "tests"]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest configuration.
+
+``bsu_tool.usbmon_source`` (and, transitively, ``bsu_tool.sniffer``) import
+``fcntl``, which only exists on Unix. To let their tests run on Windows dev
+machines — where the pure-logic and mocked paths are still worth exercising —
+we install an empty stub module *before* any test module imports its target.
+
+On Linux (including CI) the real ``fcntl`` imports cleanly and this stub is
+never installed, so behavior there is unchanged.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+
+if importlib.util.find_spec("fcntl") is None:  # pragma: no cover - Windows only
+    _stub = types.ModuleType("fcntl")
+    # Give the stub an ``ioctl`` attribute so tests can monkeypatch it with
+    # the default ``raising=True`` on Windows just as they would on Linux.
+    _stub.ioctl = None  # type: ignore[attr-defined]
+    sys.modules["fcntl"] = _stub

--- a/tests/int/test_sniffer_writer_roundtrip_goodix.py
+++ b/tests/int/test_sniffer_writer_roundtrip_goodix.py
@@ -1,0 +1,200 @@
+"""Integration test: sniffer/writer → reader → urb_decoder on the Goodix capture.
+
+The unit tests validate ``sniffer`` and ``pcapng_writer`` only as far as
+:class:`~bsu_tool.pcapng_reader.PcapNgReader`. They stop short of the real
+contract: *a capture the sniffer writes must be decodable by the downstream
+URB pipeline.* That seam — writer → reader → ``decode_urb`` — is untested by
+the hand-built headers in the unit suite, which are mostly zeros and would
+never survive real URB decoding.
+
+This test closes the loop using real usbmon bytes as ground truth. It:
+
+1. reads the reference Goodix capture's Enhanced Packet Blocks,
+2. splits each into its ``(64-byte header, data)`` halves and replays them
+   through :func:`bsu_tool.sniffer.capture` (with the Linux-only
+   :class:`UsbmonSource` swapped for a replay fake), producing a **new**
+   pcap-ng file via the real writer, then
+3. reads that file back and asserts it decodes **identically** to the
+   original — byte-for-byte packet data, preserved timestamps, and equal
+   :class:`~bsu_tool.urb_decoder.UrbRecord` values.
+
+If the writer emitted a structurally-valid-but-undecodable file, or the
+sniffer's header-derived timestamps drifted, this test fails where the unit
+tests cannot.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from threading import Event
+from types import TracebackType
+
+import pytest
+
+from bsu_tool import sniffer
+from bsu_tool.pcapng_reader import (
+    EnhancedPacketBlock,
+    InterfaceDescriptionBlock,
+    PcapNgReader,
+)
+from bsu_tool.sniffer import capture
+from bsu_tool.urb_decoder import (
+    UnsupportedTransferTypeError,
+    UrbRecord,
+    decode_urb,
+)
+
+_CAPTURE = (
+    pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures" / "goodix_enum_and_enroll_sanitized.pcapng"
+)
+
+#: usbmon header size — the split point between header and captured data in
+#: each EPB's packet_data (see urb_decoder.HEADER_SIZE_USB_LINUX_MMAPPED).
+_HEADER_SIZE = 64
+
+#: Bus number the Goodix capture was taken on (see test_urb_decode_goodix).
+_GOODIX_BUS = 1
+
+
+# ---------------------------------------------------------------------------
+# Replay source — stands in for the Linux-only UsbmonSource
+# ---------------------------------------------------------------------------
+
+
+class _ReplaySource:
+    """Yields pre-recorded ``(header, data)`` events, like a live usbmon read."""
+
+    def __init__(self, events: list[tuple[bytes, bytes]]) -> None:
+        self._events = events
+        self._pos = 0
+
+    def __enter__(self) -> _ReplaySource:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    def __iter__(self) -> _ReplaySource:
+        self._pos = 0
+        return self
+
+    def __next__(self) -> tuple[bytes, bytes]:
+        if self._pos >= len(self._events):
+            raise StopIteration
+        event = self._events[self._pos]
+        self._pos += 1
+        return event
+
+
+def _read_epbs(path: pathlib.Path) -> tuple[int, list[EnhancedPacketBlock]]:
+    """Return ``(link_type, epbs)`` from a pcap-ng file."""
+    with path.open("rb") as fp:
+        blocks = list(PcapNgReader(fp))
+    idb = next(b for b in blocks if isinstance(b, InterfaceDescriptionBlock))
+    epbs = [b for b in blocks if isinstance(b, EnhancedPacketBlock)]
+    return idb.link_type, epbs
+
+
+def _decode_all(epbs: list[EnhancedPacketBlock], link_type: int) -> list[UrbRecord]:
+    """Decode every supported EPB, skipping out-of-scope transfer types."""
+    records: list[UrbRecord] = []
+    for epb in epbs:
+        try:
+            records.append(decode_urb(epb.packet_data, link_type))
+        except UnsupportedTransferTypeError:
+            pass
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Fixture: re-emit the capture through the sniffer/writer once per module
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def roundtrip(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[list[EnhancedPacketBlock], list[EnhancedPacketBlock], int]:
+    """Replay the Goodix EPBs through ``capture`` and return original + re-emitted.
+
+    Returns ``(original_epbs, reemitted_epbs, link_type)``.
+    """
+    if not _CAPTURE.is_file():
+        pytest.skip(f"reference capture not found: {_CAPTURE}")
+
+    link_type, original_epbs = _read_epbs(_CAPTURE)
+
+    # Reconstruct the raw usbmon events the kernel would have yielded: the
+    # 64-byte header followed by the captured data, exactly as the source
+    # hands them to capture().
+    events = [(epb.packet_data[:_HEADER_SIZE], epb.packet_data[_HEADER_SIZE:]) for epb in original_epbs]
+
+    out_path = tmp_path_factory.mktemp("roundtrip") / "reemitted.pcapng"
+
+    with pytest.MonkeyPatch.context() as mp:
+
+        def _factory(*, bus_number: int, stop_event: Event) -> _ReplaySource:
+            return _ReplaySource(events)
+
+        mp.setattr(sniffer, "UsbmonSource", _factory)
+        stats = capture(bus=_GOODIX_BUS, device=None, output_path=out_path, stop_event=Event())
+
+    # Bus-only capture writes every event it sees.
+    assert stats.matched == stats.seen == len(original_epbs)
+
+    _, reemitted_epbs = _read_epbs(out_path)
+    return original_epbs, reemitted_epbs, link_type
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_reemitted_epb_count_matches(
+    roundtrip: tuple[list[EnhancedPacketBlock], list[EnhancedPacketBlock], int],
+) -> None:
+    """The re-emitted capture has one EPB per original event (253 total)."""
+    original_epbs, reemitted_epbs, _ = roundtrip
+    assert len(reemitted_epbs) == len(original_epbs) == 253
+
+
+def test_reemitted_packet_data_is_byte_identical(
+    roundtrip: tuple[list[EnhancedPacketBlock], list[EnhancedPacketBlock], int],
+) -> None:
+    """Header + data survives the sniffer/writer round-trip unchanged."""
+    original_epbs, reemitted_epbs, _ = roundtrip
+    assert [e.packet_data for e in reemitted_epbs] == [e.packet_data for e in original_epbs]
+
+
+def test_reemitted_timestamps_preserved(
+    roundtrip: tuple[list[EnhancedPacketBlock], list[EnhancedPacketBlock], int],
+) -> None:
+    """The sniffer derives EPB timestamps from the usbmon header, so a
+    re-emitted capture must carry the same timestamps as the original."""
+    original_epbs, reemitted_epbs, _ = roundtrip
+    original_ts = [(e.timestamp_high, e.timestamp_low) for e in original_epbs]
+    reemitted_ts = [(e.timestamp_high, e.timestamp_low) for e in reemitted_epbs]
+    assert reemitted_ts == original_ts
+
+
+def test_reemitted_capture_decodes_identically(
+    roundtrip: tuple[list[EnhancedPacketBlock], list[EnhancedPacketBlock], int],
+) -> None:
+    """The whole point: a sniffer-written file decodes to the same URB records.
+
+    Equality is field-wise (UrbRecord is a frozen dataclass), so this covers
+    transfer types, event types, bus/device numbers, setup packets, payloads,
+    and timestamps in one assertion.
+    """
+    original_epbs, reemitted_epbs, link_type = roundtrip
+    original_records = _decode_all(original_epbs, link_type)
+    reemitted_records = _decode_all(reemitted_epbs, link_type)
+
+    assert len(reemitted_records) == 249  # 253 EPBs minus 4 out-of-scope interrupts
+    assert reemitted_records == original_records

--- a/tests/unit/test_pcapng_writer.py
+++ b/tests/unit/test_pcapng_writer.py
@@ -1,0 +1,289 @@
+"""Tests for the pcap-ng writer module.
+
+The writer emits pcap-ng *block* structure only; these tests exercise it
+two ways:
+
+* **Byte-level** — decode the written bytes by hand to assert exact field
+  layout, endianness, and framing invariants (leading == trailing length,
+  4-byte alignment).
+* **Round-trip** — feed the written bytes back through
+  :class:`~bsu_tool.pcapng_reader.PcapNgReader` and assert the parsed
+  blocks carry the values we wrote. This is the strongest single check
+  that the two layers agree on the wire format.
+
+Like ``test_pcapng_reader``, these tests define their own little-endian
+encoders rather than importing the writer's private helpers, so the test
+and the code under test can drift apart and be caught.
+"""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Callable
+
+import pytest
+
+from bsu_tool.pcapng_reader import (
+    EnhancedPacketBlock,
+    InterfaceDescriptionBlock,
+    PcapNgReader,
+    SectionHeaderBlock,
+)
+from bsu_tool.pcapng_writer import PcapNgWriter
+from bsu_tool.urb_decoder import LINKTYPE_USB_LINUX_MMAPPED
+
+_LE = "little"
+
+
+# --- Local encoders / decode helpers ---------------------------------------
+
+
+def _u16(value: int) -> bytes:
+    return value.to_bytes(2, _LE)
+
+
+def _u32(value: int) -> bytes:
+    return value.to_bytes(4, _LE)
+
+
+def _i64(value: int) -> bytes:
+    return value.to_bytes(8, _LE, signed=True)
+
+
+def _decode_block(data: bytes, offset: int = 0) -> tuple[int, bytes, int]:
+    """Decode one framed block at ``offset``.
+
+    Returns ``(block_type, body, next_offset)`` and asserts the framing
+    invariants every block must satisfy: total length is a multiple of 4,
+    and the leading and trailing total-length fields agree.
+    """
+    block_type = int.from_bytes(data[offset : offset + 4], _LE)
+    total_length = int.from_bytes(data[offset + 4 : offset + 8], _LE)
+    assert total_length % 4 == 0, "block total length must be 4-byte aligned"
+    trailing = int.from_bytes(data[offset + total_length - 4 : offset + total_length], _LE)
+    assert trailing == total_length, "leading and trailing total-length must agree"
+    body = data[offset + 8 : offset + total_length - 4]
+    return block_type, body, offset + total_length
+
+
+def _write(fn: Callable[[PcapNgWriter], None]) -> bytes:
+    """Run ``fn(writer)`` against a fresh BytesIO and return the bytes."""
+    stream = io.BytesIO()
+    fn(PcapNgWriter(stream))
+    return stream.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Section Header Block
+# ---------------------------------------------------------------------------
+
+
+def test_shb_field_layout() -> None:
+    data = _write(lambda w: w.write_section_header())
+    block_type, body, end = _decode_block(data)
+
+    assert block_type == 0x0A0D0D0A
+    assert end == len(data)  # exactly one block written
+    assert body[0:4] == _u32(0x1A2B3C4D)  # byte-order magic
+    assert body[4:6] == _u16(1)  # major version
+    assert body[6:8] == _u16(0)  # minor version
+    assert body[8:16] == _i64(-1)  # section length "unknown"
+
+
+def test_shb_roundtrips_through_reader() -> None:
+    data = _write(lambda w: w.write_section_header())
+    (block,) = list(PcapNgReader(io.BytesIO(data)))
+    assert isinstance(block, SectionHeaderBlock)
+    assert block.byte_order == "little"
+    assert block.major_version == 1
+    assert block.minor_version == 0
+    assert block.section_length == -1
+
+
+def test_write_section_header_resets_interface_count() -> None:
+    def body(w: PcapNgWriter) -> None:
+        w.write_section_header()
+        w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED)
+        w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED)
+        assert w.interface_count == 2
+        w.write_section_header()  # new section
+        assert w.interface_count == 0
+        assert w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED) == 0
+
+    _write(body)
+
+
+# ---------------------------------------------------------------------------
+# Interface Description Block
+# ---------------------------------------------------------------------------
+
+
+def test_interface_ids_are_assigned_in_registration_order() -> None:
+    ids: list[int] = []
+
+    def body(w: PcapNgWriter) -> None:
+        w.write_section_header()
+        ids.append(w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED))
+        ids.append(w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED))
+        ids.append(w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED))
+
+    _write(body)
+    assert ids == [0, 1, 2]
+
+
+def test_idb_roundtrips_with_link_type_and_snap_len() -> None:
+    def body(w: PcapNgWriter) -> None:
+        w.write_section_header()
+        w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED, snap_len=4096)
+
+    data = _write(body)
+    blocks = list(PcapNgReader(io.BytesIO(data)))
+    idb = next(b for b in blocks if isinstance(b, InterfaceDescriptionBlock))
+    assert idb.link_type == LINKTYPE_USB_LINUX_MMAPPED
+    assert idb.snap_len == 4096
+
+
+def test_idb_carries_tsresol_option() -> None:
+    def body(w: PcapNgWriter) -> None:
+        w.write_section_header()
+        w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED, tsresol_exponent=6)
+
+    data = _write(body)
+    idb = next(b for b in PcapNgReader(io.BytesIO(data)) if isinstance(b, InterfaceDescriptionBlock))
+    tsresol = next(opt for opt in idb.options if opt.code == 9)  # if_tsresol
+    assert tsresol.value == bytes([6])
+
+
+# ---------------------------------------------------------------------------
+# Enhanced Packet Block
+# ---------------------------------------------------------------------------
+
+
+def _write_one_epb(
+    packet_data: bytes,
+    *,
+    timestamp_us: int = 0,
+    original_length: int | None = None,
+) -> bytes:
+    def body(w: PcapNgWriter) -> None:
+        w.write_section_header()
+        iface = w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED)
+        w.write_enhanced_packet(iface, timestamp_us, packet_data, original_length=original_length)
+
+    return _write(body)
+
+
+def test_epb_splits_timestamp_into_high_and_low_words() -> None:
+    # Chosen so the high and low 32-bit words are distinct and non-zero.
+    ts = 0x1_2345_6789
+    data = _write_one_epb(b"\xaa\xbb\xcc\xdd", timestamp_us=ts)
+    epb = next(b for b in PcapNgReader(io.BytesIO(data)) if isinstance(b, EnhancedPacketBlock))
+    assert epb.timestamp_high == 0x1
+    assert epb.timestamp_low == 0x23456789
+    # And the reader can reassemble the original value.
+    assert (epb.timestamp_high << 32) | epb.timestamp_low == ts
+
+
+@pytest.mark.parametrize("payload_len", [0, 1, 3, 4, 5, 7, 8])
+def test_epb_pads_packet_data_to_four_byte_boundary(payload_len: int) -> None:
+    payload = bytes(range(payload_len))
+    data = _write_one_epb(payload)
+    # The whole file must remain 4-byte aligned regardless of payload length.
+    assert len(data) % 4 == 0
+    epb = next(b for b in PcapNgReader(io.BytesIO(data)) if isinstance(b, EnhancedPacketBlock))
+    assert epb.captured_len == payload_len
+    assert epb.packet_data == payload
+
+
+def test_epb_captured_len_defaults_to_payload_length() -> None:
+    data = _write_one_epb(b"\x01\x02\x03")
+    epb = next(b for b in PcapNgReader(io.BytesIO(data)) if isinstance(b, EnhancedPacketBlock))
+    assert epb.captured_len == 3
+    assert epb.original_len == 3
+
+
+def test_epb_honors_explicit_original_length() -> None:
+    # Truncated capture: 4 bytes captured, but 100 on the wire.
+    data = _write_one_epb(b"\x01\x02\x03\x04", original_length=100)
+    epb = next(b for b in PcapNgReader(io.BytesIO(data)) if isinstance(b, EnhancedPacketBlock))
+    assert epb.captured_len == 4
+    assert epb.original_len == 100
+
+
+def test_epb_accepts_empty_packet_data() -> None:
+    data = _write_one_epb(b"")
+    epb = next(b for b in PcapNgReader(io.BytesIO(data)) if isinstance(b, EnhancedPacketBlock))
+    assert epb.captured_len == 0
+    assert epb.packet_data == b""
+
+
+def test_epb_references_the_correct_interface_id() -> None:
+    def body(w: PcapNgWriter) -> None:
+        w.write_section_header()
+        w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED)
+        second = w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED)
+        w.write_enhanced_packet(second, 0, b"\x00")
+
+    data = _write(body)
+    epb = next(b for b in PcapNgReader(io.BytesIO(data)) if isinstance(b, EnhancedPacketBlock))
+    assert epb.interface_id == 1
+
+
+# ---------------------------------------------------------------------------
+# EPB validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_id", [-1, 0, 1, 5])
+def test_write_enhanced_packet_rejects_unregistered_interface(bad_id: int) -> None:
+    # No IDBs registered, so every interface_id is invalid.
+    writer = PcapNgWriter(io.BytesIO())
+    writer.write_section_header()
+    with pytest.raises(ValueError, match="not registered"):
+        writer.write_enhanced_packet(bad_id, 0, b"\x00")
+
+
+@pytest.mark.parametrize("bad_ts", [-1, 1 << 64, (1 << 64) + 1])
+def test_write_enhanced_packet_rejects_out_of_range_timestamp(bad_ts: int) -> None:
+    writer = PcapNgWriter(io.BytesIO())
+    writer.write_section_header()
+    iface = writer.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED)
+    with pytest.raises(ValueError, match="64-bit range"):
+        writer.write_enhanced_packet(iface, bad_ts, b"\x00")
+
+
+def test_max_valid_timestamp_is_accepted() -> None:
+    ts = (1 << 64) - 1
+    data = _write_one_epb(b"\x00", timestamp_us=ts)
+    epb = next(b for b in PcapNgReader(io.BytesIO(data)) if isinstance(b, EnhancedPacketBlock))
+    assert (epb.timestamp_high << 32) | epb.timestamp_low == ts
+
+
+# ---------------------------------------------------------------------------
+# Full-file round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_full_capture_roundtrips_block_for_block() -> None:
+    packets = [
+        (b"\x53\x00header-a" + b"\xde\xad\xbe\xef", 1_000_000),
+        (b"\x43\x00header-b" + b"\x01", 1_500_000),
+        (b"\x45\x00header-c", 2_000_000),
+    ]
+
+    def body(w: PcapNgWriter) -> None:
+        w.write_section_header()
+        iface = w.write_interface_description(link_type=LINKTYPE_USB_LINUX_MMAPPED)
+        for data, ts in packets:
+            w.write_enhanced_packet(iface, ts, data)
+
+    raw = _write(body)
+    blocks = list(PcapNgReader(io.BytesIO(raw)))
+
+    assert isinstance(blocks[0], SectionHeaderBlock)
+    assert isinstance(blocks[1], InterfaceDescriptionBlock)
+    epbs = [b for b in blocks if isinstance(b, EnhancedPacketBlock)]
+    assert len(epbs) == len(packets)
+    for epb, (data, ts) in zip(epbs, packets, strict=True):
+        assert epb.packet_data == data
+        assert (epb.timestamp_high << 32) | epb.timestamp_low == ts

--- a/tests/unit/test_sniff_command.py
+++ b/tests/unit/test_sniff_command.py
@@ -1,0 +1,245 @@
+# pyright: reportPrivateUsage=false
+#
+# This module unit-tests sniff_command's internal helpers directly:
+# _format_bytes (its unit-boundary behavior is exactly what deserves precise
+# testing), and the _die / _print_final_stats presentation helpers. Only
+# run_sniff is public, so reportPrivateUsage is disabled here and only here.
+"""Tests for the ``sniff`` CLI subcommand handler.
+
+``sniff_command`` is a thin presentation layer over ``sniffer.capture``:
+SIGINT wiring, stderr progress/summary printing, and translation of the
+library's structured exceptions into ``bsu-tool: ...`` messages with a
+clean exit code. These tests target the parts that carry real logic —
+byte formatting, the exception→exit-code mapping, and the "nothing
+matched" hint branches — and skip asserting exact cosmetic layout.
+
+``capture`` is replaced with a spy so nothing touches ``/dev/usbmon`` or
+blocks on real traffic, and ``signal.signal`` is stubbed so the tests do
+not mutate the process's real SIGINT handler.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from threading import Event
+from types import FrameType
+
+import pytest
+
+from bsu_tool import sniff_command
+from bsu_tool.sniff_command import (
+    _die,
+    _format_bytes,
+    _print_final_stats,
+    run_sniff,
+)
+from bsu_tool.sniffer import CaptureStats, ProgressCallback
+from bsu_tool.usbmon_source import (
+    UsbmonBusNotAvailableError,
+    UsbmonIoctlError,
+    UsbmonPermissionError,
+)
+
+_SigintHandler = Callable[[int, FrameType | None], None]
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _CaptureSpy:
+    """Stand-in for ``sniffer.capture`` used by ``run_sniff``.
+
+    Records the ``stop_event`` it was handed (so SIGINT wiring can be
+    checked) and then either raises ``error`` or returns ``result``.
+    """
+
+    def __init__(self, *, result: CaptureStats | None = None, error: BaseException | None = None) -> None:
+        self._result = result
+        self._error = error
+        self.stop_event: Event | None = None
+
+    def __call__(
+        self,
+        *,
+        bus: int,
+        device: int | None,
+        output_path: Path,
+        stop_event: Event,
+        on_progress: ProgressCallback | None = None,
+    ) -> CaptureStats:
+        self.stop_event = stop_event
+        if self._error is not None:
+            raise self._error
+        if self._result is not None:
+            return self._result
+        return CaptureStats(output_path=output_path, seen=1, matched=1, elapsed_seconds=1.0, output_bytes=42)
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, spy: _CaptureSpy) -> list[_SigintHandler]:
+    """Patch ``capture`` and ``signal.signal``; return captured SIGINT handlers."""
+    handlers: list[_SigintHandler] = []
+
+    def _fake_signal(signum: int, handler: _SigintHandler) -> None:
+        handlers.append(handler)
+
+    monkeypatch.setattr(sniff_command, "capture", spy)
+    monkeypatch.setattr(sniff_command.signal, "signal", _fake_signal)
+    return handlers
+
+
+def _stats(*, seen: int, matched: int, output: str = "out.pcapng") -> CaptureStats:
+    return CaptureStats(
+        output_path=Path(output),
+        seen=seen,
+        matched=matched,
+        elapsed_seconds=2.0,
+        output_bytes=1024,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_bytes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("n", "expected"),
+    [
+        (0, "0 B"),
+        (512, "512 B"),
+        (1023, "1023 B"),
+        (1024, "1.0 KB"),
+        (1536, "1.5 KB"),
+        (1024 * 1024, "1.0 MB"),
+        (2 * 1024 * 1024 + 512 * 1024, "2.5 MB"),
+        (1024 * 1024 * 1024, "1.00 GB"),
+        (5 * 1024 * 1024 * 1024, "5.00 GB"),
+    ],
+)
+def test_format_bytes(n: int, expected: str) -> None:
+    assert _format_bytes(n) == expected
+
+
+def test_format_bytes_unit_boundaries() -> None:
+    # One below each threshold stays in the smaller unit; the threshold flips.
+    assert _format_bytes(1023).endswith(" B")
+    assert _format_bytes(1024).endswith(" KB")
+    assert _format_bytes(1024 * 1024 - 1).endswith(" KB")
+    assert _format_bytes(1024 * 1024).endswith(" MB")
+    assert _format_bytes(1024 * 1024 * 1024 - 1).endswith(" MB")
+    assert _format_bytes(1024 * 1024 * 1024).endswith(" GB")
+
+
+# ---------------------------------------------------------------------------
+# Exception → exit-code mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        FileExistsError(),
+        UsbmonBusNotAvailableError("bus 9 not available"),
+        UsbmonPermissionError("permission denied"),
+        UsbmonIoctlError("ENODEV"),
+    ],
+)
+def test_capture_errors_exit_cleanly(
+    error: BaseException, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _install(monkeypatch, _CaptureSpy(error=error))
+    with pytest.raises(SystemExit) as exc_info:
+        run_sniff(bus=3, device=5, output=Path("out.pcapng"))
+    assert exc_info.value.code == 1
+    assert "bsu-tool:" in capsys.readouterr().err
+
+
+def test_file_exists_error_names_the_path(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _install(monkeypatch, _CaptureSpy(error=FileExistsError()))
+    with pytest.raises(SystemExit):
+        run_sniff(bus=3, device=5, output=Path("existing.pcapng"))
+    assert "existing.pcapng" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# run_sniff happy path and wiring
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_prints_final_stats(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    spy = _CaptureSpy(result=_stats(seen=10, matched=10))
+    _install(monkeypatch, spy)
+    run_sniff(bus=3, device=5, output=Path("out.pcapng"))  # returns normally
+    err = capsys.readouterr().err
+    assert "Capture stopped." in err
+    assert "out.pcapng" in err
+
+
+def test_sigint_handler_sets_the_capture_stop_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    spy = _CaptureSpy(result=_stats(seen=1, matched=1))
+    handlers = _install(monkeypatch, spy)
+    run_sniff(bus=3, device=5, output=Path("out.pcapng"))
+
+    assert spy.stop_event is not None
+    assert not spy.stop_event.is_set()
+    # The registered SIGINT handler must set the very event capture received.
+    assert handlers, "run_sniff did not register a SIGINT handler"
+    handlers[0](2, None)  # simulate Ctrl+C
+    assert spy.stop_event.is_set()
+
+
+def test_bus_zero_all_devices_warns(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _install(monkeypatch, _CaptureSpy(result=_stats(seen=1, matched=1)))
+    run_sniff(bus=0, device=None, output=Path("out.pcapng"))
+    assert "Warning: bus 0" in capsys.readouterr().err
+
+
+def test_bus_zero_with_device_does_not_warn(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A device filter on bus 0 is fine — the whole-host warning must not fire.
+    _install(monkeypatch, _CaptureSpy(result=_stats(seen=1, matched=1)))
+    run_sniff(bus=0, device=5, output=Path("out.pcapng"))
+    assert "Warning: bus 0" not in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _print_final_stats — the "nothing matched" hint branches
+# ---------------------------------------------------------------------------
+
+
+def test_final_stats_note_when_no_events_seen(capsys: pytest.CaptureFixture[str]) -> None:
+    _print_final_stats(_stats(seen=0, matched=0))
+    assert "no events were seen" in capsys.readouterr().err
+
+
+def test_final_stats_note_when_seen_but_none_matched(capsys: pytest.CaptureFixture[str]) -> None:
+    err_text = _emit_final_stats(seen=50, matched=0, capsys=capsys)
+    assert "none" in err_text
+    assert "device number" in err_text
+
+
+def test_final_stats_no_note_when_matched(capsys: pytest.CaptureFixture[str]) -> None:
+    err_text = _emit_final_stats(seen=50, matched=50, capsys=capsys)
+    assert "no events were seen" not in err_text
+    assert "none matched" not in err_text
+
+
+def _emit_final_stats(*, seen: int, matched: int, capsys: pytest.CaptureFixture[str]) -> str:
+    _print_final_stats(_stats(seen=seen, matched=matched))
+    return capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _die
+# ---------------------------------------------------------------------------
+
+
+def test_die_raises_system_exit_one_with_prefix(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        _die("something broke")
+    assert exc_info.value.code == 1
+    assert capsys.readouterr().err.strip() == "bsu-tool: something broke"

--- a/tests/unit/test_sniffer.py
+++ b/tests/unit/test_sniffer.py
@@ -1,0 +1,280 @@
+"""Tests for the capture orchestrator.
+
+``sniffer.capture`` wires a :class:`UsbmonSource` to a
+:class:`~bsu_tool.pcapng_writer.PcapNgWriter`. These tests swap the real,
+Linux-only source for a **fake** that yields scripted ``(header, data)``
+tuples, so the filtering, timestamp derivation, stats, and — for
+:class:`CaptureController` — the start/stop threading can all be exercised
+on any platform. Output goes to a real temp file and is validated by
+reading it back with :class:`~bsu_tool.pcapng_reader.PcapNgReader`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Event
+from types import TracebackType
+
+import pytest
+
+from bsu_tool import sniffer
+from bsu_tool.pcapng_reader import EnhancedPacketBlock, PcapNgReader
+from bsu_tool.sniffer import (
+    CaptureController,
+    CaptureStateError,
+    CaptureStats,
+    capture,
+)
+from bsu_tool.usbmon_source import UsbmonPermissionError
+
+_DEVNUM_OFFSET = 11
+
+
+def _header(devnum: int = 0, *, ts_sec: int = 0, ts_usec: int = 0) -> bytes:
+    """Build a 64-byte usbmon header with the fields ``capture`` reads set."""
+    h = bytearray(64)
+    h[_DEVNUM_OFFSET] = devnum
+    h[16:24] = ts_sec.to_bytes(8, "little", signed=True)
+    h[24:28] = ts_usec.to_bytes(4, "little", signed=True)
+    return bytes(h)
+
+
+class _FakeSource:
+    """Stand-in for :class:`UsbmonSource`.
+
+    Yields the scripted ``events`` then ends. Optionally raises from
+    ``__enter__`` (startup failure) or after N events (mid-capture failure),
+    and can block in ``__enter__`` to simulate a source that never goes live.
+    """
+
+    def __init__(
+        self,
+        events: list[tuple[bytes, bytes]],
+        *,
+        enter_error: BaseException | None = None,
+        iter_error: BaseException | None = None,
+        block_enter: Event | None = None,
+        hold_until_stop: bool = False,
+    ) -> None:
+        self._events = events
+        self._enter_error = enter_error
+        self._iter_error = iter_error
+        self._block_enter = block_enter
+        self._hold_until_stop = hold_until_stop
+        # Set by the install factory so the fake can mimic the real source,
+        # which raises StopIteration only once the stop event is set.
+        self.stop_event: Event | None = None
+
+    def __enter__(self) -> _FakeSource:
+        if self._block_enter is not None:
+            self._block_enter.wait()
+        if self._enter_error is not None:
+            raise self._enter_error
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    def __iter__(self) -> _FakeSource:
+        self._pos = 0
+        return self
+
+    def __next__(self) -> tuple[bytes, bytes]:
+        if self._pos >= len(self._events):
+            if self._iter_error is not None:
+                raise self._iter_error
+            if self._hold_until_stop and self.stop_event is not None:
+                # Stay live until the controller signals stop, so a caller can
+                # observe the capture running mid-flight.
+                self.stop_event.wait()
+            raise StopIteration
+        event = self._events[self._pos]
+        self._pos += 1
+        return event
+
+
+def _install_source(monkeypatch: pytest.MonkeyPatch, source: _FakeSource) -> None:
+    """Replace ``sniffer.UsbmonSource`` with a factory returning ``source``."""
+
+    def _factory(*, bus_number: int, stop_event: Event) -> _FakeSource:
+        source.stop_event = stop_event
+        return source
+
+    monkeypatch.setattr(sniffer, "UsbmonSource", _factory)
+
+
+def _read_epbs(path: Path) -> list[EnhancedPacketBlock]:
+    with path.open("rb") as fp:
+        return [b for b in PcapNgReader(fp) if isinstance(b, EnhancedPacketBlock)]
+
+
+# ---------------------------------------------------------------------------
+# capture() — filtering and stats
+# ---------------------------------------------------------------------------
+
+
+def test_device_filter_counts_seen_vs_matched(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    events = [
+        (_header(devnum=5), b"\x01"),
+        (_header(devnum=9), b"\x02"),  # different device
+        (_header(devnum=5), b"\x03"),
+    ]
+    _install_source(monkeypatch, _FakeSource(events))
+    out = tmp_path / "cap.pcapng"
+
+    stats = capture(bus=3, device=5, output_path=out, stop_event=Event())
+
+    assert stats.seen == 3
+    assert stats.matched == 2
+    payloads = [epb.packet_data[64:] for epb in _read_epbs(out)]
+    assert payloads == [b"\x01", b"\x03"]
+
+
+def test_bus_only_mode_matches_everything(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    events = [(_header(devnum=d), bytes([d])) for d in (5, 9, 0)]
+    _install_source(monkeypatch, _FakeSource(events))
+    out = tmp_path / "cap.pcapng"
+
+    stats = capture(bus=3, device=None, output_path=out, stop_event=Event())
+
+    assert stats.matched == stats.seen == 3
+
+
+def test_device_zero_is_not_a_wildcard(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # device=0 must match only address-0 events, not "everything".
+    events = [(_header(devnum=0), b"\xa0"), (_header(devnum=1), b"\xa1")]
+    _install_source(monkeypatch, _FakeSource(events))
+    out = tmp_path / "cap.pcapng"
+
+    stats = capture(bus=3, device=0, output_path=out, stop_event=Event())
+
+    assert stats.seen == 2
+    assert stats.matched == 1
+
+
+def test_timestamp_is_derived_from_header(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    events = [(_header(devnum=0, ts_sec=1234, ts_usec=567), b"\x00")]
+    _install_source(monkeypatch, _FakeSource(events))
+    out = tmp_path / "cap.pcapng"
+
+    capture(bus=3, device=None, output_path=out, stop_event=Event())
+
+    (epb,) = _read_epbs(out)
+    expected = 1234 * 1_000_000 + 567
+    assert (epb.timestamp_high << 32) | epb.timestamp_low == expected
+
+
+def test_output_bytes_matches_file_size(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install_source(monkeypatch, _FakeSource([(_header(), b"\x01\x02")]))
+    out = tmp_path / "cap.pcapng"
+
+    stats = capture(bus=3, device=None, output_path=out, stop_event=Event())
+
+    assert stats.output_bytes == out.stat().st_size
+
+
+def test_existing_output_path_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install_source(monkeypatch, _FakeSource([]))
+    out = tmp_path / "cap.pcapng"
+    out.write_bytes(b"")  # already exists -> "xb" open fails
+    with pytest.raises(FileExistsError):
+        capture(bus=3, device=None, output_path=out, stop_event=Event())
+
+
+def test_ready_event_is_set_once_live(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install_source(monkeypatch, _FakeSource([]))
+    ready = Event()
+    capture(bus=3, device=None, output_path=tmp_path / "c.pcapng", stop_event=Event(), ready_event=ready)
+    assert ready.is_set()
+
+
+def test_progress_callback_fires_on_matched_and_filtered(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Force every event past the throttle by advancing a fake clock a full
+    # second per tick.
+    ticks = iter(range(0, 1000))
+    monkeypatch.setattr(sniffer.time, "monotonic", lambda: float(next(ticks)))
+
+    events = [(_header(devnum=5), b"\x01"), (_header(devnum=9), b"\x02")]  # one matched, one filtered
+    _install_source(monkeypatch, _FakeSource(events))
+
+    calls: list[tuple[int, int]] = []
+    capture(
+        bus=3,
+        device=5,
+        output_path=tmp_path / "c.pcapng",
+        stop_event=Event(),
+        on_progress=lambda s: calls.append((s.seen, s.matched)),
+    )
+    assert (1, 1) in calls  # matched branch
+    assert (2, 1) in calls  # filtered branch: seen climbs, matched stuck
+
+
+# ---------------------------------------------------------------------------
+# CaptureController — lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_controller_start_then_stop_returns_stats(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install_source(monkeypatch, _FakeSource([(_header(), b"\x01")]))
+    controller = CaptureController()
+    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+    stats = controller.stop()
+    assert isinstance(stats, CaptureStats)
+
+
+def test_controller_double_start_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install_source(monkeypatch, _FakeSource([]))
+    controller = CaptureController()
+    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+    with pytest.raises(CaptureStateError):
+        controller.start(bus=3, device=None, output_path=tmp_path / "d.pcapng")
+    controller.stop()
+
+
+def test_controller_stop_before_start_raises() -> None:
+    with pytest.raises(CaptureStateError):
+        CaptureController().stop()
+
+
+def test_controller_startup_error_surfaces_from_start(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    source = _FakeSource([], enter_error=UsbmonPermissionError("denied"))
+    _install_source(monkeypatch, source)
+    controller = CaptureController()
+    with pytest.raises(UsbmonPermissionError):
+        controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+
+
+def test_controller_post_live_error_surfaces_from_stop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Goes live (ready set), then raises while iterating -> stop() re-raises.
+    source = _FakeSource([(_header(), b"\x01")], iter_error=RuntimeError("bus vanished"))
+    _install_source(monkeypatch, source)
+    controller = CaptureController()
+    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+    with pytest.raises(RuntimeError, match="bus vanished"):
+        controller.stop()
+
+
+def test_controller_start_times_out_when_never_live(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    gate = Event()  # never set -> __enter__ blocks forever
+    source = _FakeSource([], block_enter=gate)
+    _install_source(monkeypatch, source)
+    controller = CaptureController()
+    with pytest.raises(TimeoutError):
+        controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng", ready_timeout=0.15)
+    gate.set()  # let the daemon thread unwind
+    controller.stop()
+
+
+def test_is_running_reflects_lifecycle(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install_source(monkeypatch, _FakeSource([(_header(), b"\x01")], hold_until_stop=True))
+    controller = CaptureController()
+    assert controller.is_running is False
+    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+    assert controller.is_running is True
+    controller.stop()
+    assert controller.is_running is False

--- a/tests/unit/test_usbmon_source.py
+++ b/tests/unit/test_usbmon_source.py
@@ -1,0 +1,361 @@
+# pyright: reportPrivateUsage=false
+#
+# This is a deliberately *white-box* test module. usbmon_source's ABI-level
+# correctness (the ioctl request-number encoding, the mon_get_arg struct
+# layout, the fetch/filter loop) is not reachable through the public API, so
+# these tests reach into module-private helpers and instance internals on
+# purpose. reportPrivateUsage is disabled here and only here.
+"""Tests for the usbmon raw event source.
+
+The module talks to ``/dev/usbmonN`` via ``ioctl``, which needs Linux and
+real hardware. These tests avoid both by:
+
+* exercising the **pure** pieces directly (ioctl-number encoding, struct
+  size, bus enumeration, error messages), and
+* **mocking** ``os.open`` / ``select.poll`` / ``fcntl.ioctl`` so the
+  iteration and event-fetch logic can be driven deterministically.
+
+``fcntl`` is stubbed by ``tests/conftest.py`` on platforms that lack it,
+so this file imports and runs on Windows as well as Linux.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+from collections.abc import Callable, Iterator
+from threading import Event
+from types import SimpleNamespace
+
+import pytest
+
+from bsu_tool import usbmon_source
+from bsu_tool.usbmon_source import (
+    UsbmonBusNotAvailableError,
+    UsbmonIoctlError,
+    UsbmonPermissionError,
+    UsbmonSource,
+    _ioc,
+    _list_available_buses,
+    _MonGetArg,
+)
+
+_HEADER_SIZE = 64
+_FILLER = 0x40
+
+
+def _no_buses() -> list[int]:
+    """A ``_list_available_buses`` mock returning no buses."""
+    return []
+
+
+def _real_event_header(*, event_byte: int = ord("S"), len_cap: int = 0) -> bytes:
+    """Build a 64-byte usbmon header with the fields the source reads set."""
+    header = bytearray(_HEADER_SIZE)
+    header[8] = event_byte  # event-type byte
+    header[36:40] = len_cap.to_bytes(4, "little", signed=False)
+    return bytes(header)
+
+
+def _prime(src: UsbmonSource, header: bytes, payload: bytes = b"") -> None:
+    """Load ``header``/``payload`` into the source's ctypes buffers.
+
+    Mimics what the kernel does on a successful ``MON_IOCX_GETX``.
+    """
+    for i, value in enumerate(header):
+        src._hdr_buf[i] = value
+    for i, value in enumerate(payload):
+        src._data_buf[i] = value
+
+
+# ---------------------------------------------------------------------------
+# ioctl-number encoding / ABI
+# ---------------------------------------------------------------------------
+
+
+def test_mon_get_arg_is_24_bytes_on_64bit() -> None:
+    # Two 8-byte pointers + one 8-byte size_t. This size is baked into the
+    # ioctl request number, so a mismatch would silently corrupt captures.
+    assert ctypes.sizeof(_MonGetArg) == 24
+
+
+def test_ioc_encodes_known_request_number() -> None:
+    # _IOW(0x92, 10, 24): dir=write(1)<<30 | size=24<<16 | type=0x92<<8 | nr=10.
+    assert _ioc(direction=1, magic=0x92, nr=10, size=24) == 0x4018920A
+
+
+def test_mon_iocx_getx_matches_encoding() -> None:
+    assert usbmon_source._MON_IOCX_GETX == _ioc(direction=1, magic=0x92, nr=10, size=ctypes.sizeof(_MonGetArg))
+
+
+# ---------------------------------------------------------------------------
+# Bus enumeration
+# ---------------------------------------------------------------------------
+
+
+def test_list_available_buses_keeps_only_digit_suffixed_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    names = ("usbmon2", "usbmon0", "usbmon", "usbmonX", "sda", "usbmon10")
+    entries = [SimpleNamespace(name=n) for n in names]
+
+    def _iterdir(self: object) -> Iterator[SimpleNamespace]:
+        return iter(entries)
+
+    monkeypatch.setattr(usbmon_source.Path, "iterdir", _iterdir)
+    assert _list_available_buses() == [0, 2, 10]
+
+
+def test_list_available_buses_empty_when_dev_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _iterdir(self: object) -> Iterator[SimpleNamespace]:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(usbmon_source.Path, "iterdir", _iterdir)
+    assert _list_available_buses() == []
+
+
+def test_not_available_message_lists_buses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(usbmon_source, "_list_available_buses", lambda: [0, 1])
+    src = UsbmonSource(bus_number=7, stop_event=Event())
+    msg = src._not_available_message()
+    assert "bus 7 not available" in msg
+    assert "Available buses: 0, 1" in msg
+
+
+def test_not_available_message_hints_module_when_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(usbmon_source, "_list_available_buses", _no_buses)
+    src = UsbmonSource(bus_number=7, stop_event=Event())
+    assert "usbmon module loaded" in src._not_available_message()
+
+
+# ---------------------------------------------------------------------------
+# Context-manager open errors
+# ---------------------------------------------------------------------------
+
+
+def test_enter_maps_missing_node_to_bus_not_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(usbmon_source, "_list_available_buses", _no_buses)
+
+    def _open(path: str, flags: int) -> int:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(usbmon_source.os, "open", _open)
+    with pytest.raises(UsbmonBusNotAvailableError):
+        UsbmonSource(bus_number=3, stop_event=Event()).__enter__()
+
+
+def test_enter_maps_permission_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _open(path: str, flags: int) -> int:
+        raise PermissionError
+
+    monkeypatch.setattr(usbmon_source.os, "open", _open)
+    with pytest.raises(UsbmonPermissionError):
+        UsbmonSource(bus_number=3, stop_event=Event()).__enter__()
+
+
+# ---------------------------------------------------------------------------
+# Fake poller for iteration tests
+# ---------------------------------------------------------------------------
+
+
+class _FakePoller:
+    """Scripted stand-in for ``select.poll``.
+
+    ``poll`` pops and returns the next value from ``responses``; when
+    exhausted it returns ``[]`` (a timeout). Each ``poll`` call also runs an
+    optional side effect, letting a test set the stop event mid-wait.
+    """
+
+    def __init__(
+        self,
+        responses: list[list[tuple[int, int]]],
+        side_effect: Callable[[], None] | None = None,
+    ) -> None:
+        self._responses = responses
+        self._side_effect = side_effect
+        self.registered: list[int] = []
+
+    def register(self, fd: int, mask: int) -> None:
+        self.registered.append(fd)
+
+    def poll(self, timeout: int) -> list[tuple[int, int]]:
+        if self._side_effect is not None:
+            self._side_effect()
+        return self._responses.pop(0) if self._responses else []
+
+
+def _make_entered(
+    monkeypatch: pytest.MonkeyPatch,
+    stop: Event,
+    poller: _FakePoller,
+) -> UsbmonSource:
+    """Enter a source with ``os.open``/``select.poll`` mocked out."""
+
+    def _open(path: str, flags: int) -> int:
+        return 7
+
+    monkeypatch.setattr(usbmon_source.os, "open", _open)
+    monkeypatch.setattr(usbmon_source.select, "poll", lambda: poller, raising=False)
+    monkeypatch.setattr(usbmon_source.select, "POLLIN", 1, raising=False)
+    src = UsbmonSource(bus_number=3, stop_event=stop)
+    return src.__enter__()
+
+
+# ---------------------------------------------------------------------------
+# Iteration
+# ---------------------------------------------------------------------------
+
+
+def test_next_outside_context_manager_raises() -> None:
+    src = UsbmonSource(bus_number=3, stop_event=Event())
+    with pytest.raises(RuntimeError, match="context manager"):
+        next(src)
+
+
+def test_stop_event_already_set_stops_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    stop = Event()
+    stop.set()
+    src = _make_entered(monkeypatch, stop, _FakePoller([]))
+    with pytest.raises(StopIteration):
+        next(src)
+
+
+def test_timeout_then_stop_ends_iteration(monkeypatch: pytest.MonkeyPatch) -> None:
+    stop = Event()
+    # First poll() returns a timeout and arms the stop flag; next loop stops.
+    poller = _FakePoller([[]], side_effect=stop.set)
+    src = _make_entered(monkeypatch, stop, poller)
+    with pytest.raises(StopIteration):
+        next(src)
+
+
+def test_interrupted_poll_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    stop = Event()
+    state = {"raised": False}
+
+    def side_effect() -> None:
+        if not state["raised"]:
+            state["raised"] = True
+            raise InterruptedError
+        stop.set()
+
+    poller = _FakePoller([], side_effect=side_effect)
+    src = _make_entered(monkeypatch, stop, poller)
+    # InterruptedError -> continue; second loop sets stop -> StopIteration.
+    with pytest.raises(StopIteration):
+        next(src)
+
+
+def test_next_returns_fetched_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    stop = Event()
+    poller = _FakePoller([[(7, 1)]])
+    src = _make_entered(monkeypatch, stop, poller)
+
+    header = _real_event_header(len_cap=2)
+    payload = b"\x01\x02"
+
+    def _ioctl(fd: int, request: int, arg: _MonGetArg) -> int:
+        _prime(src, header, payload)
+        return 0
+
+    monkeypatch.setattr(usbmon_source.fcntl, "ioctl", _ioctl)
+    hdr, data = next(src)
+    assert hdr == header
+    assert data == payload
+
+
+def test_exit_closes_and_clears_fd(monkeypatch: pytest.MonkeyPatch) -> None:
+    closed: list[int] = []
+
+    def _open(path: str, flags: int) -> int:
+        return 7
+
+    def _close(fd: int) -> None:
+        closed.append(fd)
+
+    monkeypatch.setattr(usbmon_source.os, "open", _open)
+    monkeypatch.setattr(usbmon_source.select, "poll", lambda: _FakePoller([]), raising=False)
+    monkeypatch.setattr(usbmon_source.select, "POLLIN", 1, raising=False)
+    monkeypatch.setattr(usbmon_source.os, "close", _close)
+
+    src = UsbmonSource(bus_number=3, stop_event=Event())
+    src.__enter__()
+    src.__exit__(None, None, None)
+    assert closed == [7]
+    # A second exit must not double-close.
+    src.__exit__(None, None, None)
+    assert closed == [7]
+
+
+# ---------------------------------------------------------------------------
+# _fetch_event
+# ---------------------------------------------------------------------------
+
+
+def _ioctl_ok(fd: int, request: int, arg: _MonGetArg) -> int:
+    """A ``fcntl.ioctl`` mock that succeeds without touching the buffers."""
+    return 0
+
+
+def test_fetch_event_drops_filler(monkeypatch: pytest.MonkeyPatch) -> None:
+    src = UsbmonSource(bus_number=3, stop_event=Event())
+    src._fd = 9
+    monkeypatch.setattr(usbmon_source.fcntl, "ioctl", _ioctl_ok)
+    _prime(src, _real_event_header(event_byte=_FILLER))
+    assert src._fetch_event() is None
+
+
+def test_fetch_event_slices_data_to_len_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    src = UsbmonSource(bus_number=3, stop_event=Event())
+    src._fd = 9
+    # Prime six data bytes; only the first four are the real payload. The
+    # trailing two must never appear in the result (stale-tail guard).
+    monkeypatch.setattr(usbmon_source.fcntl, "ioctl", _ioctl_ok)
+    _prime(src, _real_event_header(len_cap=4), b"\xaa\xbb\xcc\xdd\xee\xff")
+    result = src._fetch_event()
+    assert result is not None
+    _hdr, data = result
+    assert data == b"\xaa\xbb\xcc\xdd"
+
+
+def test_fetch_event_clamps_len_cap_to_buffer(monkeypatch: pytest.MonkeyPatch) -> None:
+    src = UsbmonSource(bus_number=3, stop_event=Event())
+    src._fd = 9
+    monkeypatch.setattr(usbmon_source.fcntl, "ioctl", _ioctl_ok)
+    _prime(src, _real_event_header(len_cap=0xFFFFFFFF))  # absurdly large
+    result = src._fetch_event()
+    assert result is not None
+    _hdr, data = result
+    assert len(data) == usbmon_source._DATA_BUFFER_SIZE
+
+
+def test_fetch_event_returns_none_on_interrupted(monkeypatch: pytest.MonkeyPatch) -> None:
+    src = UsbmonSource(bus_number=3, stop_event=Event())
+    src._fd = 9
+
+    def _ioctl(fd: int, request: int, arg: _MonGetArg) -> int:
+        raise InterruptedError
+
+    monkeypatch.setattr(usbmon_source.fcntl, "ioctl", _ioctl)
+    assert src._fetch_event() is None
+
+
+def test_fetch_event_returns_none_on_eintr_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    src = UsbmonSource(bus_number=3, stop_event=Event())
+    src._fd = 9
+
+    def _ioctl(fd: int, request: int, arg: _MonGetArg) -> int:
+        raise OSError(errno.EINTR, "interrupted")
+
+    monkeypatch.setattr(usbmon_source.fcntl, "ioctl", _ioctl)
+    assert src._fetch_event() is None
+
+
+def test_fetch_event_raises_on_other_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    src = UsbmonSource(bus_number=3, stop_event=Event())
+    src._fd = 9
+
+    def _ioctl(fd: int, request: int, arg: _MonGetArg) -> int:
+        raise OSError(errno.ENODEV, "no such device")
+
+    monkeypatch.setattr(usbmon_source.fcntl, "ioctl", _ioctl)
+    with pytest.raises(UsbmonIoctlError, match="MON_IOCX_GETX failed"):
+        src._fetch_event()


### PR DESCRIPTION
closes #50 

## What does this PR do?

Adds live USB capture on Linux via a new `sniff` subcommand. It reads raw events straight from `/dev/usbmonN`, filters by device number, and writes them to a pcap-ng file that the existing `parse` command can decode.

**New modules:**

- `usbmon_source.py` — reads raw events from `/dev/usbmonN` (Linux-only; `fcntl`/`ioctl` based).
- `pcapng_writer.py` — writes Enhanced Packet Blocks with `LINKTYPE_USB_LINUX_MMAPPED`.
- `sniffer.py` — orchestrates source → writer, filtering by device and tracking stats. `capture()` takes everything by argument (no globals/signals/printing) so the M2 MCP server can drive it directly; `CaptureController` runs it on a daemon thread for interactive start/stop.
- `sniff_command.py` — CLI handler: Ctrl+C to stop, in-place progress counter, and a final stats summary.

The `sniff` import is lazy in `__main__.py` so `fcntl` stays off the import path for `parse`/`mcp` on non-Linux machines. `pyrightconfig.json` now pins `pythonPlatform: Linux` so strict type checking resolves the Linux-only stdlib.

## How was it tested?

- `ruff check .`, `ruff format .`, and `pyright` pass clean.
- **Unit tests** for `pcapng_writer`, `usbmon_source`, `sniffer`, and `sniff_command` — writer/reader byte-layout round-trips, mocked `ioctl`/`poll` paths, device-filter and stats logic, and the CLI's error→exit-code mapping. A `conftest.py` `fcntl` stub lets these run on non-Linux dev machines too.
- **Integration test** replaying the Goodix capture through `sniffer → writer → reader → urb_decoder`, asserting byte-identical packet data, preserved timestamps, and identical decoded URB records.
- **Live capture on Linux**, e.g. `bsu-tool sniff --bus N --device M out.pcapng` against Goodix fingerprint reader, then `bsu-tool parse out.pcapng` to confirm the file decodes.


## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR
