### PR TITLE
feat(decoder): decode interrupt transfer

### DIFF
--- a/bsu_tool/mcp/tools/packets.py
+++ b/bsu_tool/mcp/tools/packets.py
@@ -38,7 +38,7 @@ def register(mcp: FastMCP, session: Session) -> None:
         offset: int = 0,
         limit: int = DEFAULT_LIMIT,
     ) -> GetPacketsResult:
-        """Retrieve decoded Control and Bulk URB packets from the active capture.
+        """Retrieve decoded Control, Bulk, and Interrupt URB packets from the active capture.
 
         Filters compose — a packet must satisfy all that are given. Two need
         explaining beyond their schema:

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -44,7 +44,7 @@ _DEVICE_DESCRIPTOR_TYPE: Final[int] = 0x01
 _STRING_DESCRIPTOR_TYPE: Final[int] = 0x03
 _ENDPOINT_IN_FLAG: Final[int] = 0x80
 _ENDPOINT_NUMBER_MASK: Final[int] = 0x0F
-_TRANSFER_TYPE_ORDER: Final[tuple[TransferType, ...]] = ("control", "bulk")
+_TRANSFER_TYPE_ORDER: Final[tuple[TransferType, ...]] = ("control", "bulk", "interrupt")
 _DATA_PREVIEW_BYTES: Final[int] = 32
 
 
@@ -180,8 +180,8 @@ class Session:
         """Return decoded URB packets from the active capture, filtered in place.
 
         Every keyword narrows the result independently; ``None`` disables that
-        criterion. Only Control and Bulk packets exist in the decoded stream —
-        Interrupt and Isochronous records were dropped at load time.
+        criterion. Control, Bulk, and Interrupt packets exist in the decoded
+        stream — only Isochronous records are dropped at load time.
 
         Args:
             device_id: Restrict to one device by its ``dev_bbb_ddd`` id.
@@ -190,7 +190,7 @@ class Session:
                 accepted — only its endpoint number (low nibble) is used, the
                 direction bit is ignored. Use ``direction`` to select IN or OUT.
             direction: Restrict to ``"in"`` or ``"out"`` transfers.
-            transfer_type: Restrict to ``"control"`` or ``"bulk"`` transfers.
+            transfer_type: Restrict to ``"control"``, ``"bulk"``, or ``"interrupt"`` transfers.
             event_type: Restrict to ``"submission"``, ``"completion"``, or ``"error"``.
 
         Returns:

--- a/bsu_tool/urb_decoder.py
+++ b/bsu_tool/urb_decoder.py
@@ -15,13 +15,11 @@ Two operations are exposed:
   :class:`UrbRecord` events in capture order and yields
   :class:`UrbTransaction` objects.
 
-Scope (Milestone 1):
+Scope:
 
-* Control and Bulk transfers are decoded.
-* Interrupt transfers are scheduled for Milestone 2 and intentionally
-  raise :class:`UnsupportedTransferTypeError`.
+* Control, Bulk, and Interrupt transfers are decoded.
 * Isochronous transfers are out of scope for this project entirely and
-  also raise :class:`UnsupportedTransferTypeError`.
+  raise :class:`UnsupportedTransferTypeError`.
 
 64-byte usbmon header layout (LINKTYPE_USB_LINUX_MMAPPED = 220):
 
@@ -67,7 +65,7 @@ from typing import Final, Literal
 # --- Public type aliases ---------------------------------------------------
 
 EventType = Literal["submission", "completion", "error"]
-TransferType = Literal["control", "bulk"]
+TransferType = Literal["control", "bulk", "interrupt"]
 Direction = Literal["in", "out"]
 
 # --- Link-type constants ---------------------------------------------------
@@ -147,10 +145,10 @@ class MalformedUsbmonHeaderError(UrbDecodeError):
 class UnsupportedTransferTypeError(UrbDecodeError):
     """Raised when a URB's transfer type is recognized but out of scope.
 
-    Currently raised for Interrupt (scheduled for Milestone 2) and
-    Isochronous (out of scope for this project). The decoder distinguishes
-    "I know what this is but won't decode it" from "I don't recognize
-    this byte at all" — the latter raises :class:`MalformedUsbmonHeaderError`.
+    Currently raised for Isochronous transfers (out of scope for this
+    project). The decoder distinguishes "I know what this is but won't
+    decode it" from "I don't recognize this byte at all" — the latter
+    raises :class:`MalformedUsbmonHeaderError`.
     """
 
 
@@ -218,8 +216,7 @@ def decode_urb(packet_data: bytes, link_type: int) -> UrbRecord:
         shorter than the declared header size, or the header contains
         an unrecognized event-type or transfer-type byte.
     UnsupportedTransferTypeError
-        The header declares an Interrupt transfer (Milestone 2) or an
-        Isochronous transfer (out of scope).
+        The header declares an Isochronous transfer (out of scope).
     """
     header_size = _header_size_for_link_type(link_type)
     if len(packet_data) < header_size:
@@ -303,18 +300,17 @@ def _decode_event_type(byte: int) -> EventType:
 def _decode_transfer_type(byte: int) -> TransferType:
     """Project a raw transfer-type byte into a typed :data:`TransferType`.
 
-    Raises :class:`UnsupportedTransferTypeError` for Interrupt and
-    Isochronous (recognized but out of scope), and
-    :class:`MalformedUsbmonHeaderError` for any other byte value.
+    Decodes Control, Bulk, and Interrupt. Raises
+    :class:`UnsupportedTransferTypeError` for Isochronous (recognized but
+    out of scope), and :class:`MalformedUsbmonHeaderError` for any other
+    byte value.
     """
     if byte == _XFER_CONTROL:
         return "control"
     if byte == _XFER_BULK:
         return "bulk"
     if byte == _XFER_INTERRUPT:
-        raise UnsupportedTransferTypeError(
-            "interrupt transfers are scheduled for Milestone 2 and are not yet supported"
-        )
+        return "interrupt"
     if byte == _XFER_ISOCHRONOUS:
         raise UnsupportedTransferTypeError("isochronous transfers are out of scope for this project")
     raise MalformedUsbmonHeaderError(f"unknown usbmon transfer-type byte: {byte:#04x}")

--- a/tests/int/test_mcp_get_packets_goodix.py
+++ b/tests/int/test_mcp_get_packets_goodix.py
@@ -22,12 +22,12 @@ def test_get_packets_goodix_capture() -> None:
     capture = session.load(_CAPTURE)
 
     everything = session.get_packets()
-    assert everything.total_count == len(capture.records) == 249
-    assert len(everything.matches) == 249
+    assert everything.total_count == len(capture.records) == 253
+    assert len(everything.matches) == 253
     assert [packet.index for packet in everything.matches[:3]] == [0, 1, 2]
 
     device = session.get_packets(device_id="dev_001_011")
-    assert device.total_count == 249
+    assert device.total_count == 253
     assert 0 < len(device.matches) < everything.total_count
     assert {packet.device_id for packet in device.matches} == {"dev_001_011"}
 
@@ -57,7 +57,7 @@ def test_get_packets_tool_assembles_paginated_result() -> None:
     assert isinstance(block, TextContent)
     payload = json.loads(block.text)
 
-    assert payload["total_count"] == 249
+    assert payload["total_count"] == 253
     assert 0 < payload["match_count"] < payload["total_count"]
     assert payload["returned_count"] == 5
     assert payload["limit"] == 5

--- a/tests/int/test_mcp_list_devices_goodix.py
+++ b/tests/int/test_mcp_list_devices_goodix.py
@@ -19,9 +19,10 @@ def test_list_devices_goodix_capture() -> None:
     devices = session.list_devices()
 
     assert capture.metadata.packet_count == 253
-    assert len(capture.records) == 249
+    assert len(capture.records) == 253
     assert [device.device_id for device in devices] == ["dev_001_000", "dev_001_001", "dev_001_011"]
-    assert [device.packet_count for device in devices] == [8, 74, 167]
+    assert [device.packet_count for device in devices] == [8, 78, 167]
+    assert devices[1].transfer_types_seen == ("control", "interrupt")
     assert [ep.address for ep in devices[2].endpoints_seen] == ["0x00", "0x01", "0x83"]
     assert devices[2].transfer_types_seen == ("control", "bulk")
     assert devices[2].vendor_id == "0x27c6"

