### PR TITLE
Add protocol hypothesis engine design spec

### DIFF
--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -18,7 +18,7 @@ objects already built by Milestone 1 and 2 infrastructure and writes results bac
 structured Python dataclasses that the MCP server can return to Claude.
 
 This is a spec-first issue. Implementation should start after the team reviews this
-document and resolves the open questions at the end.
+document. Earlier open questions are resolved in the Review Decisions at the end.
 
 ---
 
@@ -34,10 +34,10 @@ decoded — the engine does not re-read pcap-ng files.
 class Capture:
     source: Path
     metadata: CaptureMetadata
-    packets: tuple[CapturePacket, ...]   # raw pcap packets (not used by engine)
-    records: tuple[UrbRecord, ...]        # decoded URBs; may be fewer than packets
+    packets: tuple[CapturePacket, ...]  # raw pcap packets (not used by engine)
+    records: tuple[UrbRecord, ...]  # decoded URBs; may be fewer than packets
     transactions: tuple[UrbTransaction, ...]  # paired submission+completion URB pairs
-    markers: list[Marker]                 # analyst-placed named timestamps
+    markers: list[Marker]  # analyst-placed named timestamps
 ```
 
 Key fields per `UrbRecord`:
@@ -60,6 +60,11 @@ Key fields per `Marker`:
 - `packet_index` — index into `Capture.records` at time of marker placement
 - `note` — optional free-text annotation
 
+**Note on indices:** `records` is not one-per-packet. The decoder skips isochronous
+and malformed packets, so `len(records) <= len(packets)`. Analysis indices are
+positions in `records` and do **not** correspond to pcap frame numbers. Markers,
+`get_packet`, and `packets_between_markers` all index `records`.
+
 ### 1.2 Scope Restriction
 
 The engine operates only on:
@@ -71,8 +76,9 @@ Isochronous transfers are excluded at load time and never reach the engine.
 
 ### 1.3 Device Context Input
 
-The engine accepts a `DeviceContext` for each device under analysis. Required within the
-analyzers input to strengthen the protocol inference.
+The engine accepts a `DeviceContext` for each device under analysis. This is a
+required analyzer input, not an enrichment: protocol inference without knowing
+what the device is produces unanchored guesses.
 
 ```python
 @dataclass(frozen=True)
@@ -83,18 +89,17 @@ class DeviceContext:
     manufacturer: str | None
     product: str | None
     device_class: int | None
-    interfaces: tuple[InterfaceContext, ...] # for the class/subclass/protocol per interface
-    endpoints: tuple[EndpointContext, ...]   # address, direction, transfer type,
-                                             # wMaxPacketSize, bInterval
-                                             # for example: "CH340 USB-serial bridge",
-                                             # "binds kernel driver ch341:
-
-    known_properties: tuple[Str, ...]
+    interfaces: tuple[InterfaceContext, ...]  # class/subclass/protocol per interface
+    endpoints: tuple[EndpointContext, ...]  # address, direction, transfer type,
+    # wMaxPacketSize, bInterval
+    known_properties: tuple[str, ...]  # e.g. "CH340 USB-serial bridge",
+    # "binds kernel driver ch341"
 ```
 
-`DeviceContext` is built from decoded enumeration descriptors that our `Session.get_enumeration()` 
-already recovers. When a capture does not contain enumeration traffic, context is partial and the 
-engine must emit `analysis_note` saying so and naming which fields were unavailable.
+`DeviceContext` is built from decoded enumeration descriptors, which
+`Session.get_enumeration()` already recovers. When a capture does not contain
+enumeration traffic, context is partial and the engine must emit an
+`analysis_note` saying so and naming which fields were unavailable.
 
 ---
 
@@ -425,7 +430,7 @@ issue.
 ```python
 @dataclass(frozen=True)
 class ProtocolHypothesis:
-    device_id: str                          # e.g. "dev_001_003"
+    device_id: str  # e.g. "dev_001_003"
     command_patterns: tuple[CommandPattern, ...]
     observations: tuple[AnalysisObservation, ...]
     unsolicited_responses: tuple[UnsolicitedResponse, ...]
@@ -433,7 +438,7 @@ class ProtocolHypothesis:
     incomplete_transfers: tuple[IncompleteTransfer, ...]
     marker_correlations: tuple[MarkerCorrelation, ...]
     result_limits: ResultLimits
-    analysis_notes: tuple[str, ...]         # free-text warnings from the engine
+    analysis_notes: tuple[str, ...]  # free-text warnings from the engine
 ```
 
 ### 5.2 `ResultLimits`
@@ -461,15 +466,15 @@ the relevant `*_truncated` flag and include a short `truncation_note` in both
 ```python
 @dataclass(frozen=True)
 class CommandPattern:
-    pattern_id: str                         # e.g. "pattern_01"
+    pattern_id: str  # e.g. "pattern_01"
     occurrence_count: int
-    steps: tuple[PatternStep, ...]          # ordered, length 1..MAX_SEQUENCE_WINDOW
+    steps: tuple[PatternStep, ...]  # ordered, length 1..MAX_SEQUENCE_WINDOW
     response_timing: ResponseTimingStats | None
-    parent_pattern_id: str | None           # set only when retained as an optional sub-pattern
-    marker_correlation_id: str | None       # references MarkerCorrelation.correlation_id
-    first_occurrence_timestamp: float       # capture time of 1st occurence
-    first_packet_index: int                 # index into Capture.records
-    low_confidence: bool                    # should be True when occurence_count == 2
+    parent_pattern_id: str | None  # set only when retained as an optional sub-pattern
+    marker_correlation_id: str | None  # references MarkerCorrelation.correlation_id
+    first_occurrence_timestamp: float  # capture time of 1st occurence
+    first_packet_index: int  # index into Capture.records
+    low_confidence: bool  # should be True when occurence_count == 2
 ```
 
 ### 5.4 `PatternStep`
@@ -477,14 +482,14 @@ class CommandPattern:
 ```python
 @dataclass(frozen=True)
 class PatternStep:
-    step_index: int                         # 0-based position in the sequence
-    endpoint_number: int                    # bare endpoint number, 0-15
-    endpoint_address: str                   # display address, e.g. "0x01" or "0x81"
-    direction: Direction                    # "in" or "out"
-    transfer_type: TransferType             # "bulk" or "interrupt"
+    step_index: int  # 0-based position in the sequence
+    endpoint_number: int  # bare endpoint number, 0-15
+    endpoint_address: str  # display address, e.g. "0x01" or "0x81"
+    direction: Direction  # "in" or "out"
+    transfer_type: TransferType  # "bulk" or "interrupt"
     signature_mode: Literal["full", "prefix", "full_prefix"]
-    payload_signature: tuple[int | None, ...] # None = variable byte
-    observed_length_range: tuple[int, int]   # inclusive min/max len(data)
+    payload_signature: tuple[int | None, ...]  # None = variable byte
+    observed_length_range: tuple[int, int]  # inclusive min/max len(data)
     variable_byte_ranges: tuple[VariableByteRange, ...]
 ```
 
@@ -507,7 +512,7 @@ followed by an IN event that the pairing algorithm identifies as a likely respon
 ```python
 @dataclass(frozen=True)
 class AnalysisObservation:
-    observation_id: str                     # e.g. "observation_01"
+    observation_id: str  # e.g. "observation_01"
     reason: Literal["near_marker", "multi_step_exchange"]
     steps: tuple[PatternStep, ...]
     nearest_marker: str | None
@@ -524,7 +529,7 @@ class VariableByteRange:
     byte_index: int
     observed_min: int
     observed_max: int
-    observed_values: tuple[int, ...]        # all distinct values seen (capped at 32)
+    observed_values: tuple[int, ...]  # all distinct values seen (capped at 32)
 ```
 
 ### 5.8 `UnsolicitedResponse`
@@ -585,11 +590,11 @@ themselves sufficient evidence for `UnsolicitedResponse` or `UnansweredCommand`.
 ```python
 @dataclass(frozen=True)
 class MarkerCorrelation:
-    correlation_id: str                     # e.g. "marker_corr_01"
+    correlation_id: str  # e.g. "marker_corr_01"
     marker_name: str
-    pattern_ids: tuple[str, ...]            # which CommandPatterns appear near this marker
+    pattern_ids: tuple[str, ...]  # which CommandPatterns appear near this marker
     correlation_percent: float
-    mean_time_delta_ms: float               # average offset between marker and first pattern packet
+    mean_time_delta_ms: float  # average offset between marker and first pattern packet
 ```
 
 `MarkerCorrelation` is the authoritative source for marker-correlation details. A

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -35,7 +35,7 @@ class Capture:
     source: Path
     metadata: CaptureMetadata
     packets: tuple[CapturePacket, ...]   # raw pcap packets (not used by engine)
-    records: tuple[UrbRecord, ...]        # decoded URBs, one per packet
+    records: tuple[UrbRecord, ...]        # decoded URBs; may be fewer than packets
     transactions: tuple[UrbTransaction, ...]  # paired submission+completion URB pairs
     markers: list[Marker]                 # analyst-placed named timestamps
 ```
@@ -95,8 +95,8 @@ The preprocessing layer has five goals:
    individual IN/OUT records that carry payload data, so multi-step sequences can be
    compared one token at a time.
 4. **Group comparable events:** group by device, endpoint number, direction, transfer type,
-   and payload length. Endpoint number and direction stay separate because decoded
-   `UrbRecord` already stores them separately.
+   header discriminator, and payload length. Endpoint number and direction stay separate
+   because decoded `UrbRecord` already stores them separately.
 5. **Classify payload bytes:** within each group, identify fixed bytes that define command
    identity and variable bytes that likely represent arguments, counters, checksums, or
    response data.
@@ -112,13 +112,16 @@ benefiting from the URB pairing done earlier.
 A **token** is the normalized representation of one analysis event. It is a tuple:
 
 ```
-Token = (endpoint_number, direction, transfer_type, payload_signature)
+Token = (endpoint_number, direction, transfer_type, signature_mode, payload_signature)
 ```
 
 Where:
 - `endpoint_number` — bare endpoint number from `UrbRecord.endpoint` (`0` through `15`)
 - `direction` — `"in"` or `"out"`
 - `transfer_type` — `"bulk"` or `"interrupt"`
+- `signature_mode` — `"full"` for exact-length signatures, `"prefix"` for fallback
+  signatures across observed lengths, or `"full_prefix"` when header discrimination is
+  disabled and the first prefix bytes are kept literal
 - `payload_signature` — see §2.3
 
 The composite USB address form (`0x01` for OUT endpoint 1, `0x81` for IN endpoint 1) is
@@ -130,54 +133,117 @@ use composite endpoint strings as internal identity.
 The payload signature identifies the structural identity of a packet independent of
 variable fields. It is constructed as follows:
 
-**Step 1 — Length bucketing.**
-Packets with different lengths are always different tokens. Length is part of the
-signature: `len(data)`.
+**Step 1 — Header discriminator.**
+Treat the first `HEADER_ID_BYTES` bytes of non-empty payloads as a provisional message
+discriminator. The default is 1 byte because the Goodix reference captures show byte 0 is a
+stable opcode echoed in responses. Primary normalization groups are:
 
-**Step 2 — Fixed vs. variable byte detection.**
-For a group of packets sharing the same endpoint, direction, and length, compare byte
-positions across all packets:
+```
+(device_id, endpoint_number, direction, transfer_type, header, len(data))
+```
+
+The header discriminator prevents unrelated same-length messages from collapsing into one
+over-broad token before fixed/variable byte detection runs.
+
+**Step 2 — Length-aware full signatures.**
+Within each primary group, packets with the same header and length can produce a `"full"`
+signature. Length is represented in `PatternStep.observed_length_range` rather than embedded
+inside `payload_signature`, so variable-size instances of the same message type can still be
+reported coherently by fallback signatures.
+
+**Step 3 — Fixed vs. variable byte detection.**
+For a primary group of packets sharing device, endpoint number, direction, transfer type,
+header, and length, compare byte positions across all packets:
 - A byte position where all packets share the same value → **fixed byte** (part of identity)
 - A byte position where values differ across packets → **variable byte** (argument or counter)
 
 Fixed bytes are included in the signature as their literal value. Variable bytes are
 replaced with a `None` sentinel.
 
-**Step 3 — Signature representation.**
+**Step 4 — Signature representation.**
 The payload signature is a tuple of `int | None` values, one per byte position.
 
 Example: if three packets of length 4 have bytes `[0x01, 0x00, 0x05, 0xA1]`,
 `[0x01, 0x00, 0x07, 0xA3]`, and `[0x01, 0x00, 0x09, 0xA5]`, the signature is
 `(0x01, 0x00, None, None)` — bytes 0 and 1 are fixed, bytes 2 and 3 vary.
 
-**Step 4 — Minimum sample threshold.**
+**Step 5 — Minimum sample threshold.**
 Variable/fixed classification supports a provisional two-sample mode. With **2 packets**
-in the same endpoint+direction+length group, byte positions that differ are treated as
-variable and byte positions that match are treated as fixed. With **3 or more packets**,
-the same rule becomes more reliable because there are enough samples to distinguish
-stable identity bytes from counters, checksums, or arguments with less risk of overfitting.
-This prevents commands seen exactly twice from disappearing simply because one byte varies.
-The threshold is a named constant and can be tuned.
+in the same primary group, byte positions that differ are treated as variable and byte
+positions that match are treated as fixed. With **3 or more packets**, the same rule becomes
+more reliable because there are enough samples to distinguish stable identity bytes from
+counters, checksums, or arguments with less risk of overfitting. This prevents commands seen
+exactly twice from disappearing simply because one byte varies. The threshold is a named
+constant and can be tuned.
+
+**Step 6 — Prefix fallback across lengths.**
+If a `(device_id, endpoint_number, direction, transfer_type, header, len(data))` group has
+fewer than `MIN_NORMALIZATION_SAMPLE_COUNT` samples, re-pool candidate events across lengths
+under:
+
+```
+(device_id, endpoint_number, direction, transfer_type, header)
+```
+
+For these under-sampled groups, classify only the first `PREFIX_SIGNATURE_BYTES` payload
+bytes and emit a `"prefix"` signature. The output records the observed minimum and maximum
+payload lengths in `PatternStep.observed_length_range`. This keeps repeated message types
+visible when a driver chunks the same logical message at different read sizes.
+
+**Step 7 — Header safety valves.**
+The header discriminator is provisional. It can fail in either direction:
+- If a lane's byte-0 cardinality is 1, or below `HEADER_CARDINALITY_FLOOR` relative to the
+  number of distinct payloads, byte 0 may be a sync/framing byte with no useful
+  discrimination.
+- If a lane has too many distinct byte-0 values relative to its packet count, byte 0 may be
+  data rather than an opcode.
+
+When the initial header is too weak, widen the discriminator up to `MAX_HEADER_ID_BYTES`
+until cardinality reaches the floor. If widening still does not produce a useful
+discriminator, fall back to `"full_prefix"` signatures grouped by
+`(device_id, endpoint_number, direction, transfer_type, len(data))`: keep the first
+`PREFIX_SIGNATURE_BYTES` literal bytes with no variable-byte masking, and add an
+`analysis_notes` entry explaining that header discrimination was disabled because the
+candidate header was non-discriminating.
+
+When the initial header is too noisy, meaning
+`distinct_headers > packet_count * HEADER_CARDINALITY_FRACTION_LIMIT`, fall back to the same
+`"full_prefix"` mode and add an `analysis_notes` entry explaining that header
+discrimination was disabled because byte-0 cardinality was too high.
 
 ### 2.4 When Normalization Runs
 
 Normalization is a two-pass process:
-1. **First pass:** collect all packets per (endpoint, direction, length) group, compute
-   variable byte positions
+1. **First pass:** collect all analysis events per full group
+   `(device_id, endpoint_number, direction, transfer_type, header, len(data))`, apply the
+   header safety valve, and compute variable byte positions for full/prefix groups or literal
+   prefix bytes for `full_prefix` groups
 2. **Second pass:** assign each analysis event its token using the variable map from pass 1
 
 ### 2.5 Determinism Guarantee
 
-A token's `payload_signature` is computed only from packets sharing its
-`(device_id, endpoint_number, direction, transfer_type, len(data))` group, processed in
-ascending capture order. The variable-byte map is therefore a pure function of that group.
-Two runs over the same capture always produce identical signatures.
+A token's `payload_signature` is computed only from analysis events sharing its full group
+`(device_id, endpoint_number, direction, transfer_type, header, len(data))`, its prefix
+fallback group `(device_id, endpoint_number, direction, transfer_type, header)`, or its
+header-disabled full-prefix group `(device_id, endpoint_number, direction, transfer_type,
+len(data))`, processed in ascending capture order. The variable-byte map or literal prefix
+map is therefore a pure function of that selected group. Two runs over the same capture
+always produce identical signatures.
 
-Two captures of the same device produce identical signatures for a command when that
-command's group has the same fixed and variable byte positions in both captures. Truncating
-a capture only changes a signature when the truncation removes packets from that command's
-own group. Packets on other endpoints, other devices, or other payload lengths do not
-affect the signature.
+Two captures of the same device should produce the same signature for the same command when
+that command's selected normalization group has the same fixed and variable byte positions in
+both captures. This stability is desirable because it lets analysts compare repeated
+behavior across captures. If unrelated commands produce the same signature, that is an
+over-merging failure and should be avoided by narrower grouping or reported through
+`analysis_notes`. Truncating a capture only changes a signature when the truncation removes
+packets from that command's own full, prefix, or full-prefix group. Packets on other
+endpoints, other devices, other transfer types, or other active header groups do not affect
+the signature.
+
+Message reassembly is a non-goal for the first implementation pass. Continuation reads such
+as fixed-opcode chunks split across multiple IN transfers should remain visible through
+prefix signatures and observed length ranges, but the engine does not reconstruct a larger
+logical application message from multiple URBs.
 
 ---
 
@@ -376,7 +442,9 @@ class PatternStep:
     endpoint_address: str                   # display address, e.g. "0x01" or "0x81"
     direction: Direction                    # "in" or "out"
     transfer_type: TransferType             # "bulk" or "interrupt"
+    signature_mode: Literal["full", "prefix", "full_prefix"]
     payload_signature: tuple[int | None, ...] # None = variable byte
+    observed_length_range: tuple[int, int]   # inclusive min/max len(data)
     variable_byte_ranges: tuple[VariableByteRange, ...]
 ```
 
@@ -428,6 +496,12 @@ class UnsolicitedResponse:
     endpoint_address: str
     transfer_type: TransferType
     occurrence_count: int
+    first_occurrence_index: int
+    last_occurrence_index: int
+    first_occurrence_timestamp: float
+    last_occurrence_timestamp: float
+    signature_mode: Literal["full", "prefix", "full_prefix"]
+    observed_length_range: tuple[int, int]
     payload_signature: tuple[int | None, ...]
 ```
 
@@ -440,6 +514,12 @@ class UnansweredCommand:
     endpoint_address: str
     transfer_type: TransferType
     occurrence_count: int
+    first_occurrence_index: int
+    last_occurrence_index: int
+    first_occurrence_timestamp: float
+    last_occurrence_timestamp: float
+    signature_mode: Literal["full", "prefix", "full_prefix"]
+    observed_length_range: tuple[int, int]
     payload_signature: tuple[int | None, ...]
 ```
 
@@ -498,6 +578,10 @@ JSON and uses it to draft a human-readable protocol description.
 | Sequence seen only once | Not reported as a `CommandPattern`; may be reported as `AnalysisObservation` if marker-adjacent or a long OUT/IN exchange |
 | Two packets for normalization | Differing byte positions are provisionally treated as variable so twice-seen commands can still match |
 | One packet for normalization | All bytes treated as fixed; no variable byte detection |
+| Same header appears at multiple payload lengths | Use prefix fallback for under-sampled exact-length groups; report `observed_length_range` |
+| Byte-0 cardinality is too low for a lane | Widen the header discriminator up to `MAX_HEADER_ID_BYTES`; if still non-discriminating, use `full_prefix` mode and emit an `analysis_notes` warning |
+| Byte-0 cardinality is too high for a lane | Disable header discrimination for that lane, use `full_prefix` mode, and emit an `analysis_notes` warning |
+| Multi-URB continuation message | Do not reassemble in the first pass; preserve chunks as analysis events with prefix signatures where needed |
 | Sub-pattern has same count as parent | Drop shorter sub-pattern as redundant |
 | Sub-pattern occurs more than parent | Keep both; shorter pattern may represent optional protocol steps |
 | OUT analysis event with no following IN response candidate | Recorded as `UnansweredCommand`; not treated as error |
@@ -522,6 +606,11 @@ All tunable values are named constants in the engine module (not magic numbers):
 
 | Constant | Default | Meaning |
 |----------|---------|---------|
+| `HEADER_ID_BYTES` | 1 | Number of leading payload bytes used as a provisional message discriminator |
+| `MAX_HEADER_ID_BYTES` | 4 | Maximum leading payload bytes to try when widening a non-discriminating header |
+| `HEADER_CARDINALITY_FLOOR` | 2 | Minimum distinct header values needed before treating a candidate header as discriminating |
+| `PREFIX_SIGNATURE_BYTES` | 8 | Number of leading payload bytes classified for prefix fallback signatures |
+| `HEADER_CARDINALITY_FRACTION_LIMIT` | 0.5 | Disable header discrimination for a lane when distinct headers exceed this fraction of lane packets |
 | `MIN_NORMALIZATION_SAMPLE_COUNT` | 2 | Minimum packets needed for provisional variable-byte detection |
 | `MAX_SEQUENCE_WINDOW` | 8 | Maximum token sequence length to search for; configurable per analysis run |
 | `MIN_OCCURRENCE_COUNT` | 2 | Minimum occurrences for a pattern to be reported |
@@ -560,7 +649,10 @@ human narrative. Expected assertions:
   `unsolicited_responses`, `unanswered_commands`, and `incomplete_transfers` are present
   even when empty.
 - every returned `CommandPattern` has at least one `PatternStep`, no more than
-  `MAX_SEQUENCE_WINDOW` steps, and JSON-safe payload signatures.
+  `MAX_SEQUENCE_WINDOW` steps, JSON-safe payload signatures, `signature_mode`, and
+  `observed_length_range`.
+- `UnsolicitedResponse` and `UnansweredCommand` entries include first/last occurrence
+  indices and timestamps so analysts can locate the evidence in the capture.
 - if result caps are exceeded, truncation flags and a truncation note are present.
 
 ---

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -1,0 +1,353 @@
+# Milestone 3: Protocol Hypothesis Engine — Specification
+
+**Issue:** [#62](https://github.com/bsu-tool/bsu-tool/issues/62)
+**Branch:** `62/m3-engine-spec`
+**Status:** Draft — pending team review
+
+---
+
+## Overview
+
+The Protocol Hypothesis Engine is the core analytical output of bsu-tool. It takes a fully
+loaded `Capture` (decoded URBs + analyst markers) and produces a human-readable protocol
+description: what commands the host sends, what responses the device returns, and how those
+relate to physical actions the analyst observed during capture.
+
+The engine operates entirely on in-memory data — it reads from the `Session`/`Capture`
+objects already built by Milestone 1 and 2 infrastructure and writes results back as
+structured Python dataclasses that the MCP server can return to Claude.
+
+This is a spec-first issue. Implementation should start after the team reviews this
+document and resolves the open questions at the end.
+
+---
+
+## 1. Input
+
+### 1.1 Primary Input: `Capture`
+
+The engine receives the active `Capture` from `Session.capture`. All inputs are already
+decoded — the engine does not re-read pcap-ng files.
+
+```python
+@dataclass
+class Capture:
+    source: Path
+    metadata: CaptureMetadata
+    packets: tuple[CapturePacket, ...]   # raw pcap packets (not used by engine)
+    records: tuple[UrbRecord, ...]        # decoded URBs, one per packet
+    transactions: tuple[UrbTransaction, ...]  # paired submission+completion URB pairs
+    markers: list[Marker]                 # analyst-placed named timestamps
+```
+
+Key fields per `UrbRecord`:
+- `bus_num`, `dev_num` — which physical device
+- `endpoint` — endpoint number (0–15)
+- `direction` — `"in"` (device→host) or `"out"` (host→device)
+- `transfer_type` — `"control"`, `"bulk"`, or `"interrupt"`
+- `timestamp` — float seconds in the same timescale used by decoded `UrbRecord` values
+- `data` — raw payload bytes
+- `status` — integer URB status code (0 = success)
+
+Key fields per `UrbTransaction`:
+- `submission` — the `UrbRecord` for the submission event (`event_type == "submission"`)
+- `completion` — the `UrbRecord` for the completion event (`event_type == "completion"`)
+- Both fields may be `None` if pairing was incomplete (see edge cases)
+
+Key fields per `Marker`:
+- `name` — analyst label (e.g. `"button_press"`)
+- `timestamp` — float seconds, same timescale as `UrbRecord.timestamp`
+- `packet_index` — index into `Capture.records` at time of marker placement
+- `note` — optional free-text annotation
+
+### 1.2 Scope Restriction
+
+The engine operates only on:
+- **Bulk** and **Interrupt** transfers — these carry vendor-specific payload data
+- **Control** transfers are used only for device identification (already handled in
+  `list_devices`) and are excluded from pattern detection
+
+Isochronous transfers are excluded at load time and never reach the engine.
+
+---
+
+## 2. Token Normalization
+
+Before pattern detection can work, raw payloads must be reduced to a comparable form.
+Raw bytes alone are too brittle — two packets that differ only in a counter byte or
+checksum would appear as different commands.
+
+### 2.1 Analysis Event And Token Definition
+
+Tokenization operates on analysis events derived from `UrbTransaction` records, not on
+the full transaction object directly. For OUT commands, use the record that carries the
+host-to-device payload. For IN responses, use the record that carries the device-to-host
+payload. This keeps command and response payloads separately comparable while still
+benefiting from the URB pairing done earlier.
+
+A **token** is the normalized representation of one analysis event. It is a tuple:
+
+```
+Token = (endpoint_address, direction, transfer_type, payload_signature)
+```
+
+Where:
+- `endpoint_address` — endpoint number with direction bit applied (`endpoint | 0x80` for IN)
+- `direction` — `"in"` or `"out"`
+- `transfer_type` — `"bulk"` or `"interrupt"`
+- `payload_signature` — see §2.2
+
+### 2.2 Payload Signature
+
+The payload signature identifies the structural identity of a packet independent of
+variable fields. It is constructed as follows:
+
+**Step 1 — Length bucketing.**
+Packets with different lengths are always different tokens. Length is part of the
+signature: `len(data)`.
+
+**Step 2 — Fixed vs. variable byte detection.**
+For a group of packets sharing the same endpoint, direction, and length, compare byte
+positions across all packets:
+- A byte position where all packets share the same value → **fixed byte** (part of identity)
+- A byte position where values differ across packets → **variable byte** (argument or counter)
+
+Fixed bytes are included in the signature as their literal value. Variable bytes are
+replaced with a `None` sentinel.
+
+**Step 3 — Signature representation.**
+The payload signature is a tuple of `int | None` values, one per byte position.
+
+Example: if three packets of length 4 have bytes `[0x01, 0x00, 0x05, 0xA1]`,
+`[0x01, 0x00, 0x07, 0xA3]`, and `[0x01, 0x00, 0x09, 0xA5]`, the signature is
+`(0x01, 0x00, None, None)` — bytes 0 and 1 are fixed, bytes 2 and 3 vary.
+
+**Step 4 — Minimum sample threshold.**
+Variable/fixed classification requires a minimum of **3 packets** with the same
+endpoint+direction+length. With fewer samples, all bytes are treated as fixed (no
+variable detection). This threshold is a named constant and can be tuned.
+
+### 2.3 When Normalization Runs
+
+Normalization is a two-pass process:
+1. **First pass:** collect all packets per (endpoint, direction, length) group, compute
+   variable byte positions
+2. **Second pass:** assign each analysis event its token using the variable map from pass 1
+
+---
+
+## 3. Detection Algorithm
+
+### 3.1 Sequence Detection
+
+A **sequence** is a repeated ordered series of tokens that appears more than once in the
+analysis event stream for a given device.
+
+**Algorithm:**
+
+1. Flatten all analysis events for a device into an ordered list of tokens (by timestamp).
+2. Use a sliding window of width `w` (minimum 1, maximum configurable, default 4) to
+   extract all sub-sequences of each length.
+3. Hash each sub-sequence and count occurrences.
+4. A sequence that occurs **≥ 2 times** is a candidate pattern.
+5. Prefer longer patterns over their sub-sequences: if pattern `[A, B, C]` covers
+   every occurrence of `[A, B]`, discard `[A, B]` as a sub-pattern.
+6. Sort candidates by occurrence count descending.
+
+**Complexity note:** With N analysis events and window size W, this is O(N × W). For
+typical captures (hundreds to low thousands of packets), this is fast enough for
+synchronous execution. No async or streaming required.
+
+### 3.2 Marker Correlation
+
+Each detected sequence is correlated with analyst markers:
+
+1. For each sequence occurrence, find the nearest marker by timestamp.
+2. If the nearest marker is within a configurable window (default **2.0 seconds**),
+   the occurrence is tagged with that marker's name.
+3. A sequence is **marker-correlated** if ≥ 50% of its occurrences are near the same
+   marker name.
+
+This is how the engine connects physical device actions ("I pressed the relay button")
+to captured packet sequences ("these 3 packets always appear within 2 seconds of
+`relay_on`").
+
+---
+
+## 4. Pairing Algorithm
+
+### 4.1 Command/Response Pairing
+
+A **command/response pair** links an OUT transaction (host→device) to the IN transaction
+(device→host) that follows it on the same device and endpoint number.
+
+**Algorithm:**
+
+For each device and endpoint number, process transactions in timestamp order:
+1. When an OUT transaction is seen, push it onto a pending command queue.
+2. When an IN transaction is seen, pop the oldest pending OUT from the queue and pair them.
+3. If no pending OUT exists when an IN arrives, the IN is an **unsolicited response**
+   (recorded as such, not discarded).
+4. If a pending OUT has no IN follow-up within a configurable timeout window (default
+   **5.0 seconds** of capture time, not wall time), it is an **unanswered command**.
+
+**Endpoint scope:** pairing is scoped by device and endpoint number. An OUT on endpoint
+`0x01` may pair with an IN on endpoint `0x81` because both refer to endpoint number 1
+with opposite directions. Pairing by full endpoint address would miss this common USB
+command/response shape.
+
+### 4.2 Control Transfer Exclusion
+
+Control transactions (endpoint 0, used for device setup) are excluded from
+command/response pairing. They are already captured in the device descriptor data.
+
+---
+
+## 5. Output Format
+
+### 5.1 Top-Level Result
+
+```python
+@dataclass(frozen=True)
+class ProtocolHypothesis:
+    device_id: str                          # e.g. "dev_001_003"
+    command_patterns: tuple[CommandPattern, ...]
+    unsolicited_responses: tuple[UnsolicitedResponse, ...]
+    unanswered_commands: tuple[UnansweredCommand, ...]
+    marker_correlations: tuple[MarkerCorrelation, ...]
+    analysis_notes: tuple[str, ...]         # free-text warnings from the engine
+```
+
+### 5.2 `CommandPattern`
+
+```python
+@dataclass(frozen=True)
+class CommandPattern:
+    pattern_id: str                         # e.g. "pattern_01"
+    endpoint_address: str                   # e.g. "0x01"
+    transfer_type: TransferType             # "bulk" or "interrupt"
+    occurrence_count: int
+    command_signature: tuple[int | None, ...] # None = variable byte
+    response_signature: tuple[int | None, ...] | None  # None if no response seen
+    mean_response_time_ms: float | None     # average time from OUT to IN
+    variable_byte_ranges: tuple[VariableByteRange, ...]
+    nearest_marker: str | None              # marker name if correlated
+```
+
+### 5.3 `VariableByteRange`
+
+```python
+@dataclass(frozen=True)
+class VariableByteRange:
+    byte_index: int
+    observed_min: int
+    observed_max: int
+    observed_values: tuple[int, ...]        # all distinct values seen (capped at 32)
+```
+
+### 5.4 `UnsolicitedResponse`
+
+```python
+@dataclass(frozen=True)
+class UnsolicitedResponse:
+    endpoint_address: str
+    transfer_type: TransferType
+    occurrence_count: int
+    payload_signature: tuple[int | None, ...]
+```
+
+### 5.5 `UnansweredCommand`
+
+```python
+@dataclass(frozen=True)
+class UnansweredCommand:
+    endpoint_address: str
+    transfer_type: TransferType
+    occurrence_count: int
+    payload_signature: tuple[int | None, ...]
+```
+
+### 5.6 `MarkerCorrelation`
+
+```python
+@dataclass(frozen=True)
+class MarkerCorrelation:
+    marker_name: str
+    pattern_ids: tuple[str, ...]            # which CommandPatterns appear near this marker
+    mean_time_delta_ms: float               # average offset between marker and first pattern packet
+```
+
+### 5.7 MCP Tool Output
+
+The engine result is returned from a new MCP tool `analyze_protocol`. The tool returns
+a `ProtocolHypothesis` serialized as a typed dict (following the existing pattern in
+`bsu_tool/mcp/interfaces.py`). Claude receives this and uses it to draft a human-readable
+protocol description.
+
+---
+
+## 6. Edge Cases
+
+| Case | Handling |
+|------|----------|
+| No markers in capture | Proceed without correlation; `marker_correlations` is empty; emit analysis note |
+| Sequence seen only once | Not reported as a `CommandPattern`; minimum is 2 occurrences |
+| Fewer than 3 packets for normalization | All bytes treated as fixed; no variable byte detection |
+| OUT with no IN response | Recorded as `UnansweredCommand`; not treated as error |
+| IN with no preceding OUT | Recorded as `UnsolicitedResponse`; device may be pushing status |
+| Overlapping marker windows | Occurrence assigned to the single nearest marker by timestamp |
+| Multiple devices in capture | Engine runs independently per device; results are separate `ProtocolHypothesis` objects |
+| All-zero payload | Treated as a valid payload; not filtered out |
+| Empty capture (no bulk/interrupt packets) | Return empty `ProtocolHypothesis` with analysis note explaining why |
+| Status != 0 (failed URB) | Failed URBs are excluded from pattern detection; counted and reported in `analysis_notes` |
+| Capture with only control transfers | All packets excluded from engine scope; empty result with note |
+
+---
+
+## 7. Configuration Constants
+
+All tunable values are named constants in the engine module (not magic numbers):
+
+| Constant | Default | Meaning |
+|----------|---------|---------|
+| `MIN_NORMALIZATION_SAMPLE_COUNT` | 3 | Minimum packets needed to detect variable bytes |
+| `MAX_SEQUENCE_WINDOW` | 4 | Maximum token sequence length to search for |
+| `MIN_OCCURRENCE_COUNT` | 2 | Minimum occurrences for a pattern to be reported |
+| `MARKER_CORRELATION_WINDOW_SECONDS` | 2.0 | Max time delta to associate a packet with a marker |
+| `COMMAND_RESPONSE_TIMEOUT_SECONDS` | 5.0 | Max capture-time gap to pair OUT→IN |
+| `MAX_VARIABLE_VALUES_REPORTED` | 32 | Cap on distinct values stored per variable byte |
+
+---
+
+## 8. Module Location
+
+The engine will live in `bsu_tool/analyzer.py`. It has no dependencies outside the
+existing package and must not read pcap-ng files directly. It reads from the existing
+`Capture` and `Session` types in `bsu_tool/session.py`.
+
+MCP-facing output dataclasses or typed result models should follow the existing pattern
+in `bsu_tool/mcp/interfaces.py`.
+
+The MCP tool wrapper goes in `bsu_tool/mcp/tools/analysis.py` and is registered in
+`bsu_tool/mcp/tools/__init__.py`.
+
+Tests go in:
+- `tests/unit/test_analyzer.py` — unit tests for each algorithm step
+- `tests/int/test_mcp_analyze_goodix.py` — integration test against the Goodix capture
+
+---
+
+## Open Questions for Team Review
+
+1. **Sequence window size** — is a max of 4 tokens per sequence sufficient? USB
+   command sequences for relay boards tend to be 1–3 packets, but unknown devices
+   may use longer sequences.
+
+2. **Marker correlation threshold** — should 50% match be enough to call a sequence
+   "correlated" with a marker, or should we require a higher threshold?
+
+3. **Response time reporting** — mean is simple but can be skewed by outliers. Should
+   we also report median or min/max?
+
+4. **Multi-device handling** — should `analyze_protocol` accept an optional `device_id`
+   filter, or always return results for all devices and let Claude filter?

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -226,16 +226,10 @@ discarded silently either.
 Single-occurrence sequences are reported as `AnalysisObservation` objects when they meet
 one of these criteria:
 - The sequence occurs within the marker correlation window of an analyst marker.
-- The sequence is a long multi-step exchange that does not repeat but includes both OUT
-  and IN traffic on the same device.
+- The sequence is a multi-step exchange that does not repeat but contains at least `MIN_OBSERVATION_STEPS` steps with both OUT and IN traffic on the same device.
 
 This keeps the main `command_patterns` list focused on repeated evidence while preserving
 important one-time behavior for analyst review.
-
-The engine does not infer an "end of enumeration" boundary by default because Control
-transfers are excluded from the default runtime analysis path. If the team later wants a
-boundary-based observation rule, the loader or analyzer must first expose an explicit
-enumeration-end timestamp.
 
 **Complexity note:** With N analysis events and window size W across all endpoint lanes,
 this is O(N × W). For typical captures (hundreds to low thousands of packets), this is
@@ -277,16 +271,17 @@ URB id, including orphan submissions and orphan completions.
 **Algorithm:**
 
 For each endpoint lane, process available `UrbTransaction` objects in timestamp order:
-1. Convert each transaction into an analysis event using the record that carries payload
-   data and status information.
+1. Convert each transaction into an analysis event using the submission record for direction
+   and the completion record for status and payload data.
 2. Keep failed transactions visible to this pass so retries and failed responses affect
    timing and notes, even if they are not promoted into successful command patterns.
-3. When an OUT event is followed by an IN event on the same endpoint lane within the
-   configurable timeout window, record it as a likely command/response pair.
-4. If an IN event has no preceding successful OUT candidate in the timeout window, record
-   it as an **unsolicited response** unless it is explained by a failed transaction.
-5. If an OUT event has no following successful IN candidate in the timeout window, record
-   it as an **unanswered command** unless it is explained by a failed transaction.
+3. When a transaction's submission is an OUT event and its completion is an IN event on
+   the same endpoint lane, record it as a likely command/response pair.
+4. If a transaction has an orphan completion with no matching submission, record it as an
+   **unsolicited response** unless it is explained by a failed transaction.
+5. If a transaction has an orphan submission with no matching completion within the
+   configurable timeout window, record it as an **unanswered command** unless it is
+   explained by a failed transaction.
 
 **Endpoint scope:** pairing is scoped by device and endpoint number. An OUT on endpoint
 `0x01` may pair with an IN on endpoint `0x81` because both refer to endpoint number 1
@@ -392,7 +387,7 @@ followed by an IN event that the pairing algorithm identifies as a likely respon
 @dataclass(frozen=True)
 class AnalysisObservation:
     observation_id: str                     # e.g. "observation_01"
-    reason: str                             # e.g. "near_marker" or "single_exchange"
+    reason: Literal["near_marker", "multi_step_exchange"]
     steps: tuple[PatternStep, ...]
     nearest_marker: str | None
 ```
@@ -504,6 +499,7 @@ All tunable values are named constants in the engine module (not magic numbers):
 | `MAX_VARIABLE_VALUES_REPORTED` | 32 | Cap on distinct values stored per variable byte |
 | `MAX_COMMAND_PATTERNS_RETURNED` | 20 | Cap on ranked command patterns returned in one MCP response |
 | `MAX_OBSERVATIONS_RETURNED` | 10 | Cap on ranked single-occurrence observations returned in one MCP response |
+| `MIN_OBSERVATION_STEPS` | 2 | Minimum number of steps containing both IN and OUT traffic a single-occurrence exchange must have to qualify as an `AnalysisObservation` via the multi-step criteria |
 
 ---
 
@@ -551,6 +547,11 @@ human narrative. Expected assertions:
 
 4. **Multi-device handling** — `analyze_protocol` returns all devices by default and
    accepts an optional `device_id` filter, matching the shape of `get_packets`.
+
+5. **Single-occurrence observation criteria** — proceed with the two proposed criteria
+   (marker-adjacent and multi-step exchange with `MIN_OBSERVATION_STEPS`) as sufficient
+   for initial implementation. Additional computable rules should be defined only after
+   validation against reference captures confirms meaningful observations are being dropped.
 
 ## Open Questions for Team Review
 

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -77,7 +77,27 @@ Before pattern detection can work, raw payloads must be reduced to a comparable 
 Raw bytes alone are too brittle — two packets that differ only in a counter byte or
 checksum would appear as different commands.
 
-### 2.1 Analysis Event And Token Definition
+### 2.1 Normalization Philosophy
+
+Normalization is the boundary between decoded USB evidence and protocol inference. It
+should preserve enough packet-level detail for human validation while removing noise that
+would prevent repeated behavior from matching.
+
+The preprocessing layer has four goals:
+1. **Filter analysis scope:** keep successful Bulk and Interrupt records; exclude Control
+   setup traffic and failed URBs from pattern detection while still reporting exclusions in
+   `analysis_notes`.
+2. **Create directional analysis events:** split paired `UrbTransaction` objects into the
+   individual IN/OUT records that carry payload data, so multi-step sequences can be
+   compared one token at a time.
+3. **Group comparable events:** group by device, endpoint number, direction, transfer type,
+   and payload length. Endpoint number and direction stay separate because decoded
+   `UrbRecord` already stores them separately.
+4. **Classify payload bytes:** within each group, identify fixed bytes that define command
+   identity and variable bytes that likely represent arguments, counters, checksums, or
+   response data.
+
+### 2.2 Analysis Event And Token Definition
 
 Tokenization operates on analysis events derived from `UrbTransaction` records, not on
 the full transaction object directly. For OUT commands, use the record that carries the
@@ -88,16 +108,20 @@ benefiting from the URB pairing done earlier.
 A **token** is the normalized representation of one analysis event. It is a tuple:
 
 ```
-Token = (endpoint_address, direction, transfer_type, payload_signature)
+Token = (endpoint_number, direction, transfer_type, payload_signature)
 ```
 
 Where:
-- `endpoint_address` — endpoint number with direction bit applied (`endpoint | 0x80` for IN)
+- `endpoint_number` — bare endpoint number from `UrbRecord.endpoint` (`0` through `15`)
 - `direction` — `"in"` or `"out"`
 - `transfer_type` — `"bulk"` or `"interrupt"`
-- `payload_signature` — see §2.2
+- `payload_signature` — see §2.3
 
-### 2.2 Payload Signature
+The composite USB address form (`0x01` for OUT endpoint 1, `0x81` for IN endpoint 1) is
+derived only for output display. The engine should not parse `EndpointSummary.address` or
+use composite endpoint strings as internal identity.
+
+### 2.3 Payload Signature
 
 The payload signature identifies the structural identity of a packet independent of
 variable fields. It is constructed as follows:
@@ -127,7 +151,7 @@ Variable/fixed classification requires a minimum of **3 packets** with the same
 endpoint+direction+length. With fewer samples, all bytes are treated as fixed (no
 variable detection). This threshold is a named constant and can be tuned.
 
-### 2.3 When Normalization Runs
+### 2.4 When Normalization Runs
 
 Normalization is a two-pass process:
 1. **First pass:** collect all packets per (endpoint, direction, length) group, compute
@@ -141,32 +165,57 @@ Normalization is a two-pass process:
 ### 3.1 Sequence Detection
 
 A **sequence** is a repeated ordered series of tokens that appears more than once in the
-analysis event stream for a given device.
+analysis event stream for a given device. In this document, a sequence becomes a
+`CommandPattern` when it is promoted into the output model. "Sequence" describes the
+ordered tokens found by the algorithm; "pattern" describes that sequence plus metadata
+such as occurrence count, marker correlation, and response-time statistics.
 
 **Algorithm:**
 
 1. Flatten all analysis events for a device into an ordered list of tokens (by timestamp).
-2. Use a sliding window of width `w` (minimum 1, maximum configurable, default 4) to
+2. Use a sliding window of width `w` (minimum 1, maximum configurable, default 8) to
    extract all sub-sequences of each length.
 3. Hash each sub-sequence and count occurrences.
-4. A sequence that occurs **≥ 2 times** is a candidate pattern.
+4. A sequence that occurs **≥ 2 times** is a repeated candidate pattern.
 5. Prefer longer patterns over their sub-sequences: if pattern `[A, B, C]` covers
-   every occurrence of `[A, B]`, discard `[A, B]` as a sub-pattern.
+   every occurrence of `[A, B]`, discard `[A, B]` as a redundant sub-pattern.
 6. Sort candidates by occurrence count descending.
+
+Subsumed shorter patterns are dropped only when their occurrence count exactly matches
+the longer parent pattern. If `[A, B]` occurs more often than `[A, B, C]`, keep both
+patterns because the extra `[A, B]` occurrences may indicate optional protocol steps.
+
+### 3.2 Single-Occurrence Event Preservation
+
+Some meaningful protocol events, such as initialization handshakes, may occur only once.
+These should not be emitted as repeated `CommandPattern` objects, but they should not be
+discarded silently either.
+
+Single-occurrence sequences are reported as `AnalysisObservation` objects when they meet
+one of these criteria:
+- The sequence occurs within the marker correlation window of an analyst marker.
+- The sequence appears near the beginning of runtime traffic after enumeration.
+- The sequence is a long multi-step exchange that does not repeat but includes both OUT
+  and IN traffic on the same device.
+
+This keeps the main `command_patterns` list focused on repeated evidence while preserving
+important one-time behavior for analyst review.
 
 **Complexity note:** With N analysis events and window size W, this is O(N × W). For
 typical captures (hundreds to low thousands of packets), this is fast enough for
 synchronous execution. No async or streaming required.
 
-### 3.2 Marker Correlation
+### 3.3 Marker Correlation
 
 Each detected sequence is correlated with analyst markers:
 
 1. For each sequence occurrence, find the nearest marker by timestamp.
 2. If the nearest marker is within a configurable window (default **2.0 seconds**),
    the occurrence is tagged with that marker's name.
