### PR TITLE
feat: cross-marker packet retrieval mcp tool (closes #55)

### DIFF
--- a/bsu_tool/mcp/tools/markers.py
+++ b/bsu_tool/mcp/tools/markers.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 
 from mcp.server.fastmcp import FastMCP
 
+from bsu_tool.mcp.interfaces import PacketRecord
+from bsu_tool.mcp.tools.pagination import DEFAULT_LIMIT, validate_pagination
 from bsu_tool.session import Marker, Session
 
 
@@ -21,6 +23,27 @@ class ListMarkersResult:
 
     markers: tuple[Marker, ...]
     count: int
+
+
+@dataclass(frozen=True, slots=True)
+class PacketsBetweenMarkersResult:
+    """A page of the packets recorded between two named markers.
+
+    ``span_count`` is the total number of packets strictly between the markers;
+    ``packets`` is the ``offset``/``limit`` slice of that span, mirroring how
+    get_packets paginates so a large span never floods a single MCP response.
+    When a ``device_id`` filter is given, ``span_count`` is the post-filter total
+    (packets in the span for that device), so pagination stays coherent.
+    """
+
+    start_marker: Marker
+    end_marker: Marker
+    packets: tuple[PacketRecord, ...]
+    span_count: int
+    offset: int
+    limit: int
+    returned_count: int
+    has_more: bool
 
 
 def register(mcp: FastMCP, session: Session) -> None:
@@ -46,3 +69,43 @@ def register(mcp: FastMCP, session: Session) -> None:
         """List all markers on the active capture in the order they were added."""
         markers = session.list_markers()
         return ListMarkersResult(markers=markers, count=len(markers))
+
+    @mcp.tool()
+    def packets_between_markers(  # pyright: ignore[reportUnusedFunction]
+        start_name: str,
+        end_name: str,
+        device_id: str | None = None,
+        offset: int = 0,
+        limit: int = DEFAULT_LIMIT,
+    ) -> PacketsBetweenMarkersResult:
+        """Retrieve the decoded packets recorded between two named markers.
+
+        Give a bracketing marker pair — the marker added when an action began as
+        ``start_name`` and the one added when it ended as ``end_name`` — to isolate
+        just the traffic produced by that single action. The packets anchored to
+        the markers themselves are the boundaries and are excluded. Raises if
+        either name is unknown or the start marker is anchored after the end marker.
+
+        Pass ``device_id`` (a ``dev_bbb_ddd`` id from list_devices) to keep only
+        that device's packets within the span, mirroring get_packets; an unknown id
+        yields an empty span. When a ``device_id`` is given, ``span_count`` is the
+        post-filter total, so pagination stays coherent.
+
+        Pagination (offset, limit) slices the span, and ``span_count`` reports the
+        full number of packets between the markers, so a long action does not
+        overflow one response. Passing the same marker name twice yields an empty
+        span.
+        """
+        validate_pagination(offset, limit)
+        span = session.packets_between_markers(start_name=start_name, end_name=end_name, device_id=device_id)
+        page = span.packets[offset : offset + limit]
+        return PacketsBetweenMarkersResult(
+            start_marker=span.start_marker,
+            end_marker=span.end_marker,
+            packets=page,
+            span_count=span.count,
+            offset=offset,
+            limit=limit,
+            returned_count=len(page),
+            has_more=offset + len(page) < span.count,
+        )

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -58,6 +58,27 @@ class Marker:
     note: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class MarkerSpan:
+    """Decoded packets recorded strictly between a pair of named markers.
+
+    ``packets`` are the records whose index lies between the two markers'
+    anchor packets, exclusive of the marker-anchored packets themselves. The
+    resolved markers are carried alongside so a caller can see exactly which
+    boundaries produced the span.
+
+    When a ``device_id`` filter is applied, ``packets`` holds only the records
+    in that span belonging to the device and ``count`` is the post-filter total
+    (the number of packets in the span for that device), so pagination against
+    ``count`` stays coherent.
+    """
+
+    start_marker: Marker
+    end_marker: Marker
+    packets: tuple[PacketRecord, ...]
+    count: int
+
+
 def _empty_markers() -> list[Marker]:
     return []
 
@@ -185,6 +206,63 @@ class Session:
             raise RuntimeError("No capture loaded. Call load() first.")
         return tuple(self.capture.markers)
 
+    def packets_between_markers(
+        self,
+        start_name: str,
+        end_name: str,
+        *,
+        device_id: str | None = None,
+    ) -> MarkerSpan:
+        """Return the decoded packets recorded strictly between two named markers.
+
+        The markers bracket a single physical action (see the marker tools): pass
+        the marker added when the action began as ``start_name`` and the one added
+        when it ended as ``end_name``. The returned packets are those whose index
+        lies strictly between the two markers' anchor packets — the marker-anchored
+        packets are the boundaries and are excluded — which isolates the traffic
+        produced by that one action.
+
+        Args:
+            start_name: Name of the marker anchoring the start of the span.
+            end_name: Name of the marker anchoring the end of the span.
+            device_id: Restrict the span to one device by its ``dev_bbb_ddd`` id,
+                mirroring ``get_packets``. ``None`` keeps every device in range. An
+                unknown id matches nothing and yields an empty span (no error). The
+                returned span's ``count`` is the post-filter total.
+
+        Returns:
+            A :class:`MarkerSpan` holding the resolved markers and the packets
+            between them in capture order. The span is empty when the markers are
+            adjacent, anchored to the same packet, when the same marker name is
+            passed for both ends, or when ``device_id`` excludes every packet in
+            range.
+
+        Raises:
+            RuntimeError: No capture has been loaded.
+            ValueError: Either name has no marker, or ``start_name`` is anchored
+                after ``end_name`` (a reversed span).
+        """
+        if self.capture is None:
+            raise RuntimeError("No capture loaded. Call load() first.")
+        markers = self.capture.markers
+        records = self.capture.records
+        start = _find_marker(markers, start_name)
+        end = _find_marker(markers, end_name)
+        if start.packet_index > end.packet_index:
+            raise ValueError(
+                f"start marker {start_name!r} (index {start.packet_index}) is anchored "
+                f"after end marker {end_name!r} (index {end.packet_index})"
+            )
+        # The span is the contiguous decoded-record range strictly between the
+        # two anchors; keep each record's original index and drop any that a
+        # device_id filter excludes so count reflects the post-filter total.
+        packets = tuple(
+            _packet_record(index, records[index])
+            for index in range(start.packet_index + 1, end.packet_index)
+            if device_id is None or _device_id(records[index].bus_num, records[index].dev_num) == device_id
+        )
+        return MarkerSpan(start_marker=start, end_marker=end, packets=packets, count=len(packets))
+
     def list_devices(self) -> tuple[DeviceSummary, ...]:
         """Return USB devices observed in the active capture."""
         if self.capture is None:
@@ -241,6 +319,13 @@ class Session:
             )
         )
         return PacketSelection(matches=matches, total_count=len(records))
+
+
+def _find_marker(markers: list[Marker], name: str) -> Marker:
+    for marker in markers:
+        if marker.name == name:
+            return marker
+    raise ValueError(f"no marker named {name!r}")
 
 
 def _validate_capture_path(path: Path) -> Path:

--- a/tests/int/test_mcp_markers_goodix.py
+++ b/tests/int/test_mcp_markers_goodix.py
@@ -47,3 +47,50 @@ def test_marker_tools_bracket_pair_end_to_end() -> None:
     assert names == ["enroll-1-start", "enroll-1-end"]
     assert listed["markers"][0]["note"] == "finger on"
     assert listed["markers"][1]["note"] is None
+
+
+def test_packets_between_markers_end_to_end() -> None:
+    """packets_between_markers returns the traffic bracketed by a marker pair via MCP."""
+    session = Session()
+    session.load(_CAPTURE)
+    server = build_server(session=session)
+
+    def call(tool: str, arguments: dict[str, object]) -> dict[str, Any]:
+        result = asyncio.run(server.call_tool(tool, arguments))
+        if isinstance(result, tuple):
+            return cast("dict[str, Any]", result[1])
+        assert not isinstance(result, dict)
+        block = result[0]
+        assert isinstance(block, TextContent)
+        payload: dict[str, Any] = json.loads(block.text)
+        return payload
+
+    call("add_marker", {"name": "enroll-1-start", "packet_index": 10})
+    call("add_marker", {"name": "enroll-1-end", "packet_index": 200})
+
+    # a wide limit returns the whole span so we can check its shape
+    span = call(
+        "packets_between_markers",
+        {"start_name": "enroll-1-start", "end_name": "enroll-1-end", "limit": 1000},
+    )
+
+    assert span["start_marker"]["name"] == "enroll-1-start"
+    assert span["end_marker"]["name"] == "enroll-1-end"
+    indices = [packet["index"] for packet in span["packets"]]
+    # deterministic values for this capture with markers at 10 and 200
+    assert span["span_count"] == 189
+    assert span["returned_count"] == len(indices)
+    assert span["has_more"] is False
+    # strictly between: neither marker's own packet is included
+    assert min(indices) == 11
+    assert max(indices) == 199
+
+    # a small limit pages the same span without dropping the total count
+    first_page = call(
+        "packets_between_markers",
+        {"start_name": "enroll-1-start", "end_name": "enroll-1-end", "limit": 5},
+    )
+    assert first_page["span_count"] == span["span_count"]
+    assert first_page["returned_count"] == 5
+    assert first_page["has_more"] is True
+    assert [packet["index"] for packet in first_page["packets"]] == indices[:5]

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -549,3 +549,148 @@ def test_list_markers_returns_insertion_order(tmp_path: Path) -> None:
     first = session.add_marker(name="a-start", packet_index=0)
     second = session.add_marker(name="a-end", packet_index=1)
     assert session.list_markers() == (first, second)
+
+
+def _span_session(tmp_path: Path) -> Session:
+    """A Session over the 5-packet multi-device capture (indices 0..4)."""
+    path = tmp_path / "span.pcapng"
+    path.write_bytes(_capture_bytes(_multi_device_packets()))
+    session = Session()
+    session.load(path)
+    return session
+
+
+def test_packets_between_markers_requires_loaded_capture() -> None:
+    """packets_between_markers raises RuntimeError if no capture has been loaded."""
+    with pytest.raises(RuntimeError):
+        Session().packets_between_markers("start", "end")
+
+
+def test_packets_between_markers_returns_packets_strictly_between(tmp_path: Path) -> None:
+    """The span is the records between the markers, excluding the marker packets."""
+    session = _span_session(tmp_path)
+    session.add_marker(name="start", packet_index=0)
+    session.add_marker(name="end", packet_index=4)
+
+    span = session.packets_between_markers("start", "end")
+
+    assert span.start_marker.name == "start"
+    assert span.end_marker.name == "end"
+    assert span.count == 3
+    assert [packet.index for packet in span.packets] == [1, 2, 3]
+
+
+def test_packets_between_markers_missing_start(tmp_path: Path) -> None:
+    """An unknown start marker name raises a clear ValueError."""
+    session = _span_session(tmp_path)
+    session.add_marker(name="end", packet_index=4)
+
+    with pytest.raises(ValueError, match="no marker named 'start'"):
+        session.packets_between_markers("start", "end")
+
+
+def test_packets_between_markers_missing_end(tmp_path: Path) -> None:
+    """An unknown end marker name raises a clear ValueError."""
+    session = _span_session(tmp_path)
+    session.add_marker(name="start", packet_index=0)
+
+    with pytest.raises(ValueError, match="no marker named 'end'"):
+        session.packets_between_markers("start", "end")
+
+
+def test_packets_between_markers_rejects_reversed_span(tmp_path: Path) -> None:
+    """A start marker anchored after the end marker raises ValueError."""
+    session = _span_session(tmp_path)
+    session.add_marker(name="start", packet_index=4)
+    session.add_marker(name="end", packet_index=1)
+
+    with pytest.raises(ValueError, match="anchored after"):
+        session.packets_between_markers("start", "end")
+
+
+def test_packets_between_markers_empty_when_adjacent(tmp_path: Path) -> None:
+    """Adjacent markers bound no packets, so the span is empty (not an error)."""
+    session = _span_session(tmp_path)
+    session.add_marker(name="start", packet_index=2)
+    session.add_marker(name="end", packet_index=3)
+
+    span = session.packets_between_markers("start", "end")
+
+    assert span.count == 0
+    assert span.packets == ()
+
+
+def test_packets_between_markers_empty_for_same_name(tmp_path: Path) -> None:
+    """Passing one marker name for both ends yields an empty span, not an error."""
+    session = _span_session(tmp_path)
+    session.add_marker(name="solo", packet_index=2)
+
+    span = session.packets_between_markers("solo", "solo")
+
+    assert span.count == 0
+    assert span.packets == ()
+    assert span.start_marker is span.end_marker
+
+
+def test_packets_between_markers_empty_for_distinct_markers_same_index(tmp_path: Path) -> None:
+    """Two differently named markers on the same packet bound an empty span."""
+    session = _span_session(tmp_path)
+    session.add_marker(name="start", packet_index=2)
+    session.add_marker(name="end", packet_index=2)
+
+    span = session.packets_between_markers("start", "end")
+
+    assert span.count == 0
+    assert span.packets == ()
+
+
+def test_packets_between_markers_spans_multiple_devices(tmp_path: Path) -> None:
+    """The span filters by index only, so it includes every device in range."""
+    session = _span_session(tmp_path)
+    # indices 0..4 across two devices: dev_001_004 at 0..1, dev_001_007 at 2..4.
+    session.add_marker(name="start", packet_index=0)
+    session.add_marker(name="end", packet_index=4)
+
+    span = session.packets_between_markers("start", "end")
+
+    assert [packet.index for packet in span.packets] == [1, 2, 3]
+    assert {packet.device_id for packet in span.packets} == {"dev_001_004", "dev_001_007"}
+
+
+def test_packets_between_markers_filters_by_device(tmp_path: Path) -> None:
+    """device_id keeps only that device's packets in the span; count is post-filter."""
+    session = _span_session(tmp_path)
+    # span 1..3 holds dev_001_004 at index 1 and dev_001_007 at indices 2..3.
+    session.add_marker(name="start", packet_index=0)
+    session.add_marker(name="end", packet_index=4)
+
+    span = session.packets_between_markers("start", "end", device_id="dev_001_007")
+
+    assert span.count == 2
+    assert [packet.index for packet in span.packets] == [2, 3]
+    assert {packet.device_id for packet in span.packets} == {"dev_001_007"}
+
+
+def test_packets_between_markers_device_with_zero_packets_in_span(tmp_path: Path) -> None:
+    """A known device absent from the span yields an empty span, not an error."""
+    session = _span_session(tmp_path)
+    # span 2..3 is all dev_001_007; dev_001_004 exists in the capture but not here.
+    session.add_marker(name="start", packet_index=1)
+    session.add_marker(name="end", packet_index=4)
+
+    span = session.packets_between_markers("start", "end", device_id="dev_001_004")
+
+    assert span.count == 0
+    assert span.packets == ()
+
+
+def test_packets_between_markers_unknown_device_id_is_empty(tmp_path: Path) -> None:
+    """An unknown device_id matches nothing and yields an empty span (as get_packets)."""
+    session = _span_session(tmp_path)
+    session.add_marker(name="start", packet_index=0)
+    session.add_marker(name="end", packet_index=4)
+
+    span = session.packets_between_markers("start", "end", device_id="dev_009_009")
+
+    assert span.count == 0
+    assert span.packets == ()


### PR DESCRIPTION
## adds packets_between_markers marker span tool, closes #55

this adds a packets_between_markers mcp tool plus the session-layer support behind it. an analyst brackets a physical action with a start marker and an end marker, then this tool returns just the decoded packets recorded strictly between that pair, so the traffic for one action is isolated without hand-counting indices.

design decisions
- strictly-between semantics: the two marker-anchored packets are the boundaries and are excluded. adjacent markers, two markers on the same packet, and passing the same marker name for both ends all yield an empty span rather than an error.
- packet indices are preserved: each returned packet keeps its original get_packets index, so the analyst can cross-reference back into the full stream.
- optional device_id filter: mirrors get_packets exactly (same dev_bbb_ddd id, same str or none signature, none = all devices). when a device_id is given the filter is applied within the span and span_count is the post-filter total, so has_more and the offset/limit math all compute against the filtered count and pagination stays coherent. an unknown device_id matches nothing and returns an empty span, consistent with get_packets rather than raising.
- pagination: offset and limit slice the span the same way get_packets paginates, and span_count reports the full span total so a long action never floods one mcp response.

edge cases handled
- no capture loaded raises runtimeerror.
- unknown start or end marker name raises a clear valueerror naming the marker.
- start marker anchored after the end marker (a reversed span) raises valueerror.
- device_id that excludes every packet in range, and unknown device_id, both return an empty span with no error.

testing
- unit tests cover strictly-between slicing, empty spans (adjacent, same-name, distinct-markers-same-index), missing start, missing end, reversed span, multi-device spans, the device_id filter matching one device in a multi-device span, a known device with zero packets in the span, and an unknown device_id.
- the goodix integration test drives add_marker plus packets_between_markers end to end through the real mcp server and now pins exact span values on the unfiltered whole-span call: span_count == 189, min index == 11, max index == 199, so regressions in the span math surface immediately.
- full gate is green: ruff check, ruff format --check, pyright (0 errors), pytest (240 passed).