--- a/tests/int/test_sniffer_writer_roundtrip_goodix.py
+++ b/tests/int/test_sniffer_writer_roundtrip_goodix.py
@@ -196,5 +196,5 @@ def test_reemitted_capture_decodes_identically(
     original_records = _decode_all(original_epbs, link_type)
     reemitted_records = _decode_all(reemitted_epbs, link_type)
 
-    assert len(reemitted_records) == 249  # 253 EPBs minus 4 out-of-scope interrupts
+    assert len(reemitted_records) == 253  # all EPBs decode; only isochronous is out of scope
     assert reemitted_records == original_records

--- a/tests/int/test_urb_decode_goodix.py
+++ b/tests/int/test_urb_decode_goodix.py
@@ -2,30 +2,28 @@
 
 These tests exercise the full decode pipeline against the sanitized
 goodix_enum_and_enroll capture file.  Unlike the unit tests, which build
-pcap-ng blocks by hand, these tests use a real capture containing control
-and bulk transfers (plus 4 interrupt packets that are skipped as
-out-of-scope for Milestone 1), validating that the two modules compose
+pcap-ng blocks by hand, these tests use a real capture containing control,
+bulk, and interrupt transfers, validating that the two modules compose
 correctly end-to-end.
 
 Capture profile (goodix_enum_and_enroll_sanitized.pcapng):
-    253 EPBs total
-     -4 interrupt (hub port-change notifications, skipped)
-    ---
-    249 decoded URB records
+    253 EPBs total = 253 decoded URB records
+    (no isochronous transfers — the only remaining out-of-scope type)
 
-    Transfer types:   142 control, 107 bulk
-    Event types:      125 submissions, 124 completions
+    Transfer types:   142 control, 107 bulk, 4 interrupt
+    Event types:      127 submissions, 126 completions
     Bus numbers:      {1}
     Device numbers:   {0, 1, 11}
         device  0 — default address (pre-SET_ADDRESS enumeration)
         device  1 — USB hub (port management and interrupt)
         device 11 — Goodix MOC fingerprint reader (Goodix protocol)
 
-    Transactions:     125 total
-        124 fully paired
-          1 orphan submission (bulk IN read queued on EP 0x83 in-flight
-                               at capture end — expected at capture boundaries)
-          0 orphan completions
+    Transactions:     128 total
+        125 fully paired
+          2 orphan submissions (in-flight at capture end — a bulk IN read on
+                                EP 0x83 and an interrupt poll)
+          1 orphan completion  (interrupt completion whose submission was
+                                queued before the capture began)
 """
 
 from __future__ import annotations
@@ -69,7 +67,7 @@ def pipeline() -> tuple[int, list[EnhancedPacketBlock]]:
 
 @pytest.fixture(scope="module")
 def urb_records(pipeline: tuple[int, list[EnhancedPacketBlock]]) -> list[UrbRecord]:
-    """Decode supported EPBs; silently skip interrupt/isochronous transfers."""
+    """Decode supported EPBs; silently skip out-of-scope isochronous transfers."""
     link_type, epbs = pipeline
     records: list[UrbRecord] = []
     for epb in epbs:
@@ -104,7 +102,7 @@ def test_epbs_decode_without_malformed_error(
         try:
             decode_urb(epb.packet_data, link_type)
         except UnsupportedTransferTypeError:
-            pass  # interrupt -- recognized but out of scope for Milestone 1
+            pass  # isochronous -- recognized but out of scope for this project
 
 
 def test_link_type(pipeline: tuple[int, list[EnhancedPacketBlock]]) -> None:
@@ -127,30 +125,31 @@ def test_epb_count(pipeline: tuple[int, list[EnhancedPacketBlock]]) -> None:
 
 
 def test_record_count(urb_records: list[UrbRecord]) -> None:
-    """253 EPBs minus 4 interrupt yields 249 decoded URB records."""
-    assert len(urb_records) == 249
+    """All 253 EPBs decode into URB records (no isochronous to skip)."""
+    assert len(urb_records) == 253
 
 
 def test_transfer_type_counts(urb_records: list[UrbRecord]) -> None:
-    """The decoded records contain 142 control and 107 bulk transfers."""
+    """The decoded records contain 142 control, 107 bulk, and 4 interrupt transfers."""
     ctrl = sum(1 for r in urb_records if r.transfer_type == "control")
     bulk = sum(1 for r in urb_records if r.transfer_type == "bulk")
+    interrupt = sum(1 for r in urb_records if r.transfer_type == "interrupt")
     assert ctrl == 142
     assert bulk == 107
+    assert interrupt == 4
 
 
 def test_submission_completion_counts(urb_records: list[UrbRecord]) -> None:
-    """The capture contains 125 submissions and 124 completions.
+    """The capture contains 127 submissions and 126 completions.
 
-    The single extra submission is a bulk IN read queued on EP 0x83 that
-    was still in-flight when the capture ended (no matching completion
-    packet).  This is normal at capture boundaries and exercises the
-    orphan-submission path in pair_urbs.
+    The submission/completion imbalance comes from transactions straddling
+    the capture boundaries (see test_transaction_pairing_stats), which
+    exercise the orphan-submission and orphan-completion paths in pair_urbs.
     """
     submissions = [r for r in urb_records if r.event_type == "submission"]
     completions = [r for r in urb_records if r.event_type == "completion"]
-    assert len(submissions) == 125
-    assert len(completions) == 124
+    assert len(submissions) == 127
+    assert len(completions) == 126
 
 
 def test_devices_on_single_bus(urb_records: list[UrbRecord]) -> None:
@@ -215,22 +214,23 @@ def test_bulk_records_have_no_setup(urb_records: list[UrbRecord]) -> None:
 
 
 def test_transaction_count(urb_transactions: list[UrbTransaction]) -> None:
-    """pair_urbs must produce exactly 125 transactions from the 249 records."""
-    assert len(urb_transactions) == 125
+    """pair_urbs must produce exactly 128 transactions from the 253 records."""
+    assert len(urb_transactions) == 128
 
 
 def test_transaction_pairing_stats(urb_transactions: list[UrbTransaction]) -> None:
-    """124 fully-paired transactions; 1 orphan submission; 0 orphan completions.
+    """125 fully-paired transactions; 2 orphan submissions; 1 orphan completion.
 
-    The single orphan submission is the bulk IN read in-flight at capture
-    end (see test_submission_completion_counts for details).
+    The orphans are transactions straddling the capture boundaries: a bulk IN
+    read and an interrupt poll still in-flight at capture end, plus an
+    interrupt completion whose submission preceded the capture start.
     """
     paired = sum(1 for t in urb_transactions if t.submission and t.completion)
     orphan_sub = sum(1 for t in urb_transactions if t.submission and not t.completion)
     orphan_cmp = sum(1 for t in urb_transactions if not t.submission and t.completion)
-    assert paired == 124
-    assert orphan_sub == 1
-    assert orphan_cmp == 0
+    assert paired == 125
+    assert orphan_sub == 2
+    assert orphan_cmp == 1
 
 
 def test_paired_urb_ids_match(urb_transactions: list[UrbTransaction]) -> None:

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -15,6 +15,7 @@ _COMPLETION = 0x43
 _CONTROL = 2
 _BULK = 3
 _INTERRUPT = 1
+_ISOCHRONOUS = 0
 
 
 def _pad4(data: bytes) -> bytes:
@@ -228,9 +229,13 @@ def test_load_rejects_packet_with_unknown_interface(tmp_path: Path) -> None:
 
 
 def test_load_skips_unsupported_transfers(tmp_path: Path) -> None:
-    """Session.load keeps metadata while skipping unsupported decoded records."""
-    path = tmp_path / "interrupt.pcapng"
-    path.write_bytes(_capture_bytes((_usbmon_packet(transfer_type=_INTERRUPT),)))
+    """Session.load keeps metadata while skipping unsupported decoded records.
+
+    Isochronous is the only transfer type still out of scope; interrupt is
+    now decoded like control and bulk.
+    """
+    path = tmp_path / "isochronous.pcapng"
+    path.write_bytes(_capture_bytes((_usbmon_packet(transfer_type=_ISOCHRONOUS),)))
 
     capture = Session().load(path)
 
@@ -241,12 +246,24 @@ def test_load_skips_unsupported_transfers(tmp_path: Path) -> None:
 
 def test_list_devices_returns_empty_for_unsupported_only_capture(tmp_path: Path) -> None:
     """list_devices returns an empty tuple when no packets decode into records."""
-    path = tmp_path / "interrupt-only.pcapng"
-    path.write_bytes(_capture_bytes((_usbmon_packet(transfer_type=_INTERRUPT),)))
+    path = tmp_path / "isochronous-only.pcapng"
+    path.write_bytes(_capture_bytes((_usbmon_packet(transfer_type=_ISOCHRONOUS),)))
     session = Session()
     session.load(path)
 
     assert session.list_devices() == ()
+
+
+def test_load_decodes_interrupt_transfers(tmp_path: Path) -> None:
+    """Interrupt transfers are now decoded into records like control and bulk."""
+    path = tmp_path / "interrupt.pcapng"
+    path.write_bytes(_capture_bytes((_usbmon_packet(transfer_type=_INTERRUPT, endpoint=0x81),)))
+
+    capture = Session().load(path)
+
+    assert capture.metadata.packet_count == 1
+    assert len(capture.records) == 1
+    assert capture.records[0].transfer_type == "interrupt"
 
 
 def test_list_devices_requires_loaded_capture() -> None:
@@ -440,8 +457,8 @@ def test_get_packets_endpoint_number_is_decimal(tmp_path: Path) -> None:
             session.get_packets(endpoint=bad)
 
 
-def test_get_packets_excludes_interrupt(tmp_path: Path) -> None:
-    """Interrupt packets never appear in the decoded record stream."""
+def test_get_packets_includes_interrupt(tmp_path: Path) -> None:
+    """Interrupt packets appear in the decoded record stream alongside bulk."""
     path = tmp_path / "interrupt.pcapng"
     path.write_bytes(
         _capture_bytes(
@@ -455,8 +472,8 @@ def test_get_packets_excludes_interrupt(tmp_path: Path) -> None:
     session.load(path)
 
     selection = session.get_packets()
-    assert selection.total_count == 1
-    assert selection.matches[0].transfer_type == "bulk"
+    assert selection.total_count == 2
+    assert [match.transfer_type for match in selection.matches] == ["bulk", "interrupt"]
 
 
 def test_add_marker_requires_loaded_capture() -> None:

--- a/tests/unit/test_urb_decoder.py
+++ b/tests/unit/test_urb_decoder.py
@@ -347,13 +347,13 @@ def test_captured_length_exceeds_available_data_off_by_one_raises() -> None:
         decode_urb(_packet(h, data=payload), LINKTYPE_USB_LINUX)
 
 
-# --- UnsupportedTransferTypeError tests --------------------------------------
+# --- Interrupt + UnsupportedTransferTypeError tests --------------------------
 
 
-def test_interrupt_transfer_raises() -> None:
+def test_interrupt_transfer_decodes() -> None:
     h = _hdr(xfer=_INTR)
-    with pytest.raises(UnsupportedTransferTypeError):
-        decode_urb(_packet(h), LINKTYPE_USB_LINUX)
+    rec = decode_urb(_packet(h), LINKTYPE_USB_LINUX)
+    assert rec.transfer_type == "interrupt"
 
 
 def test_isochronous_transfer_raises() -> None:


### PR DESCRIPTION
Closes #52 

## What does this PR do?

Decodes USB Interrupt transfers into `UrbRecord`s alongside Control and Bulk,
instead of raising `UnsupportedTransferTypeError`. Isochronous is now the only
out-of-scope transfer type. Updates the `TransferType` literal, session
transfer-type ordering, `get_packets`/MCP docstrings, and the goodix
integration fixtures for the 4 newly-decoded interrupt packets.

## How was it tested?

Ran locally on the sanitized goodix capture and the full suite:

- `pytest` — 125 passed (goodix capture now decodes all 253 EPBs, incl. 4 interrupt packets across control/interrupt pairing and orphan-at-boundary paths)
- `ruff check .` / `ruff format .` — clean
- `pyright` — 0 errors


## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR
