### PR TITLE
feat: session summary and validation

### DIFF
--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -79,6 +79,24 @@ class MarkerSpan:
     count: int
 
 
+@dataclass(frozen=True, slots=True)
+class CaptureSummary:
+    """Aggregate counts describing the active capture at a glance.
+
+    The counts are derived from the decoded record stream and the device
+    summaries, so they cover the same packets ``get_packets`` reports.
+    """
+
+    device_count: int  # distinct USB devices observed in the decoded records
+    packet_count: int  # total decoded URB records in the capture
+    marker_count: int  # analyst-supplied markers on the capture
+    endpoint_count: int  # endpoints across all devices (sum of each device's distinct endpoints)
+    # Neutral statistics, NOT errors. usbmon captures routinely begin and end
+    # mid-transaction, so a healthy capture normally carries some of each.
+    unmatched_submission_count: int  # submissions still in flight (no matching completion captured)
+    orphan_completion_count: int  # completions whose submission was not captured (capture began mid-transaction)
+
+
 def _empty_markers() -> list[Marker]:
     return []
 
@@ -344,6 +362,73 @@ class Session:
         if not 0 <= index < len(records):
             return None
         return _packet_record(index, records[index])
+
+    def summary(self) -> CaptureSummary:
+        """Return aggregate counts for the active capture.
+
+        Counts distinct devices, total decoded packets, markers, and endpoints
+        (summed across every device's distinct endpoints). Also reports the
+        neutral in-flight and orphan-completion statistics: these are normal for
+        captures that begin or end mid-transaction and are not faults.
+
+        Raises:
+            RuntimeError: No capture has been loaded.
+        """
+        if self.capture is None:
+            raise RuntimeError("No capture loaded. Call load() first.")
+        devices = _summarize_devices(self.capture.records, self.capture.transactions)
+        transactions = self.capture.transactions
+        return CaptureSummary(
+            device_count=len(devices),
+            packet_count=len(self.capture.records),
+            marker_count=len(self.capture.markers),
+            endpoint_count=sum(len(device.endpoints_seen) for device in devices),
+            unmatched_submission_count=_count_unmatched_submissions(transactions),
+            orphan_completion_count=_count_orphan_completions(transactions),
+        )
+
+    def validate(self) -> list[str]:
+        """Return human-readable integrity faults in the active capture.
+
+        An empty list genuinely means the capture is valid. Only true faults are
+        reported, in this order:
+
+        1. The capture decoded no supported URB records (an empty analysis).
+        2. A marker anchored outside the decoded record range (a dangling
+           reference that ``get_packet`` would resolve to nothing).
+
+        In-flight submissions (no matching completion) and orphan completions
+        (submission not captured) are NOT faults: usbmon captures routinely begin
+        and end mid-transaction, so a healthy capture normally carries some of
+        each. Those are surfaced as neutral statistics on :class:`CaptureSummary`
+        (``unmatched_submission_count`` / ``orphan_completion_count``) instead.
+
+        Raises:
+            RuntimeError: No capture has been loaded.
+        """
+        if self.capture is None:
+            raise RuntimeError("No capture loaded. Call load() first.")
+        records = self.capture.records
+        problems: list[str] = []
+        if not records:
+            problems.append("capture contains no decoded USB packets")
+        for marker in self.capture.markers:
+            if not 0 <= marker.packet_index < len(records):
+                problems.append(
+                    f"marker {marker.name!r} references packet index {marker.packet_index} "
+                    f"outside the decoded range 0..{len(records) - 1}"
+                )
+        return problems
+
+
+def _count_unmatched_submissions(transactions: tuple[UrbTransaction, ...]) -> int:
+    """Count in-flight submissions: a submission with no matching completion."""
+    return sum(1 for tx in transactions if tx.submission is not None and tx.completion is None)
+
+
+def _count_orphan_completions(transactions: tuple[UrbTransaction, ...]) -> int:
+    """Count orphan completions: a completion whose submission was not captured."""
+    return sum(1 for tx in transactions if tx.submission is None and tx.completion is not None)
 
 
 def _find_marker(markers: list[Marker], name: str) -> Marker:

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -7,7 +7,7 @@ import pytest
 
 from bsu_tool.mcp.interfaces import EndpointSummary
 from bsu_tool.pcapng_reader import PcapNgError
-from bsu_tool.session import Marker, Session
+from bsu_tool.session import CaptureSummary, Marker, Session
 
 _USBMON_HEADER_FORMAT = "<QBBBBHBBqiiII8s"
 _SUBMISSION = 0x53
@@ -727,3 +727,121 @@ def test_packets_between_markers_unknown_device_id_is_empty(tmp_path: Path) -> N
 
     assert span.count == 0
     assert span.packets == ()
+
+
+def test_summary_requires_loaded_capture() -> None:
+    """summary raises RuntimeError if no capture has been loaded."""
+    with pytest.raises(RuntimeError):
+        Session().summary()
+
+
+def test_summary_returns_correct_counts(tmp_path: Path) -> None:
+    """summary counts devices, packets, markers, and endpoints across devices."""
+    setup_device = _get_descriptor_setup(descriptor_type=1, descriptor_index=0, length=18)
+    descriptor = _device_descriptor(vendor_id=0x27C6, product_id=0x533C, manufacturer_index=0, product_index=0)
+    # Two fully paired devices: dev 4 uses endpoints 0x01/0x81, dev 7 uses 0x00 (control).
+    path = tmp_path / "summary.pcapng"
+    path.write_bytes(
+        _capture_bytes(
+            (
+                _usbmon_packet(urb_id=1, endpoint=0x01, dev_num=4, data=b"a"),
+                _usbmon_packet(urb_id=1, event=_COMPLETION, endpoint=0x81, dev_num=4, data=b"bc"),
+                _usbmon_packet(urb_id=2, transfer_type=_CONTROL, endpoint=0x80, dev_num=7, setup=setup_device),
+                _usbmon_packet(
+                    urb_id=2,
+                    event=_COMPLETION,
+                    transfer_type=_CONTROL,
+                    endpoint=0x80,
+                    dev_num=7,
+                    flag_setup=0x3E,
+                    data=descriptor,
+                ),
+            )
+        )
+    )
+    session = Session()
+    session.load(path)
+    session.add_marker(name="start", packet_index=0)
+    session.add_marker(name="end", packet_index=3)
+
+    summary = session.summary()
+
+    assert summary == CaptureSummary(
+        device_count=2,
+        packet_count=4,
+        marker_count=2,
+        endpoint_count=3,
+        unmatched_submission_count=0,
+        orphan_completion_count=0,
+    )
+    assert session.validate() == []
+
+
+def test_validate_requires_loaded_capture() -> None:
+    """validate raises RuntimeError if no capture has been loaded."""
+    with pytest.raises(RuntimeError):
+        Session().validate()
+
+
+def test_validate_flags_empty_capture(tmp_path: Path) -> None:
+    """A capture that decodes no supported records is reported as empty."""
+    path = tmp_path / "isochronous-only.pcapng"
+    path.write_bytes(_capture_bytes((_usbmon_packet(transfer_type=_ISOCHRONOUS),)))
+    session = Session()
+    session.load(path)
+
+    assert session.validate() == ["capture contains no decoded USB packets"]
+
+
+def test_summary_counts_unmatched_submission(tmp_path: Path) -> None:
+    """An in-flight submission (no completion) is a neutral summary statistic, not a validate fault."""
+    path = tmp_path / "orphan-sub.pcapng"
+    path.write_bytes(_capture_bytes((_usbmon_packet(urb_id=1, endpoint=0x01, dev_num=4, data=b"a"),)))
+    session = Session()
+    session.load(path)
+
+    # A lone submission is still a valid capture: captures normally begin/end mid-transaction.
+    assert session.validate() == []
+    summary = session.summary()
+    assert summary.unmatched_submission_count == 1
+    assert summary.orphan_completion_count == 0
+
+
+def test_summary_counts_orphan_completion(tmp_path: Path) -> None:
+    """A completion whose submission was never captured is a neutral statistic, not a validate fault."""
+    path = tmp_path / "orphan-comp.pcapng"
+    completion = _usbmon_packet(urb_id=9, event=_COMPLETION, endpoint=0x81, dev_num=4, data=b"z")
+    path.write_bytes(_capture_bytes((completion,)))
+    session = Session()
+    session.load(path)
+
+    assert session.validate() == []
+    summary = session.summary()
+    assert summary.orphan_completion_count == 1
+    assert summary.unmatched_submission_count == 0
+
+
+def test_validate_flags_marker_out_of_range(tmp_path: Path) -> None:
+    """A marker anchored outside the decoded record range is reported."""
+    session = Session()
+    capture = session.load(_write_capture(tmp_path))
+    # Bypass add_marker's guard to model a dangling marker reference (capture has 2 records).
+    capture.markers.append(Marker(name="stale", timestamp=0.0, packet_index=99))
+
+    assert "marker 'stale' references packet index 99 outside the decoded range 0..1" in session.validate()
+
+
+def test_validate_reports_multiple_faults_in_order(tmp_path: Path) -> None:
+    """With both genuine faults present, validate reports empty-capture first, then the dangling marker."""
+    path = tmp_path / "empty-with-marker.pcapng"
+    path.write_bytes(_capture_bytes((_usbmon_packet(transfer_type=_ISOCHRONOUS),)))
+    session = Session()
+    capture = session.load(path)
+    assert len(capture.records) == 0
+    # Bypass add_marker's guard: on a zero-record capture any index dangles.
+    capture.markers.append(Marker(name="stale", timestamp=0.0, packet_index=0))
+
+    assert session.validate() == [
+        "capture contains no decoded USB packets",
+        "marker 'stale' references packet index 0 outside the decoded range 0..-1",
+    ]


### PR DESCRIPTION
this adds two read-only reporting methods to the mcp session model so claude
code can get a quick read on a loaded capture.

summary() returns a CaptureSummary with:
- device_count: distinct usb devices in the decoded records
- packet_count: total decoded urb records
- marker_count: analyst markers on the capture
- endpoint_count: endpoints summed across every device's distinct endpoints
- unmatched_submission_count: submissions still in flight (no matching completion)
- orphan_completion_count: completions whose submission was not captured

validate() returns a list of human-readable integrity faults. an empty list
genuinely means the capture is valid. it reports only true faults, in this order:
1. the capture decoded no supported urb records
2. a marker anchored outside the decoded record range (a dangling reference)

design decision worth calling out: in-flight submissions and orphan completions
are NOT validation errors. usbmon captures routinely begin and end
mid-transaction, so a perfectly healthy capture normally carries some of each.
treating them as validate() faults meant a good capture returned a non-empty
problem list, which made "empty == valid" a lie. so i moved those two counts out
of validate() and into summary() as neutral statistics instead. now validate()
is honest about integrity and summary() surfaces the in-flight/orphan facts
without crying wolf.

edge cases covered: zero decoded records (empty capture), dangling markers past
the decoded range, both genuine faults present at once (order is pinned), lone
submission with no completion, lone completion with no submission, and a fully
paired capture reporting 0/0 for the neutral stats.

tested with pytest against real pcap-ng bytes built in the test fixtures. the
two former validate tests were repurposed to assert the new contract (validate
stays empty, summary reports the exact counts), the pinned CaptureSummary in
test_summary_returns_correct_counts now includes the two new fields, and a new
multi-fault ordering test pins the validate() check order. full gate is green:
ruff check, ruff format --check, pyright (0 errors), pytest (256 passed).

closes #57
