### PR TITLE
54/marker-mcp-tools

### DIFF
--- a/bsu_tool/mcp/tools/__init__.py
+++ b/bsu_tool/mcp/tools/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from bsu_tool.mcp.tools import capture, devices, packets
+from bsu_tool.mcp.tools import capture, devices, markers, packets
 from bsu_tool.session import Session
 
 
@@ -16,4 +16,5 @@ def register_all(mcp: FastMCP, session: Session) -> None:
     """Register every MCP tool group against the FastMCP instance."""
     capture.register(mcp, session)
     devices.register(mcp, session)
+    markers.register(mcp, session)
     packets.register(mcp, session)

--- a/bsu_tool/mcp/tools/markers.py
+++ b/bsu_tool/mcp/tools/markers.py
@@ -1,0 +1,48 @@
+"""Marker MCP tools.
+
+Markers tie analyst actions to points in the capture. The intended flow is
+bracket pairs: add one marker when an instruction is given ("press the button
+now") and another when the analyst reports done, then analyze the packets
+between the pair.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from bsu_tool.session import Marker, Session
+
+
+@dataclass(frozen=True, slots=True)
+class ListMarkersResult:
+    """All markers on the active capture."""
+
+    markers: tuple[Marker, ...]
+    count: int
+
+
+def register(mcp: FastMCP, session: Session) -> None:
+    """Register marker tools on the FastMCP instance."""
+
+    @mcp.tool()
+    def add_marker(  # pyright: ignore[reportUnusedFunction]
+        name: str,
+        packet_index: int,
+        note: str | None = None,
+    ) -> Marker:
+        """Add a named marker anchored to a decoded packet in the active capture.
+
+        The marker's timestamp is taken from the packet at ``packet_index`` —
+        the same ``index`` values get_packets reports. Names must be unique
+        within the capture; use suffixes like ``button-press-1-start`` /
+        ``button-press-1-end`` to bracket repeated trials of one action.
+        """
+        return session.add_marker(name=name, packet_index=packet_index, note=note)
+
+    @mcp.tool()
+    def list_markers() -> ListMarkersResult:  # pyright: ignore[reportUnusedFunction]
+        """List all markers on the active capture in the order they were added."""
+        markers = session.list_markers()
+        return ListMarkersResult(markers=markers, count=len(markers))

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -154,13 +154,36 @@ class Session:
         )
         return self.capture
 
-    def add_marker(self, name: str, timestamp: float, packet_index: int, note: str | None = None) -> Marker:
-        """Append a named marker to the loaded capture and return it."""
+    def add_marker(self, name: str, packet_index: int, note: str | None = None) -> Marker:
+        """Append a named marker anchored to a decoded packet and return it.
+
+        The marker's timestamp is taken from the decoded record at
+        ``packet_index`` (the same index space ``get_packets`` reports).
+
+        Raises:
+            RuntimeError: No capture has been loaded.
+            ValueError: ``name`` is empty or already used, or ``packet_index``
+                is outside the decoded record range.
+        """
         if self.capture is None:
             raise RuntimeError("No capture loaded. Call load() first.")
-        marker = Marker(name=name, timestamp=timestamp, packet_index=packet_index, note=note)
+        if not name:
+            raise ValueError("marker name must not be empty")
+        if any(marker.name == name for marker in self.capture.markers):
+            raise ValueError(f"marker name {name!r} already exists")
+        records = self.capture.records
+        if not 0 <= packet_index < len(records):
+            raise ValueError(f"packet_index {packet_index} out of range (0..{len(records) - 1})")
+        # Record lookup by index; swap onto the #53 packet store's get_packet() when it lands.
+        marker = Marker(name=name, timestamp=records[packet_index].timestamp, packet_index=packet_index, note=note)
         self.capture.markers.append(marker)
         return marker
+
+    def list_markers(self) -> tuple[Marker, ...]:
+        """Return all markers on the loaded capture in insertion order."""
+        if self.capture is None:
+            raise RuntimeError("No capture loaded. Call load() first.")
+        return tuple(self.capture.markers)
 
     def list_devices(self) -> tuple[DeviceSummary, ...]:
         """Return USB devices observed in the active capture."""

--- a/tests/int/test_mcp_markers_goodix.py
+++ b/tests/int/test_mcp_markers_goodix.py
@@ -1,0 +1,49 @@
+"""Integration tests for MCP marker tools on a real Goodix capture."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+from typing import Any, cast
+
+from mcp.types import TextContent
+
+from bsu_tool.mcp.server import build_server
+from bsu_tool.session import Session
+
+_CAPTURE = (
+    pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures" / "goodix_enum_and_enroll_sanitized.pcapng"
+)
+
+
+def test_marker_tools_bracket_pair_end_to_end() -> None:
+    """add_marker and list_markers round-trip a bracket pair through the MCP tools."""
+    session = Session()
+    capture = session.load(_CAPTURE)
+    server = build_server(session=session)
+
+    def call(tool: str, arguments: dict[str, object]) -> dict[str, Any]:
+        result = asyncio.run(server.call_tool(tool, arguments))
+        if isinstance(result, tuple):
+            # (content, structured) for tools with an output schema — a shape
+            # the SDK's declared return type omits, hence the cast.
+            return cast("dict[str, Any]", result[1])
+        assert not isinstance(result, dict)
+        block = result[0]
+        assert isinstance(block, TextContent)
+        payload: dict[str, Any] = json.loads(block.text)
+        return payload
+
+    added = call("add_marker", {"name": "enroll-1-start", "packet_index": 10, "note": "finger on"})
+    assert added["name"] == "enroll-1-start"
+    assert added["packet_index"] == 10
+    assert added["timestamp"] == capture.records[10].timestamp
+    call("add_marker", {"name": "enroll-1-end", "packet_index": 200})
+
+    listed = call("list_markers", {})
+    assert listed["count"] == 2
+    names = [marker["name"] for marker in listed["markers"]]
+    assert names == ["enroll-1-start", "enroll-1-end"]
+    assert listed["markers"][0]["note"] == "finger on"
+    assert listed["markers"][1]["note"] is None

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -71,6 +71,30 @@ def test_get_packets_rejects_invalid_pagination() -> None:
         asyncio.run(call_tool())
 
 
+def test_build_server_registers_marker_tools() -> None:
+    """build_server registers the Issue #54 add_marker and list_markers tools."""
+
+    async def tool_names() -> set[str]:
+        tools = await build_server().list_tools()
+        return {tool.name for tool in tools}
+
+    names = asyncio.run(tool_names())
+    assert "add_marker" in names
+    assert "list_markers" in names
+
+
+@pytest.mark.parametrize("tool", ["add_marker", "list_markers"])
+def test_marker_tools_without_capture_report_error(tool: str) -> None:
+    """Marker tools fail gracefully when no capture has been loaded."""
+
+    async def call_tool() -> None:
+        arguments = {"name": "x", "packet_index": 0} if tool == "add_marker" else {}
+        await build_server().call_tool(tool, arguments)
+
+    with pytest.raises(ToolError, match="No capture loaded"):
+        asyncio.run(call_tool())
+
+
 def test_get_packets_without_capture_reports_error() -> None:
     """get_packets fails gracefully when no capture has been loaded."""
 

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -480,15 +480,72 @@ def test_add_marker_requires_loaded_capture() -> None:
     """add_marker raises RuntimeError if no capture has been loaded."""
     session = Session()
     with pytest.raises(RuntimeError):
-        session.add_marker(name="x", timestamp=0.0, packet_index=0)
+        session.add_marker(name="x", packet_index=0)
 
 
 def test_add_marker_appends_to_capture(tmp_path: Path) -> None:
     """add_marker stores a Marker on the active capture and returns it."""
     session = Session()
     session.load(_write_capture(tmp_path))
-    marker = session.add_marker(name="press_button", timestamp=0.05, packet_index=1, note="hi")
+    marker = session.add_marker(name="press_button", packet_index=1, note="hi")
 
     assert isinstance(marker, Marker)
     assert session.capture is not None
     assert session.capture.markers == [marker]
+    assert marker.note == "hi"
+
+
+def test_add_marker_derives_timestamp_from_packet(tmp_path: Path) -> None:
+    """The marker's timestamp is the decoded record's timestamp at packet_index."""
+    session = Session()
+    capture = session.load(_write_capture(tmp_path))
+
+    marker = session.add_marker(name="m", packet_index=1)
+
+    assert marker.timestamp == capture.records[1].timestamp
+
+
+def test_add_marker_rejects_duplicate_name(tmp_path: Path) -> None:
+    """Marker names are unique per capture — duplicates raise ValueError."""
+    session = Session()
+    session.load(_write_capture(tmp_path))
+    session.add_marker(name="press", packet_index=0)
+
+    with pytest.raises(ValueError, match="'press' already exists"):
+        session.add_marker(name="press", packet_index=1)
+
+
+def test_add_marker_rejects_empty_name(tmp_path: Path) -> None:
+    """An empty marker name raises ValueError."""
+    session = Session()
+    session.load(_write_capture(tmp_path))
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        session.add_marker(name="", packet_index=0)
+
+
+@pytest.mark.parametrize("packet_index", [-1, 2, 100])
+def test_add_marker_rejects_out_of_range_index(tmp_path: Path, packet_index: int) -> None:
+    """packet_index must address a decoded record (capture has 2)."""
+    session = Session()
+    session.load(_write_capture(tmp_path))
+
+    with pytest.raises(ValueError, match="out of range"):
+        session.add_marker(name="m", packet_index=packet_index)
+
+
+def test_list_markers_requires_loaded_capture() -> None:
+    """list_markers raises RuntimeError if no capture has been loaded."""
+    with pytest.raises(RuntimeError):
+        Session().list_markers()
+
+
+def test_list_markers_returns_insertion_order(tmp_path: Path) -> None:
+    """list_markers returns () when empty, then markers in the order added."""
+    session = Session()
+    session.load(_write_capture(tmp_path))
+
+    assert session.list_markers() == ()
+    first = session.add_marker(name="a-start", packet_index=0)
+    second = session.add_marker(name="a-end", packet_index=1)
+    assert session.list_markers() == (first, second)


### PR DESCRIPTION
Expose the session marker system over MCP. add_marker anchors a named marker to a decoded packet index (same index space get_packets reports) and derives its timestamp from that record; names must be unique so bracket pairs around repeated trials stay unambiguous. list_markers returns markers in insertion order.

Session.add_marker no longer takes a caller-supplied timestamp and now rejects empty/duplicate names and out-of-range indexes. The index lookup is a single seam to swap onto the #53 packet store when it lands.

closes #54