-3. A sequence is **marker-correlated** if ≥ 50% of its occurrences are near the same
-   marker name.
+3. Compute the percentage of occurrences near each marker name.
+4. A sequence is **marker-correlated** by default if ≥ 50% of its occurrences are near
+   the same marker name, but the raw percentage is always reported so analysts can judge
+   borderline cases.
 
 This is how the engine connects physical device actions ("I pressed the relay button")
 to captured packet sequences ("these 3 packets always appear within 2 seconds of
@@ -179,7 +228,9 @@ to captured packet sequences ("these 3 packets always appear within 2 seconds of
 ### 4.1 Command/Response Pairing
 
 A **command/response pair** links an OUT transaction (host→device) to the IN transaction
-(device→host) that follows it on the same device and endpoint number.
+(device→host) that follows it on the same device and endpoint number. This is a
+best-effort label for common Bulk/Interrupt runtime traffic; the full pattern detector
+still preserves multi-step and cross-endpoint sequences through `CommandPattern.steps`.
 
 **Algorithm:**
 
@@ -196,10 +247,18 @@ For each device and endpoint number, process transactions in timestamp order:
 with opposite directions. Pairing by full endpoint address would miss this common USB
 command/response shape.
 
+If a device sends commands and responses on different endpoint numbers, those events are
+not forced into a simple command/response pair. They remain visible as adjacent
+`PatternStep` entries in a detected `CommandPattern`.
+
 ### 4.2 Control Transfer Exclusion
 
-Control transactions (endpoint 0, used for device setup) are excluded from
-command/response pairing. They are already captured in the device descriptor data.
+Control transactions (endpoint 0, used for enumeration and device setup) are excluded
+from runtime command/response pairing and repeated pattern detection. Descriptor-related
+control traffic is already summarized through `list_devices`. If later validation shows
+vendor-specific devices use post-enumeration control transfers for meaningful commands,
+that can be added as a separate analyzer mode rather than mixed into the default
+Bulk/Interrupt workflow.
 
 ---
 
@@ -212,6 +271,7 @@ command/response pairing. They are already captured in the device descriptor dat
 class ProtocolHypothesis:
     device_id: str                          # e.g. "dev_001_003"
     command_patterns: tuple[CommandPattern, ...]
+    observations: tuple[AnalysisObservation, ...]
     unsolicited_responses: tuple[UnsolicitedResponse, ...]
     unanswered_commands: tuple[UnansweredCommand, ...]
     marker_correlations: tuple[MarkerCorrelation, ...]
@@ -224,17 +284,57 @@ class ProtocolHypothesis:
 @dataclass(frozen=True)
 class CommandPattern:
     pattern_id: str                         # e.g. "pattern_01"
-    endpoint_address: str                   # e.g. "0x01"
-    transfer_type: TransferType             # "bulk" or "interrupt"
     occurrence_count: int
-    command_signature: tuple[int | None, ...] # None = variable byte
-    response_signature: tuple[int | None, ...] | None  # None if no response seen
-    mean_response_time_ms: float | None     # average time from OUT to IN
-    variable_byte_ranges: tuple[VariableByteRange, ...]
+    steps: tuple[PatternStep, ...]          # ordered, length 1..MAX_SEQUENCE_WINDOW
+    response_timing: ResponseTimingStats | None
+    parent_pattern_id: str | None           # set only when retained as an optional sub-pattern
     nearest_marker: str | None              # marker name if correlated
+    marker_correlation_percent: float | None
 ```
 
-### 5.3 `VariableByteRange`
+### 5.3 `PatternStep`
+
+```python
+@dataclass(frozen=True)
+class PatternStep:
+    step_index: int                         # 0-based position in the sequence
+    endpoint_number: int                    # bare endpoint number, 0-15
+    endpoint_address: str                   # display address, e.g. "0x01" or "0x81"
+    direction: Direction                    # "in" or "out"
+    transfer_type: TransferType             # "bulk" or "interrupt"
+    payload_signature: tuple[int | None, ...] # None = variable byte
+    variable_byte_ranges: tuple[VariableByteRange, ...]
+```
+
+### 5.4 `ResponseTimingStats`
+
+```python
+@dataclass(frozen=True)
+class ResponseTimingStats:
+    mean_ms: float
+    median_ms: float
+    min_ms: float
+    max_ms: float
+```
+
+These timing values are only meaningful for patterns whose steps include an OUT event
+followed by an IN event that the pairing algorithm identifies as a likely response.
+
+### 5.5 `AnalysisObservation`
+
+```python
+@dataclass(frozen=True)
+class AnalysisObservation:
+    observation_id: str                     # e.g. "observation_01"
+    reason: str                             # e.g. "near_marker" or "startup_exchange"
+    steps: tuple[PatternStep, ...]
+    nearest_marker: str | None
+```
+
+Observations preserve meaningful single-occurrence behavior without weakening the
+definition of repeated command patterns.
+
+### 5.6 `VariableByteRange`
 
 ```python
 @dataclass(frozen=True)
@@ -245,44 +345,52 @@ class VariableByteRange:
     observed_values: tuple[int, ...]        # all distinct values seen (capped at 32)
 ```
 
-### 5.4 `UnsolicitedResponse`
+### 5.7 `UnsolicitedResponse`
 
 ```python
 @dataclass(frozen=True)
 class UnsolicitedResponse:
+    endpoint_number: int
     endpoint_address: str
     transfer_type: TransferType
     occurrence_count: int
     payload_signature: tuple[int | None, ...]
 ```
 
-### 5.5 `UnansweredCommand`
+### 5.8 `UnansweredCommand`
 
 ```python
 @dataclass(frozen=True)
 class UnansweredCommand:
+    endpoint_number: int
     endpoint_address: str
     transfer_type: TransferType
     occurrence_count: int
     payload_signature: tuple[int | None, ...]
 ```
 
-### 5.6 `MarkerCorrelation`
+### 5.9 `MarkerCorrelation`
 
 ```python
 @dataclass(frozen=True)
 class MarkerCorrelation:
     marker_name: str
     pattern_ids: tuple[str, ...]            # which CommandPatterns appear near this marker
+    correlation_percent: float
     mean_time_delta_ms: float               # average offset between marker and first pattern packet
 ```
 
-### 5.7 MCP Tool Output
+### 5.10 MCP Tool Output
 
-The engine result is returned from a new MCP tool `analyze_protocol`. The tool returns
-a `ProtocolHypothesis` serialized as a typed dict (following the existing pattern in
-`bsu_tool/mcp/interfaces.py`). Claude receives this and uses it to draft a human-readable
-protocol description.
+The engine result is returned from a new MCP tool `analyze_protocol`. The tool accepts an
+optional `device_id` filter. If `device_id` is omitted, it returns one
+`ProtocolHypothesis` per device, matching the broad/default behavior of `get_packets`.
+If `device_id` is provided, it returns only that device's hypothesis.
+
+The MCP response must be machine-readable JSON. Dataclasses may be used internally, but
+the MCP wrapper should serialize the result through typed, JSON-friendly models following
+the existing pattern in `bsu_tool/mcp/interfaces.py`. Claude receives this structured
+JSON and uses it to draft a human-readable protocol description.
 
 ---
 
@@ -291,10 +399,14 @@ protocol description.
 | Case | Handling |
 |------|----------|
 | No markers in capture | Proceed without correlation; `marker_correlations` is empty; emit analysis note |
-| Sequence seen only once | Not reported as a `CommandPattern`; minimum is 2 occurrences |
+| Sequence seen only once | Not reported as a `CommandPattern`; may be reported as `AnalysisObservation` if marker-adjacent, startup-related, or a long OUT/IN exchange |
 | Fewer than 3 packets for normalization | All bytes treated as fixed; no variable byte detection |
+| Sub-pattern has same count as parent | Drop shorter sub-pattern as redundant |
+| Sub-pattern occurs more than parent | Keep both; shorter pattern may represent optional protocol steps |
 | OUT with no IN response | Recorded as `UnansweredCommand`; not treated as error |
 | IN with no preceding OUT | Recorded as `UnsolicitedResponse`; device may be pushing status |
+| OUT and IN use same endpoint number with opposite directions | Pair as likely command/response, e.g. `0x01` OUT and `0x81` IN |
+| OUT and IN use different endpoint numbers | Preserve as multi-step pattern; do not force into simple pair |
 | Overlapping marker windows | Occurrence assigned to the single nearest marker by timestamp |
 | Multiple devices in capture | Engine runs independently per device; results are separate `ProtocolHypothesis` objects |
 | All-zero payload | Treated as a valid payload; not filtered out |
@@ -311,9 +423,10 @@ All tunable values are named constants in the engine module (not magic numbers):
 | Constant | Default | Meaning |
 |----------|---------|---------|
 | `MIN_NORMALIZATION_SAMPLE_COUNT` | 3 | Minimum packets needed to detect variable bytes |
-| `MAX_SEQUENCE_WINDOW` | 4 | Maximum token sequence length to search for |
+| `MAX_SEQUENCE_WINDOW` | 8 | Maximum token sequence length to search for; configurable per analysis run |
 | `MIN_OCCURRENCE_COUNT` | 2 | Minimum occurrences for a pattern to be reported |
-| `MARKER_CORRELATION_WINDOW_SECONDS` | 2.0 | Max time delta to associate a packet with a marker |
+| `MARKER_CORRELATION_WINDOW_SECONDS` | 2.0 | Max time delta to associate a packet with a marker; configurable per analysis run |
+| `MARKER_CORRELATION_THRESHOLD_PERCENT` | 50.0 | Default percentage needed to call out a marker association; raw percentage is always reported |
 | `COMMAND_RESPONSE_TIMEOUT_SECONDS` | 5.0 | Max capture-time gap to pair OUT→IN |
 | `MAX_VARIABLE_VALUES_REPORTED` | 32 | Cap on distinct values stored per variable byte |
 
@@ -337,17 +450,28 @@ Tests go in:
 
 ---
 
+## Review Decisions
+
+1. **Sequence window size** — default `MAX_SEQUENCE_WINDOW` is 8 and must be configurable
+   per analysis run so unknown vendor devices are not truncated by a hardcoded small
+   window.
+
+2. **Marker correlation threshold** — default threshold is 50%, configurable per analysis
+   run. Results report the actual correlation percentage so analysts can evaluate
+   borderline matches.
+
+3. **Response time reporting** — report median, min, max, and mean. Median should be the
+   lead statistic in human summaries because USB jitter and retries can skew mean.
+
+4. **Multi-device handling** — `analyze_protocol` returns all devices by default and
+   accepts an optional `device_id` filter, matching the shape of `get_packets`.
+
 ## Open Questions for Team Review
 
-1. **Sequence window size** — is a max of 4 tokens per sequence sufficient? USB
-   command sequences for relay boards tend to be 1–3 packets, but unknown devices
-   may use longer sequences.
+1. **Single-occurrence observations** — are the three proposed criteria for preserving
+   one-time handshakes enough, or should the team define additional rules for startup
+   traffic before implementation?
 
-2. **Marker correlation threshold** — should 50% match be enough to call a sequence
-   "correlated" with a marker, or should we require a higher threshold?
-
-3. **Response time reporting** — mean is simple but can be skewed by outliers. Should
-   we also report median or min/max?
-
-4. **Multi-device handling** — should `analyze_protocol` accept an optional `device_id`
-   filter, or always return results for all devices and let Claude filter?
+2. **Control-transfer runtime commands** — should default analysis continue to exclude
+   all Control transfers, or should the engine include an optional mode for devices that
+   use vendor-specific Control transfers after enumeration?

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -257,10 +257,11 @@ to captured packet sequences ("these 3 packets always appear within 2 seconds of
 
 ### 4.1 Command/Response Pairing
 
-A **command/response pair** links an OUT transaction (host→device) to the IN transaction
-(device→host) that follows it on the same device and endpoint number. This is a
-best-effort label for common Bulk/Interrupt runtime traffic; the full pattern detector
-still preserves multi-step and cross-endpoint sequences through `CommandPattern.steps`.
+A **command/response pair** links an OUT analysis event (host→device) derived from one
+`UrbTransaction` to a later IN analysis event (device→host) derived from a separate
+`UrbTransaction` on the same device and endpoint number. This is a best-effort label for
+common Bulk/Interrupt runtime traffic; the full pattern detector still preserves
+multi-step and cross-endpoint sequences through `CommandPattern.steps`.
 
 The engine must start from the existing `UrbTransaction` objects created by
 `pair_urbs()`. It must not rebuild submit/complete pairs with a FIFO queue because USB
@@ -271,17 +272,28 @@ URB id, including orphan submissions and orphan completions.
 **Algorithm:**
 
 For each endpoint lane, process available `UrbTransaction` objects in timestamp order:
-1. Convert each transaction into an analysis event using the submission record for direction
-   and the completion record for status and payload data.
+1. Convert each transaction into zero or one payload-bearing analysis event:
+   - For OUT transfers, use the submission record as the command payload evidence.
+   - For IN transfers, use the completion record as the response payload evidence.
+   - Carry completion/error status into the event when a matching completion/error exists.
+   - If the needed payload-bearing side is missing, record an `IncompleteTransfer` and do
+     not promote the transaction directly into a protocol-level command or response.
 2. Keep failed transactions visible to this pass so retries and failed responses affect
    timing and notes, even if they are not promoted into successful command patterns.
-3. When a transaction's submission is an OUT event and its completion is an IN event on
-   the same endpoint lane, record it as a likely command/response pair.
-4. If a transaction has an orphan completion with no matching submission, record it as an
-   **unsolicited response** unless it is explained by a failed transaction.
-5. If a transaction has an orphan submission with no matching completion within the
+3. When a successful OUT analysis event is followed by a successful IN analysis event on
+   the same endpoint lane within the configurable timeout window, record those separate
+   events as a likely command/response pair.
+4. If an IN analysis event has no preceding compatible OUT analysis event within the
+   protocol pairing window, record it as an **unsolicited response** unless it is explained
+   by failed traffic or an incomplete transfer at a capture boundary.
+5. If an OUT analysis event has no following compatible IN analysis event within the
    configurable timeout window, record it as an **unanswered command** unless it is
-   explained by a failed transaction.
+   explained by failed traffic or an incomplete transfer at a capture boundary.
+
+The engine must not classify a transaction as a command/response pair because its own
+submission and completion have opposite directions. A single `UrbTransaction` represents one
+URB id lifecycle, while command/response inference is a protocol-level relationship between
+separate directional analysis events.
 
 **Endpoint scope:** pairing is scoped by device and endpoint number. An OUT on endpoint
 `0x01` may pair with an IN on endpoint `0x81` because both refer to endpoint number 1
@@ -315,6 +327,7 @@ class ProtocolHypothesis:
     observations: tuple[AnalysisObservation, ...]
     unsolicited_responses: tuple[UnsolicitedResponse, ...]
     unanswered_commands: tuple[UnansweredCommand, ...]
+    incomplete_transfers: tuple[IncompleteTransfer, ...]
     marker_correlations: tuple[MarkerCorrelation, ...]
     result_limits: ResultLimits
     analysis_notes: tuple[str, ...]         # free-text warnings from the engine
@@ -430,7 +443,24 @@ class UnansweredCommand:
     payload_signature: tuple[int | None, ...]
 ```
 
-### 5.10 `MarkerCorrelation`
+### 5.10 `IncompleteTransfer`
+
+```python
+@dataclass(frozen=True)
+class IncompleteTransfer:
+    endpoint_number: int
+    endpoint_address: str
+    direction: Direction
+    transfer_type: TransferType
+    reason: Literal["orphan_submission", "orphan_completion", "missing_payload_side"]
+    occurrence_count: int
+```
+
+Incomplete transfers report neutral capture-boundary or malformed-lifecycle evidence from
+`UrbTransaction` pairing. They can help explain missing protocol pairs, but they are not
+themselves sufficient evidence for `UnsolicitedResponse` or `UnansweredCommand`.
+
+### 5.11 `MarkerCorrelation`
 
 ```python
 @dataclass(frozen=True)
@@ -446,7 +476,7 @@ class MarkerCorrelation:
 `CommandPattern` references it by `marker_correlation_id` so marker names and percentages
 cannot disagree across two output locations.
 
-### 5.11 MCP Tool Output
+### 5.12 MCP Tool Output
 
 The engine result is returned from a new MCP tool `analyze_protocol`. The tool accepts an
 optional `device_id` filter. If `device_id` is omitted, it returns one
@@ -470,8 +500,10 @@ JSON and uses it to draft a human-readable protocol description.
 | One packet for normalization | All bytes treated as fixed; no variable byte detection |
 | Sub-pattern has same count as parent | Drop shorter sub-pattern as redundant |
 | Sub-pattern occurs more than parent | Keep both; shorter pattern may represent optional protocol steps |
-| OUT with no IN response | Recorded as `UnansweredCommand`; not treated as error |
-| IN with no preceding OUT | Recorded as `UnsolicitedResponse`; device may be pushing status |
+| OUT analysis event with no following IN response candidate | Recorded as `UnansweredCommand`; not treated as error |
+| IN analysis event with no preceding OUT candidate | Recorded as `UnsolicitedResponse`; device may be pushing status |
+| Orphan submission | Recorded as `IncompleteTransfer`; does not by itself imply an unanswered protocol command |
+| Orphan completion | Recorded as `IncompleteTransfer`; does not by itself imply an unsolicited protocol response |
 | OUT and IN use same endpoint number with opposite directions | Pair as likely command/response, e.g. `0x01` OUT and `0x81` IN |
 | OUT and IN use different endpoint numbers | Preserve as separate endpoint-lane patterns or `AnalysisObservation`; do not force into simple pair |
 | Background endpoint traffic interleaves with command traffic | Analyze per endpoint lane by default so unrelated polling does not contaminate n-gram windows |
@@ -525,7 +557,8 @@ human narrative. Expected assertions:
   requested Goodix device.
 - `result_limits` is present and reports the configured caps.
 - `command_patterns`, `observations`, `marker_correlations`, `analysis_notes`,
-  `unsolicited_responses`, and `unanswered_commands` are present even when empty.
+  `unsolicited_responses`, `unanswered_commands`, and `incomplete_transfers` are present
+  even when empty.
 - every returned `CommandPattern` has at least one `PatternStep`, no more than
   `MAX_SEQUENCE_WINDOW` steps, and JSON-safe payload signatures.
 - if result caps are exceeded, truncation flags and a truncation note are present.

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -69,6 +69,33 @@ The engine operates only on:
 
 Isochronous transfers are excluded at load time and never reach the engine.
 
+### 1.3 Device Context Input
+
+The engine accepts a `DeviceContext` for each device under analysis. Required within the
+analyzers input to strengthen the protocol inference.
+
+```python
+@dataclass(frozen=True)
+class DeviceContext:
+    device_id: str
+    vendor_id: int | None
+    product_id: int | None
+    manufacturer: str | None
+    product: str | None
+    device_class: int | None
+    interfaces: tuple[InterfaceContext, ...] # for the class/subclass/protocol per interface
+    endpoints: tuple[EndpointContext, ...]   # address, direction, transfer type,
+                                             # wMaxPacketSize, bInterval
+                                             # for example: "CH340 USB-serial bridge",
+                                             # "binds kernel driver ch341:
+
+    known_properties: tuple[Str, ...]
+```
+
+`DeviceContext` is built from decoded enumeration descriptors that our `Session.get_enumeration()` 
+already recovers. When a capture does not contain enumeration traffic, context is partial and the 
+engine must emit `analysis_note` saying so and naming which fields were unavailable.
+
 ---
 
 ## 2. Token Normalization
@@ -233,8 +260,12 @@ always produce identical signatures.
 Two captures of the same device should produce the same signature for the same command when
 that command's selected normalization group has the same fixed and variable byte positions in
 both captures. This stability is desirable because it lets analysts compare repeated
-behavior across captures. If unrelated commands produce the same signature, that is an
-over-merging failure and should be avoided by narrower grouping or reported through
+behavior across captures. A command with enough samples at one length in capture A but split
+across lengths in capture B can legitimately classify as `"full"` in one capture and `"prefix"` 
+in the other, producing different signatures for the same physical command. `signature_mode` 
+makes this explicit rather than silent, and cross-capture comparison in that case should use 
+only the first `PREFIX_SIGNATURE_BYTES` bytes. If unrelated commands produce the same signature, 
+that is an over-merging failure and should be avoided by narrower grouping or reported through
 `analysis_notes`. Truncating a capture only changes a signature when the truncation removes
 packets from that command's own full, prefix, or full-prefix group. Packets on other
 endpoints, other devices, other transfer types, or other active header groups do not affect
@@ -292,7 +323,8 @@ discarded silently either.
 Single-occurrence sequences are reported as `AnalysisObservation` objects when they meet
 one of these criteria:
 - The sequence occurs within the marker correlation window of an analyst marker.
-- The sequence is a multi-step exchange that does not repeat but contains at least `MIN_OBSERVATION_STEPS` steps with both OUT and IN traffic on the same device.
+- The sequence is a multi-step exchange that does not repeat but contains at least
+  `MIN_OBSERVATION_STEPS` steps with both OUT and IN traffic on the same device.
 
 This keeps the main `command_patterns` list focused on repeated evidence while preserving
 important one-time behavior for analyst review.
@@ -370,14 +402,19 @@ If a device sends commands and responses on different endpoint numbers, those ev
 not forced into a simple command/response pair. They remain visible as separate endpoint
 lane patterns or as `AnalysisObservation` entries for analyst review.
 
-### 4.2 Control Transfer Exclusion
+### 4.2 Control Transfer Handling
 
-Control transactions (endpoint 0, used for enumeration and device setup) are excluded
-from runtime command/response pairing and repeated pattern detection. Descriptor-related
-control traffic is already summarized through `list_devices`. If later validation shows
-vendor-specific devices use post-enumeration control transfers for meaningful commands,
-that can be added as a separate analyzer mode rather than mixed into the default
-Bulk/Interrupt workflow.
+Standard Control transfers (enumeration and device setup) are excluded from runtime
+command/response pairing and repeated pattern detection. They are summarized through
+`list_devices` and `DeviceContext`.
+
+Vendor-specific Control transfers (`bmRequestType` type field = vendor) that occur
+**after** enumeration are not protocol noise. For USB-serial bridges and similar
+devices they carry the vendor protocol itself. The engine must count them and report
+them in `analysis_notes`, for example: "14 vendor-specific control transfers seen
+after enumeration on ep0 (requests 0x9A, 0xA1, 0xA4); not included in pattern
+detection." Full analysis of vendor control transfers is deferred to a follow-up
+issue.
 
 ---
 
@@ -430,6 +467,9 @@ class CommandPattern:
     response_timing: ResponseTimingStats | None
     parent_pattern_id: str | None           # set only when retained as an optional sub-pattern
     marker_correlation_id: str | None       # references MarkerCorrelation.correlation_id
+    first_occurrence_timestamp: float       # capture time of 1st occurence
+    first_packet_index: int                 # index into Capture.records
+    low_confidence: bool                    # should be True when occurence_count == 2
 ```
 
 ### 5.4 `PatternStep`
@@ -565,8 +605,12 @@ If `device_id` is provided, it returns only that device's hypothesis.
 
 The MCP response must be machine-readable JSON. Dataclasses may be used internally, but
 the MCP wrapper should serialize the result through typed, JSON-friendly models following
-the existing pattern in `bsu_tool/mcp/interfaces.py`. Claude receives this structured
-JSON and uses it to draft a human-readable protocol description.
+the existing pattern in `bsu_tool/mcp/interfaces.py`. The response also includes the `DeviceContext`,
+so Claude can reason about the device and bytes in tandem. 
+
+**Division of labor for prose:** the engine emits a short, deterministic, snapshot-testable summary 
+(counts, pattern ids, headline finding). Claude receives this structured JSON and drafts the full 
+human-readable protocol description. The engine does not attempt narrative prose.
 
 ---
 
@@ -654,7 +698,21 @@ human narrative. Expected assertions:
 - `UnsolicitedResponse` and `UnansweredCommand` entries include first/last occurrence
   indices and timestamps so analysts can locate the evidence in the capture.
 - if result caps are exceeded, truncation flags and a truncation note are present.
+- Content assertions (these must fail on an empty or degenerate result):
+- at least one `CommandPattern` is returned for the Goodix device, with
+  `occurrence_count >= 2`
+- at least one returned `CommandPattern` has more than one `PatternStep`
+- no returned `payload_signature` is entirely `None` (an all-variable signature means
+  normalization erased the command identity)
+- the distinct token count is greater than 1% of the analysis event count (a tripwire
+  for the over-merge failure mode in §2.3)
 
+A second integration test, `tests/int/test_mcp_analyze_relay.py`, runs against the
+CH340 relay capture (to be committed):
+- the six-step toggle sequence is detected as a single `CommandPattern` with
+  `occurrence_count >= 2`
+- at least one `PatternStep` has a variable byte whose observed values include more
+  than one distinct value (the relay channel selector)
 ---
 
 ## Review Decisions
@@ -677,13 +735,3 @@ human narrative. Expected assertions:
    (marker-adjacent and multi-step exchange with `MIN_OBSERVATION_STEPS`) as sufficient
    for initial implementation. Additional computable rules should be defined only after
    validation against reference captures confirms meaningful observations are being dropped.
-
-## Open Questions for Team Review
-
-1. **Single-occurrence observations** — are the two proposed criteria for preserving
-   one-time handshakes enough, or should the team define additional computable rules
-   before implementation?
-
-2. **Control-transfer runtime commands** — should default analysis continue to exclude
-   all Control transfers, or should the engine include an optional mode for devices that
-   use vendor-specific Control transfers after enumeration?

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -170,6 +170,9 @@ analysis event stream for a given device. In this document, a sequence becomes a
 ordered tokens found by the algorithm; "pattern" describes that sequence plus metadata
 such as occurrence count, marker correlation, and response-time statistics.
 
+Sequence detection uses n-gram frequency analysis: a sliding window extracts all
+sub-sequences of each length and counts occurrences across the token stream.
+
 **Algorithm:**
 
 1. Flatten all analysis events for a device into an ordered list of tokens (by timestamp).
@@ -213,7 +216,7 @@ Each detected sequence is correlated with analyst markers:
 2. If the nearest marker is within a configurable window (default **2.0 seconds**),
    the occurrence is tagged with that marker's name.
 3. Compute the percentage of occurrences near each marker name.
-4. A sequence is **marker-correlated** by default if ≥ 50% of its occurrences are near
+4. A sequence is **marker-correlated** by default if ≥ 70% of its occurrences are near
    the same marker name, but the raw percentage is always reported so analysts can judge
    borderline cases.
 
@@ -426,7 +429,7 @@ All tunable values are named constants in the engine module (not magic numbers):
 | `MAX_SEQUENCE_WINDOW` | 8 | Maximum token sequence length to search for; configurable per analysis run |
 | `MIN_OCCURRENCE_COUNT` | 2 | Minimum occurrences for a pattern to be reported |
 | `MARKER_CORRELATION_WINDOW_SECONDS` | 2.0 | Max time delta to associate a packet with a marker; configurable per analysis run |
-| `MARKER_CORRELATION_THRESHOLD_PERCENT` | 50.0 | Default percentage needed to call out a marker association; raw percentage is always reported |
+| `MARKER_CORRELATION_THRESHOLD_PERCENT` | 70.0 | Default percentage needed to call out a marker association; raw percentage is always reported |
 | `COMMAND_RESPONSE_TIMEOUT_SECONDS` | 5.0 | Max capture-time gap to pair OUT→IN |
 | `MAX_VARIABLE_VALUES_REPORTED` | 32 | Cap on distinct values stored per variable byte |
 
@@ -456,7 +459,7 @@ Tests go in:
    per analysis run so unknown vendor devices are not truncated by a hardcoded small
    window.
 
-2. **Marker correlation threshold** — default threshold is 50%, configurable per analysis
+2. **Marker correlation threshold** — default threshold is 70%, configurable per analysis
    run. Results report the actual correlation percentage so analysts can evaluate
    borderline matches.
 

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -83,17 +83,21 @@ Normalization is the boundary between decoded USB evidence and protocol inferenc
 should preserve enough packet-level detail for human validation while removing noise that
 would prevent repeated behavior from matching.
 
-The preprocessing layer has four goals:
-1. **Filter analysis scope:** keep successful Bulk and Interrupt records; exclude Control
-   setup traffic and failed URBs from pattern detection while still reporting exclusions in
-   `analysis_notes`.
-2. **Create directional analysis events:** split paired `UrbTransaction` objects into the
+The preprocessing layer has five goals:
+1. **Filter promotion scope:** keep Bulk and Interrupt records as candidate runtime
+   traffic; exclude Control setup traffic from default pattern promotion while still
+   reporting exclusions in `analysis_notes`.
+2. **Preserve URB status:** failed URBs remain visible during pairing and timing analysis
+   so retries, failed OUTs, and failed INs do not turn into false `UnansweredCommand` or
+   `UnsolicitedResponse` results. Failed URBs are excluded only when promoting successful
+   repeated patterns.
+3. **Create directional analysis events:** split paired `UrbTransaction` objects into the
    individual IN/OUT records that carry payload data, so multi-step sequences can be
    compared one token at a time.
-3. **Group comparable events:** group by device, endpoint number, direction, transfer type,
+4. **Group comparable events:** group by device, endpoint number, direction, transfer type,
    and payload length. Endpoint number and direction stay separate because decoded
    `UrbRecord` already stores them separately.
-4. **Classify payload bytes:** within each group, identify fixed bytes that define command
+5. **Classify payload bytes:** within each group, identify fixed bytes that define command
    identity and variable bytes that likely represent arguments, counters, checksums, or
    response data.
 
@@ -147,9 +151,13 @@ Example: if three packets of length 4 have bytes `[0x01, 0x00, 0x05, 0xA1]`,
 `(0x01, 0x00, None, None)` — bytes 0 and 1 are fixed, bytes 2 and 3 vary.
 
 **Step 4 — Minimum sample threshold.**
-Variable/fixed classification requires a minimum of **3 packets** with the same
-endpoint+direction+length. With fewer samples, all bytes are treated as fixed (no
-variable detection). This threshold is a named constant and can be tuned.
+Variable/fixed classification supports a provisional two-sample mode. With **2 packets**
+in the same endpoint+direction+length group, byte positions that differ are treated as
+variable and byte positions that match are treated as fixed. With **3 or more packets**,
+the same rule becomes more reliable because there are enough samples to distinguish
+stable identity bytes from counters, checksums, or arguments with less risk of overfitting.
+This prevents commands seen exactly twice from disappearing simply because one byte varies.
+The threshold is a named constant and can be tuned.
 
 ### 2.4 When Normalization Runs
 
@@ -157,6 +165,19 @@ Normalization is a two-pass process:
 1. **First pass:** collect all packets per (endpoint, direction, length) group, compute
    variable byte positions
 2. **Second pass:** assign each analysis event its token using the variable map from pass 1
+
+### 2.5 Determinism Guarantee
+
+A token's `payload_signature` is computed only from packets sharing its
+`(device_id, endpoint_number, direction, transfer_type, len(data))` group, processed in
+ascending capture order. The variable-byte map is therefore a pure function of that group.
+Two runs over the same capture always produce identical signatures.
+
+Two captures of the same device produce identical signatures for a command when that
+command's group has the same fixed and variable byte positions in both captures. Truncating
+a capture only changes a signature when the truncation removes packets from that command's
+own group. Packets on other endpoints, other devices, or other payload lengths do not
+affect the signature.
 
 ---
 
@@ -171,18 +192,26 @@ ordered tokens found by the algorithm; "pattern" describes that sequence plus me
 such as occurrence count, marker correlation, and response-time statistics.
 
 Sequence detection uses n-gram frequency analysis: a sliding window extracts all
-sub-sequences of each length and counts occurrences across the token stream.
+sub-sequences of each length and counts occurrences across scoped token streams.
+
+The default scope is an **endpoint lane**: one device, one endpoint number, and one
+transfer type, with IN and OUT events for that endpoint number kept in the same
+timestamp-ordered stream. This keeps background traffic on unrelated endpoints from
+contaminating command traffic while still allowing common OUT/IN exchanges such as
+`0x01` OUT followed by `0x81` IN to appear in one sequence.
 
 **Algorithm:**
 
-1. Flatten all analysis events for a device into an ordered list of tokens (by timestamp).
-2. Use a sliding window of width `w` (minimum 1, maximum configurable, default 8) to
+1. Partition analysis events into endpoint lanes by `(device_id, endpoint_number,
+   transfer_type)`.
+2. Sort each lane by timestamp.
+3. Use a sliding window of width `w` (minimum 1, maximum configurable, default 8) to
    extract all sub-sequences of each length.
-3. Hash each sub-sequence and count occurrences.
-4. A sequence that occurs **≥ 2 times** is a repeated candidate pattern.
-5. Prefer longer patterns over their sub-sequences: if pattern `[A, B, C]` covers
+4. Hash each sub-sequence and count occurrences within that lane.
+5. A sequence that occurs **≥ 2 times** is a repeated candidate pattern.
+6. Prefer longer patterns over their sub-sequences: if pattern `[A, B, C]` covers
    every occurrence of `[A, B]`, discard `[A, B]` as a redundant sub-pattern.
-6. Sort candidates by occurrence count descending.
+7. Sort candidates by occurrence count descending.
 
 Subsumed shorter patterns are dropped only when their occurrence count exactly matches
 the longer parent pattern. If `[A, B]` occurs more often than `[A, B, C]`, keep both
@@ -197,16 +226,20 @@ discarded silently either.
 Single-occurrence sequences are reported as `AnalysisObservation` objects when they meet
 one of these criteria:
 - The sequence occurs within the marker correlation window of an analyst marker.
-- The sequence appears near the beginning of runtime traffic after enumeration.
 - The sequence is a long multi-step exchange that does not repeat but includes both OUT
   and IN traffic on the same device.
 
 This keeps the main `command_patterns` list focused on repeated evidence while preserving
 important one-time behavior for analyst review.
 
-**Complexity note:** With N analysis events and window size W, this is O(N × W). For
-typical captures (hundreds to low thousands of packets), this is fast enough for
-synchronous execution. No async or streaming required.
+The engine does not infer an "end of enumeration" boundary by default because Control
+transfers are excluded from the default runtime analysis path. If the team later wants a
+boundary-based observation rule, the loader or analyzer must first expose an explicit
+enumeration-end timestamp.
+
+**Complexity note:** With N analysis events and window size W across all endpoint lanes,
+this is O(N × W). For typical captures (hundreds to low thousands of packets), this is
+fast enough for synchronous execution. No async or streaming required.
 
 ### 3.3 Marker Correlation
 
@@ -235,15 +268,25 @@ A **command/response pair** links an OUT transaction (host→device) to the IN t
 best-effort label for common Bulk/Interrupt runtime traffic; the full pattern detector
 still preserves multi-step and cross-endpoint sequences through `CommandPattern.steps`.
 
+The engine must start from the existing `UrbTransaction` objects created by
+`pair_urbs()`. It must not rebuild submit/complete pairs with a FIFO queue because USB
+allows multiple outstanding URBs and completions are not guaranteed to arrive in submit
+order. `UrbTransaction` already preserves the actual submit/complete relationship by
+URB id, including orphan submissions and orphan completions.
+
 **Algorithm:**
 
-For each device and endpoint number, process transactions in timestamp order:
-1. When an OUT transaction is seen, push it onto a pending command queue.
-2. When an IN transaction is seen, pop the oldest pending OUT from the queue and pair them.
-3. If no pending OUT exists when an IN arrives, the IN is an **unsolicited response**
-   (recorded as such, not discarded).
-4. If a pending OUT has no IN follow-up within a configurable timeout window (default
-   **5.0 seconds** of capture time, not wall time), it is an **unanswered command**.
+For each endpoint lane, process available `UrbTransaction` objects in timestamp order:
+1. Convert each transaction into an analysis event using the record that carries payload
+   data and status information.
+2. Keep failed transactions visible to this pass so retries and failed responses affect
+   timing and notes, even if they are not promoted into successful command patterns.
+3. When an OUT event is followed by an IN event on the same endpoint lane within the
+   configurable timeout window, record it as a likely command/response pair.
+4. If an IN event has no preceding successful OUT candidate in the timeout window, record
+   it as an **unsolicited response** unless it is explained by a failed transaction.
+5. If an OUT event has no following successful IN candidate in the timeout window, record
+   it as an **unanswered command** unless it is explained by a failed transaction.
 
 **Endpoint scope:** pairing is scoped by device and endpoint number. An OUT on endpoint
 `0x01` may pair with an IN on endpoint `0x81` because both refer to endpoint number 1
@@ -251,8 +294,8 @@ with opposite directions. Pairing by full endpoint address would miss this commo
 command/response shape.
 
 If a device sends commands and responses on different endpoint numbers, those events are
-not forced into a simple command/response pair. They remain visible as adjacent
-`PatternStep` entries in a detected `CommandPattern`.
+not forced into a simple command/response pair. They remain visible as separate endpoint
+lane patterns or as `AnalysisObservation` entries for analyst review.
 
 ### 4.2 Control Transfer Exclusion
 
@@ -278,10 +321,31 @@ class ProtocolHypothesis:
     unsolicited_responses: tuple[UnsolicitedResponse, ...]
     unanswered_commands: tuple[UnansweredCommand, ...]
     marker_correlations: tuple[MarkerCorrelation, ...]
+    result_limits: ResultLimits
     analysis_notes: tuple[str, ...]         # free-text warnings from the engine
 ```
 
-### 5.2 `CommandPattern`
+### 5.2 `ResultLimits`
+
+```python
+@dataclass(frozen=True)
+class ResultLimits:
+    max_command_patterns: int
+    max_observations: int
+    max_variable_values_reported: int
+    command_patterns_truncated: bool
+    observations_truncated: bool
+    truncation_note: str | None
+```
+
+The analyzer must rank results before truncation so MCP output stays token-frugal.
+Command patterns are sorted by marker correlation, occurrence count, sequence length, and
+then first occurrence timestamp. Observations are sorted by marker proximity, sequence
+length, and first occurrence timestamp. If truncation occurs, the returned JSON must set
+the relevant `*_truncated` flag and include a short `truncation_note` in both
+`result_limits` and `analysis_notes`.
+
+### 5.3 `CommandPattern`
 
 ```python
 @dataclass(frozen=True)
@@ -291,11 +355,10 @@ class CommandPattern:
     steps: tuple[PatternStep, ...]          # ordered, length 1..MAX_SEQUENCE_WINDOW
     response_timing: ResponseTimingStats | None
     parent_pattern_id: str | None           # set only when retained as an optional sub-pattern
-    nearest_marker: str | None              # marker name if correlated
-    marker_correlation_percent: float | None
+    marker_correlation_id: str | None       # references MarkerCorrelation.correlation_id
 ```
 
-### 5.3 `PatternStep`
+### 5.4 `PatternStep`
 
 ```python
 @dataclass(frozen=True)
@@ -309,7 +372,7 @@ class PatternStep:
     variable_byte_ranges: tuple[VariableByteRange, ...]
 ```
 
-### 5.4 `ResponseTimingStats`
+### 5.5 `ResponseTimingStats`
 
 ```python
 @dataclass(frozen=True)
@@ -323,13 +386,13 @@ class ResponseTimingStats:
 These timing values are only meaningful for patterns whose steps include an OUT event
 followed by an IN event that the pairing algorithm identifies as a likely response.
 
-### 5.5 `AnalysisObservation`
+### 5.6 `AnalysisObservation`
 
 ```python
 @dataclass(frozen=True)
 class AnalysisObservation:
     observation_id: str                     # e.g. "observation_01"
-    reason: str                             # e.g. "near_marker" or "startup_exchange"
+    reason: str                             # e.g. "near_marker" or "single_exchange"
     steps: tuple[PatternStep, ...]
     nearest_marker: str | None
 ```
@@ -337,7 +400,7 @@ class AnalysisObservation:
 Observations preserve meaningful single-occurrence behavior without weakening the
 definition of repeated command patterns.
 
-### 5.6 `VariableByteRange`
+### 5.7 `VariableByteRange`
 
 ```python
 @dataclass(frozen=True)
@@ -348,7 +411,7 @@ class VariableByteRange:
     observed_values: tuple[int, ...]        # all distinct values seen (capped at 32)
 ```
 
-### 5.7 `UnsolicitedResponse`
+### 5.8 `UnsolicitedResponse`
 
 ```python
 @dataclass(frozen=True)
@@ -360,7 +423,7 @@ class UnsolicitedResponse:
     payload_signature: tuple[int | None, ...]
 ```
 
-### 5.8 `UnansweredCommand`
+### 5.9 `UnansweredCommand`
 
 ```python
 @dataclass(frozen=True)
@@ -372,18 +435,23 @@ class UnansweredCommand:
     payload_signature: tuple[int | None, ...]
 ```
 
-### 5.9 `MarkerCorrelation`
+### 5.10 `MarkerCorrelation`
 
 ```python
 @dataclass(frozen=True)
 class MarkerCorrelation:
+    correlation_id: str                     # e.g. "marker_corr_01"
     marker_name: str
     pattern_ids: tuple[str, ...]            # which CommandPatterns appear near this marker
     correlation_percent: float
     mean_time_delta_ms: float               # average offset between marker and first pattern packet
 ```
 
-### 5.10 MCP Tool Output
+`MarkerCorrelation` is the authoritative source for marker-correlation details. A
+`CommandPattern` references it by `marker_correlation_id` so marker names and percentages
+cannot disagree across two output locations.
+
+### 5.11 MCP Tool Output
 
 The engine result is returned from a new MCP tool `analyze_protocol`. The tool accepts an
 optional `device_id` filter. If `device_id` is omitted, it returns one
@@ -402,19 +470,21 @@ JSON and uses it to draft a human-readable protocol description.
 | Case | Handling |
 |------|----------|
 | No markers in capture | Proceed without correlation; `marker_correlations` is empty; emit analysis note |
-| Sequence seen only once | Not reported as a `CommandPattern`; may be reported as `AnalysisObservation` if marker-adjacent, startup-related, or a long OUT/IN exchange |
-| Fewer than 3 packets for normalization | All bytes treated as fixed; no variable byte detection |
+| Sequence seen only once | Not reported as a `CommandPattern`; may be reported as `AnalysisObservation` if marker-adjacent or a long OUT/IN exchange |
+| Two packets for normalization | Differing byte positions are provisionally treated as variable so twice-seen commands can still match |
+| One packet for normalization | All bytes treated as fixed; no variable byte detection |
 | Sub-pattern has same count as parent | Drop shorter sub-pattern as redundant |
 | Sub-pattern occurs more than parent | Keep both; shorter pattern may represent optional protocol steps |
 | OUT with no IN response | Recorded as `UnansweredCommand`; not treated as error |
 | IN with no preceding OUT | Recorded as `UnsolicitedResponse`; device may be pushing status |
 | OUT and IN use same endpoint number with opposite directions | Pair as likely command/response, e.g. `0x01` OUT and `0x81` IN |
-| OUT and IN use different endpoint numbers | Preserve as multi-step pattern; do not force into simple pair |
+| OUT and IN use different endpoint numbers | Preserve as separate endpoint-lane patterns or `AnalysisObservation`; do not force into simple pair |
+| Background endpoint traffic interleaves with command traffic | Analyze per endpoint lane by default so unrelated polling does not contaminate n-gram windows |
 | Overlapping marker windows | Occurrence assigned to the single nearest marker by timestamp |
 | Multiple devices in capture | Engine runs independently per device; results are separate `ProtocolHypothesis` objects |
 | All-zero payload | Treated as a valid payload; not filtered out |
 | Empty capture (no bulk/interrupt packets) | Return empty `ProtocolHypothesis` with analysis note explaining why |
-| Status != 0 (failed URB) | Failed URBs are excluded from pattern detection; counted and reported in `analysis_notes` |
+| Status != 0 (failed URB) | Failed URBs remain visible to pairing/timing and retry notes, but are not promoted into successful repeated patterns |
 | Capture with only control transfers | All packets excluded from engine scope; empty result with note |
 
 ---
@@ -425,13 +495,15 @@ All tunable values are named constants in the engine module (not magic numbers):
 
 | Constant | Default | Meaning |
 |----------|---------|---------|
-| `MIN_NORMALIZATION_SAMPLE_COUNT` | 3 | Minimum packets needed to detect variable bytes |
+| `MIN_NORMALIZATION_SAMPLE_COUNT` | 2 | Minimum packets needed for provisional variable-byte detection |
 | `MAX_SEQUENCE_WINDOW` | 8 | Maximum token sequence length to search for; configurable per analysis run |
 | `MIN_OCCURRENCE_COUNT` | 2 | Minimum occurrences for a pattern to be reported |
 | `MARKER_CORRELATION_WINDOW_SECONDS` | 2.0 | Max time delta to associate a packet with a marker; configurable per analysis run |
 | `MARKER_CORRELATION_THRESHOLD_PERCENT` | 70.0 | Default percentage needed to call out a marker association; raw percentage is always reported |
 | `COMMAND_RESPONSE_TIMEOUT_SECONDS` | 5.0 | Max capture-time gap to pair OUT→IN |
 | `MAX_VARIABLE_VALUES_REPORTED` | 32 | Cap on distinct values stored per variable byte |
+| `MAX_COMMAND_PATTERNS_RETURNED` | 20 | Cap on ranked command patterns returned in one MCP response |
+| `MAX_OBSERVATIONS_RETURNED` | 10 | Cap on ranked single-occurrence observations returned in one MCP response |
 
 ---
 
@@ -450,6 +522,17 @@ The MCP tool wrapper goes in `bsu_tool/mcp/tools/analysis.py` and is registered 
 Tests go in:
 - `tests/unit/test_analyzer.py` — unit tests for each algorithm step
 - `tests/int/test_mcp_analyze_goodix.py` — integration test against the Goodix capture
+
+The Goodix integration test should assert the stable output shape rather than an exact
+human narrative. Expected assertions:
+- `analyze_protocol` returns machine-readable JSON with one `ProtocolHypothesis` for the
+  requested Goodix device.
+- `result_limits` is present and reports the configured caps.
+- `command_patterns`, `observations`, `marker_correlations`, `analysis_notes`,
+  `unsolicited_responses`, and `unanswered_commands` are present even when empty.
+- every returned `CommandPattern` has at least one `PatternStep`, no more than
+  `MAX_SEQUENCE_WINDOW` steps, and JSON-safe payload signatures.
+- if result caps are exceeded, truncation flags and a truncation note are present.
 
 ---
 
@@ -471,9 +554,9 @@ Tests go in:
 
 ## Open Questions for Team Review
 
-1. **Single-occurrence observations** — are the three proposed criteria for preserving
-   one-time handshakes enough, or should the team define additional rules for startup
-   traffic before implementation?
+1. **Single-occurrence observations** — are the two proposed criteria for preserving
+   one-time handshakes enough, or should the team define additional computable rules
+   before implementation?
 
 2. **Control-transfer runtime commands** — should default analysis continue to exclude
    all Control transfers, or should the engine include an optional mode for devices that


### PR DESCRIPTION
## What does this PR do?

Adds a spec-first architecture document for the Milestone 3 Protocol Hypothesis Engine.

The spec covers:
- engine inputs from the existing session/capture model
- token normalization for USB analysis events
- repeated sequence detection
- marker correlation
- command/response pairing
- output dataclass/schema design
- edge cases, configuration constants, module locations, and team review questions

closes #62

## How was it tested?

Docs-only change. I reviewed the Markdown locally for clarity and checked that the spec lines up with the current session and MCP architecture.

## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR