### PR TITLE
53/session get packet

### DIFF
--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -174,7 +174,7 @@ class Session:
         records = self.capture.records
         if not 0 <= packet_index < len(records):
             raise ValueError(f"packet_index {packet_index} out of range (0..{len(records) - 1})")
-        # Record lookup by index; swap onto the #53 packet store's get_packet() when it lands.
+        # Direct record lookup: add_marker raises on a bad index, whereas get_packet() returns None.
         marker = Marker(name=name, timestamp=records[packet_index].timestamp, packet_index=packet_index, note=note)
         self.capture.markers.append(marker)
         return marker
@@ -241,6 +241,31 @@ class Session:
             )
         )
         return PacketSelection(matches=matches, total_count=len(records))
+
+    def get_packet(self, index: int) -> PacketRecord | None:
+        """Return the decoded packet at ``index``, or ``None`` if out of range.
+
+        ``index`` is the capture-order position in the decoded record stream —
+        the same index space :meth:`get_packets` reports and markers anchor to.
+        This is random single-packet access; use :meth:`get_packets` to retrieve
+        filtered collections.
+
+        Args:
+            index: Zero-based position of the decoded packet to retrieve.
+
+        Returns:
+            The :class:`PacketRecord` at ``index``, or ``None`` when ``index`` is
+            negative or beyond the last decoded record.
+
+        Raises:
+            RuntimeError: No capture has been loaded.
+        """
+        if self.capture is None:
+            raise RuntimeError("No capture loaded. Call load_capture() first.")
+        records = self.capture.records
+        if not 0 <= index < len(records):
+            return None
+        return _packet_record(index, records[index])
 
 
 def _validate_capture_path(path: Path) -> Path:

--- a/docs/session-roadmap-issues.md
+++ b/docs/session-roadmap-issues.md
@@ -1,5 +1,21 @@
 # Capture Session Roadmap Issues
 
+> **Status note (stale — read before using):** This roadmap predates the MCP
+> session work and its central premise no longer holds. It assumed the legacy
+> `bsu_tool.session.CaptureSession` would become the shared backing store that
+> MCP tools query (see issue 29). In practice the MCP layer grew its own model —
+> `Session` → `Capture` holding `records`/`packets`/`transactions`/`markers`,
+> with `get_packets(device_id=…, endpoint=…, …)` already providing device and
+> endpoint filtering. `CaptureSession` remains CLI-`parse`-summary only.
+>
+> As a result, issues **22–24** (the `USBPacket` model plus `add_packet` /
+> `packets_for_device` / `packets_for_endpoint` on `CaptureSession`) are
+> **obsolete**: their goal — "a backing store for `get_packets`" — is already
+> met by `Session`. Issue **#53** therefore landed as a single non-duplicative
+> accessor, `Session.get_packet(index) -> PacketRecord | None`, rather than a
+> parallel packet store. Treat the rest of this document as historical intent,
+> not a literal spec, until it is rewritten against the `Session`/`Capture` model.
+
 This document outlines future GitHub issues for continuing the capture session work. Each issue is sized for roughly 3-4 days of work, making it realistic to complete about two issues per week.
 
 The roadmap is aligned with:

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -476,6 +476,39 @@ def test_get_packets_includes_interrupt(tmp_path: Path) -> None:
     assert [match.transfer_type for match in selection.matches] == ["bulk", "interrupt"]
 
 
+def test_get_packet_requires_loaded_capture() -> None:
+    """get_packet raises RuntimeError if no capture has been loaded."""
+    with pytest.raises(RuntimeError):
+        Session().get_packet(0)
+
+
+def test_get_packet_returns_record_at_index(tmp_path: Path) -> None:
+    """get_packet returns the same PacketRecord get_packets reports at that index."""
+    path = tmp_path / "multi.pcapng"
+    path.write_bytes(_capture_bytes(_multi_device_packets()))
+    session = Session()
+    session.load(path)
+
+    matches = session.get_packets().matches
+    assert len(matches) == 5
+    for index, expected in enumerate(matches):
+        packet = session.get_packet(index)
+        assert packet is not None
+        assert packet.index == index
+        assert packet == expected
+
+
+@pytest.mark.parametrize("index", [-1, 5, 100])
+def test_get_packet_out_of_range_returns_none(tmp_path: Path, index: int) -> None:
+    """get_packet returns None for negative or beyond-the-end indexes (capture has 5)."""
+    path = tmp_path / "multi.pcapng"
+    path.write_bytes(_capture_bytes(_multi_device_packets()))
+    session = Session()
+    session.load(path)
+
+    assert session.get_packet(index) is None
+
+
 def test_add_marker_requires_loaded_capture() -> None:
     """add_marker raises RuntimeError if no capture has been loaded."""
     session = Session()


### PR DESCRIPTION
Closes #53 

## What does this PR do?

Adds `Session.get_packet(index) -> PacketRecord | None`, a random single-packet accessor in the same index space `get_packets` and markers use. Returns `None` for out-of-range/negative indexes and raises `RuntimeError` when no capture is loaded.

Re-scopes #53: the MCP backing store already exists via `Session`/`Capture`/`get_packets`, so the original `USBPacket` model and `add_packet`/`packets_for_device`/`packets_for_endpoint` were dropped as duplicative. `get_packet` is the one genuinely-missing piece (needed later by `packets_between_markers` and a single-packet detail tool). Also marks roadmap issues 22–24 obsolete in `docs/session-roadmap-issues.md`.

## How was it tested?

`ruff check` + `ruff format --check`, `pyright`, and `pytest` all clean. New unit tests cover the no-capture error, an in-range hit across a multi-device/multi-endpoint capture, and out-of-range (`-1`, past-the-end) → `None`.


## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR
