### PR TITLE
80/capture mcp tools

### DIFF
--- a/bsu_tool/mcp/tools/__init__.py
+++ b/bsu_tool/mcp/tools/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from bsu_tool.mcp.tools import capture, devices, markers, packets
+from bsu_tool.mcp.tools import capture, devices, live_capture, markers, packets
 from bsu_tool.session import Session
 
 
@@ -16,5 +16,6 @@ def register_all(mcp: FastMCP, session: Session) -> None:
     """Register every MCP tool group against the FastMCP instance."""
     capture.register(mcp, session)
     devices.register(mcp, session)
+    live_capture.register(mcp, session)
     markers.register(mcp, session)
     packets.register(mcp, session)

--- a/bsu_tool/mcp/tools/live_capture.py
+++ b/bsu_tool/mcp/tools/live_capture.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -36,7 +37,7 @@ def register(mcp: FastMCP, session: Session) -> None:
     """Register live-capture tools on the FastMCP instance."""
 
     @mcp.tool()
-    def start_capture(  # pyright: ignore[reportUnusedFunction]
+    async def start_capture(  # pyright: ignore[reportUnusedFunction]
         bus: int,
         output_path: str,
         device: int | None = None,
@@ -54,9 +55,9 @@ def register(mcp: FastMCP, session: Session) -> None:
           already exist.
 
         Requires Linux with the usbmon module loaded and readable. Only one
-        capture can run at a time.
+        capture can run per session.
         """
-        destination = Path(output_path)
+        destination = Path(output_path).expanduser().resolve()
         # Checked before capturing: stop_capture's auto-load only accepts
         # .pcapng, and that failure must not wait until after the analyst
         # has already operated the device.
@@ -72,18 +73,36 @@ def register(mcp: FastMCP, session: Session) -> None:
         live_capture = LiveCapture(controller=controller, output_path=destination)
         session.reserve_live_capture(live_capture)
         capture_started = False
+        start_job = asyncio.create_task(
+            asyncio.to_thread(controller.start, bus=bus, device=device, output_path=destination)
+        )
         try:
-            controller.start(bus=bus, device=device, output_path=destination)
+            await asyncio.shield(start_job)
             if not controller.is_running:
                 raise CaptureStateError("capture controller returned before the capture was live")
             if not session.mark_live_capture_running(live_capture):
                 raise CaptureStateError("capture no longer owns the session after startup")
             capture_started = True
-        except TimeoutError as exc:
+        except asyncio.CancelledError:
             try:
-                controller.stop()
+                await asyncio.shield(start_job)
+            except Exception:
+                pass
+            session.mark_live_capture_stopping(live_capture)
+            try:
+                await asyncio.shield(asyncio.to_thread(controller.stop))
+            except Exception:
+                pass
+            raise
+        except TimeoutError as exc:
+            session.mark_live_capture_stopping(live_capture)
+            try:
+                await asyncio.to_thread(controller.stop)
             except Exception as cleanup_error:  # noqa: BLE001 - report startup and cleanup failures together
-                raise RuntimeError(f"capture startup timed out and cleanup failed: {cleanup_error}") from exc
+                raise RuntimeError(
+                    "capture startup timed out and cleanup failed; "
+                    f"retry stop_capture before starting another capture: {cleanup_error}"
+                ) from exc
             raise RuntimeError(f"capture startup timed out: {exc}") from exc
         except FileExistsError as exc:
             raise RuntimeError(f"capture output already exists: {destination}") from exc
@@ -93,11 +112,14 @@ def register(mcp: FastMCP, session: Session) -> None:
             raise RuntimeError(f"capture could not start: {exc}") from exc
         finally:
             if not capture_started:
-                session.release_live_capture(live_capture)
+                if controller.is_active:
+                    session.mark_live_capture_stalled(live_capture)
+                else:
+                    session.release_live_capture(live_capture)
         return StartCaptureResult(bus=bus, device=device, output_path=str(destination))
 
     @mcp.tool()
-    def stop_capture() -> StopCaptureResult:  # pyright: ignore[reportUnusedFunction]
+    async def stop_capture() -> StopCaptureResult:  # pyright: ignore[reportUnusedFunction]
         """Stop the running capture, load it as the active capture, and summarize it.
 
         Returns the final capture statistics plus what the loaded file contains
@@ -112,12 +134,16 @@ def register(mcp: FastMCP, session: Session) -> None:
 
         try:
             try:
-                stats = controller.stop()
+                stats = await asyncio.to_thread(controller.stop)
+            except TimeoutError as exc:
+                raise RuntimeError(
+                    f"capture did not stop in time; retry stop_capture before starting another capture: {exc}"
+                ) from exc
             except CaptureStateError as exc:
                 raise RuntimeError(f"capture could not stop: {exc}") from exc
             except UsbmonError as exc:
                 raise RuntimeError(f"usbmon capture failed while stopping: {exc}") from exc
-            capture = session.load(output_path)
+            capture = await asyncio.to_thread(session.load_stopped_capture, live_capture)
             return StopCaptureResult(
                 output_path=str(output_path),
                 output_bytes=stats.output_bytes,
@@ -128,4 +154,7 @@ def register(mcp: FastMCP, session: Session) -> None:
                 device_ids=tuple(device.device_id for device in session.list_devices()),
             )
         finally:
-            session.release_live_capture(live_capture)
+            if controller.is_active:
+                session.mark_live_capture_stalled(live_capture)
+            else:
+                session.release_live_capture(live_capture)

--- a/bsu_tool/mcp/tools/live_capture.py
+++ b/bsu_tool/mcp/tools/live_capture.py
@@ -1,0 +1,128 @@
+"""Live-capture MCP tools: start_capture / stop_capture."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from bsu_tool.session import LiveCapture, Session
+
+
+@dataclass(frozen=True, slots=True)
+class StartCaptureResult:
+    """Confirmation that a live capture is running."""
+
+    bus: int
+    device: int | None
+    output_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class StopCaptureResult:
+    """Final capture statistics plus a summary of the auto-loaded capture."""
+
+    output_path: str
+    output_bytes: int
+    events_seen: int
+    events_matched: int
+    elapsed_seconds: float
+    packet_count: int
+    device_ids: tuple[str, ...]
+
+
+def register(mcp: FastMCP, session: Session) -> None:
+    """Register live-capture tools on the FastMCP instance."""
+
+    @mcp.tool()
+    def start_capture(  # pyright: ignore[reportUnusedFunction]
+        bus: int,
+        output_path: str,
+        device: int | None = None,
+    ) -> StartCaptureResult:
+        """Start a live usbmon capture and return once it is verifiably running.
+
+        After this returns, instruct the analyst to operate the device, then
+        call stop_capture to end the capture and load the result for analysis.
+
+        - bus: usbmon bus number (the N in /dev/usbmonN).
+        - device: USB device number on that bus, or omit for bus-only capture.
+          Bus-only is the right default when the capture should include
+          enumeration, since device addresses shift while a device enumerates.
+        - output_path: destination pcap-ng file; must end with .pcapng and not
+          already exist.
+
+        Requires Linux with the usbmon module loaded and readable. Only one
+        capture can run at a time.
+        """
+        destination = Path(output_path)
+        # Checked before capturing: stop_capture's auto-load only accepts
+        # .pcapng, and that failure must not wait until after the analyst
+        # has already operated the device.
+        if destination.suffix.lower() != ".pcapng":
+            raise ValueError("output_path must end with .pcapng so stop_capture can load it")
+        # Lazy import: bsu_tool.sniffer pulls in the usbmon plumbing, which
+        # imports Unix-only modules (fcntl) — importing it at module load
+        # would break server startup on Windows.
+        from bsu_tool.sniffer import CaptureController, CaptureStateError
+        from bsu_tool.usbmon_source import UsbmonError
+
+        controller = CaptureController()
+        live_capture = LiveCapture(controller=controller, output_path=destination)
+        session.reserve_live_capture(live_capture)
+        capture_started = False
+        try:
+            controller.start(bus=bus, device=device, output_path=destination)
+            if not controller.is_running:
+                raise CaptureStateError("capture controller returned before the capture was live")
+            capture_started = True
+        except TimeoutError as exc:
+            try:
+                controller.stop()
+            except Exception as cleanup_error:  # noqa: BLE001 - report startup and cleanup failures together
+                raise RuntimeError(f"capture startup timed out and cleanup failed: {cleanup_error}") from exc
+            raise RuntimeError(f"capture startup timed out: {exc}") from exc
+        except FileExistsError as exc:
+            raise RuntimeError(f"capture output already exists: {destination}") from exc
+        except UsbmonError as exc:
+            raise RuntimeError(f"usbmon capture could not start: {exc}") from exc
+        except CaptureStateError as exc:
+            raise RuntimeError(f"capture could not start: {exc}") from exc
+        finally:
+            if not capture_started:
+                session.release_live_capture(live_capture)
+        return StartCaptureResult(bus=bus, device=device, output_path=str(destination))
+
+    @mcp.tool()
+    def stop_capture() -> StopCaptureResult:  # pyright: ignore[reportUnusedFunction]
+        """Stop the running capture, load it as the active capture, and summarize it.
+
+        Returns the final capture statistics plus what the loaded file contains
+        (packet count and device ids). The other analysis tools operate on the
+        newly loaded capture from here on.
+        """
+        live_capture = session.pop_live_capture()
+        if live_capture is None:
+            raise RuntimeError("no capture is running; call start_capture first")
+        controller = live_capture.controller
+        output_path = live_capture.output_path
+        from bsu_tool.sniffer import CaptureStateError
+        from bsu_tool.usbmon_source import UsbmonError
+
+        try:
+            stats = controller.stop()
+        except CaptureStateError as exc:
+            raise RuntimeError(f"capture could not stop: {exc}") from exc
+        except UsbmonError as exc:
+            raise RuntimeError(f"usbmon capture failed while stopping: {exc}") from exc
+        capture = session.load(output_path)
+        return StopCaptureResult(
+            output_path=str(output_path),
+            output_bytes=stats.output_bytes,
+            events_seen=stats.seen,
+            events_matched=stats.matched,
+            elapsed_seconds=stats.elapsed_seconds,
+            packet_count=capture.metadata.packet_count,
+            device_ids=tuple(device.device_id for device in session.list_devices()),
+        )

--- a/bsu_tool/mcp/tools/live_capture.py
+++ b/bsu_tool/mcp/tools/live_capture.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -37,7 +36,7 @@ def register(mcp: FastMCP, session: Session) -> None:
     """Register live-capture tools on the FastMCP instance."""
 
     @mcp.tool()
-    async def start_capture(  # pyright: ignore[reportUnusedFunction]
+    def start_capture(  # pyright: ignore[reportUnusedFunction]
         bus: int,
         output_path: str,
         device: int | None = None,
@@ -73,31 +72,14 @@ def register(mcp: FastMCP, session: Session) -> None:
         live_capture = LiveCapture(controller=controller, output_path=destination)
         session.reserve_live_capture(live_capture)
         capture_started = False
-        start_job = asyncio.create_task(
-            asyncio.to_thread(controller.start, bus=bus, device=device, output_path=destination)
-        )
         try:
-            await asyncio.shield(start_job)
+            controller.start(bus=bus, device=device, output_path=destination)
             if not controller.is_running:
                 raise CaptureStateError("capture controller returned before the capture was live")
-            if not session.mark_live_capture_running(live_capture):
-                raise CaptureStateError("capture no longer owns the session after startup")
             capture_started = True
-        except asyncio.CancelledError:
-            try:
-                await asyncio.shield(start_job)
-            except Exception:
-                pass
-            session.mark_live_capture_stopping(live_capture)
-            try:
-                await asyncio.shield(asyncio.to_thread(controller.stop))
-            except Exception:
-                pass
-            raise
         except TimeoutError as exc:
-            session.mark_live_capture_stopping(live_capture)
             try:
-                await asyncio.to_thread(controller.stop)
+                controller.stop()
             except Exception as cleanup_error:  # noqa: BLE001 - report startup and cleanup failures together
                 raise RuntimeError(
                     "capture startup timed out and cleanup failed; "
@@ -112,14 +94,12 @@ def register(mcp: FastMCP, session: Session) -> None:
             raise RuntimeError(f"capture could not start: {exc}") from exc
         finally:
             if not capture_started:
-                if controller.is_active:
-                    session.mark_live_capture_stalled(live_capture)
-                else:
+                if not controller.is_active:
                     session.release_live_capture(live_capture)
         return StartCaptureResult(bus=bus, device=device, output_path=str(destination))
 
     @mcp.tool()
-    async def stop_capture() -> StopCaptureResult:  # pyright: ignore[reportUnusedFunction]
+    def stop_capture() -> StopCaptureResult:  # pyright: ignore[reportUnusedFunction]
         """Stop the running capture, load it as the active capture, and summarize it.
 
         Returns the final capture statistics plus what the loaded file contains
@@ -134,7 +114,7 @@ def register(mcp: FastMCP, session: Session) -> None:
 
         try:
             try:
-                stats = await asyncio.to_thread(controller.stop)
+                stats = controller.stop()
             except TimeoutError as exc:
                 raise RuntimeError(
                     f"capture did not stop in time; retry stop_capture before starting another capture: {exc}"
@@ -143,7 +123,7 @@ def register(mcp: FastMCP, session: Session) -> None:
                 raise RuntimeError(f"capture could not stop: {exc}") from exc
             except UsbmonError as exc:
                 raise RuntimeError(f"usbmon capture failed while stopping: {exc}") from exc
-            capture = await asyncio.to_thread(session.load_stopped_capture, live_capture)
+            capture = session.load_stopped_capture(live_capture)
             return StopCaptureResult(
                 output_path=str(output_path),
                 output_bytes=stats.output_bytes,
@@ -154,7 +134,5 @@ def register(mcp: FastMCP, session: Session) -> None:
                 device_ids=tuple(device.device_id for device in session.list_devices()),
             )
         finally:
-            if controller.is_active:
-                session.mark_live_capture_stalled(live_capture)
-            else:
+            if not controller.is_active:
                 session.release_live_capture(live_capture)

--- a/bsu_tool/mcp/tools/live_capture.py
+++ b/bsu_tool/mcp/tools/live_capture.py
@@ -72,15 +72,24 @@ def register(mcp: FastMCP, session: Session) -> None:
         live_capture = LiveCapture(controller=controller, output_path=destination)
         session.reserve_live_capture(live_capture)
         capture_started = False
+        retry_stop = False
         try:
             controller.start(bus=bus, device=device, output_path=destination)
             if not controller.is_running:
                 raise CaptureStateError("capture controller returned before the capture was live")
+            if not session.mark_live_capture_running(live_capture):
+                raise CaptureStateError("capture no longer owns the session after startup")
             capture_started = True
         except TimeoutError as exc:
             try:
                 controller.stop()
             except Exception as cleanup_error:  # noqa: BLE001 - report startup and cleanup failures together
+                retry_stop = controller.is_active
+                if not retry_stop:
+                    raise RuntimeError(
+                        "capture startup timed out and cleanup failed, but the capture is no longer active: "
+                        f"{cleanup_error}"
+                    ) from exc
                 raise RuntimeError(
                     "capture startup timed out and cleanup failed; "
                     f"retry stop_capture before starting another capture: {cleanup_error}"
@@ -94,7 +103,9 @@ def register(mcp: FastMCP, session: Session) -> None:
             raise RuntimeError(f"capture could not start: {exc}") from exc
         finally:
             if not capture_started:
-                if not controller.is_active:
+                if retry_stop or controller.is_active:
+                    session.mark_live_capture_running(live_capture)
+                else:
                     session.release_live_capture(live_capture)
         return StartCaptureResult(bus=bus, device=device, output_path=str(destination))
 
@@ -112,10 +123,12 @@ def register(mcp: FastMCP, session: Session) -> None:
         from bsu_tool.sniffer import CaptureStateError
         from bsu_tool.usbmon_source import UsbmonError
 
+        retry_stop = False
         try:
             try:
                 stats = controller.stop()
             except TimeoutError as exc:
+                retry_stop = True
                 raise RuntimeError(
                     f"capture did not stop in time; retry stop_capture before starting another capture: {exc}"
                 ) from exc
@@ -134,5 +147,7 @@ def register(mcp: FastMCP, session: Session) -> None:
                 device_ids=tuple(device.device_id for device in session.list_devices()),
             )
         finally:
-            if not controller.is_active:
+            if retry_stop or controller.is_active:
+                session.mark_live_capture_running(live_capture)
+            else:
                 session.release_live_capture(live_capture)

--- a/bsu_tool/mcp/tools/live_capture.py
+++ b/bsu_tool/mcp/tools/live_capture.py
@@ -76,6 +76,8 @@ def register(mcp: FastMCP, session: Session) -> None:
             controller.start(bus=bus, device=device, output_path=destination)
             if not controller.is_running:
                 raise CaptureStateError("capture controller returned before the capture was live")
+            if not session.mark_live_capture_running(live_capture):
+                raise CaptureStateError("capture no longer owns the session after startup")
             capture_started = True
         except TimeoutError as exc:
             try:
@@ -102,27 +104,28 @@ def register(mcp: FastMCP, session: Session) -> None:
         (packet count and device ids). The other analysis tools operate on the
         newly loaded capture from here on.
         """
-        live_capture = session.pop_live_capture()
-        if live_capture is None:
-            raise RuntimeError("no capture is running; call start_capture first")
+        live_capture = session.begin_stop_live_capture()
         controller = live_capture.controller
         output_path = live_capture.output_path
         from bsu_tool.sniffer import CaptureStateError
         from bsu_tool.usbmon_source import UsbmonError
 
         try:
-            stats = controller.stop()
-        except CaptureStateError as exc:
-            raise RuntimeError(f"capture could not stop: {exc}") from exc
-        except UsbmonError as exc:
-            raise RuntimeError(f"usbmon capture failed while stopping: {exc}") from exc
-        capture = session.load(output_path)
-        return StopCaptureResult(
-            output_path=str(output_path),
-            output_bytes=stats.output_bytes,
-            events_seen=stats.seen,
-            events_matched=stats.matched,
-            elapsed_seconds=stats.elapsed_seconds,
-            packet_count=capture.metadata.packet_count,
-            device_ids=tuple(device.device_id for device in session.list_devices()),
-        )
+            try:
+                stats = controller.stop()
+            except CaptureStateError as exc:
+                raise RuntimeError(f"capture could not stop: {exc}") from exc
+            except UsbmonError as exc:
+                raise RuntimeError(f"usbmon capture failed while stopping: {exc}") from exc
+            capture = session.load(output_path)
+            return StopCaptureResult(
+                output_path=str(output_path),
+                output_bytes=stats.output_bytes,
+                events_seen=stats.seen,
+                events_matched=stats.matched,
+                elapsed_seconds=stats.elapsed_seconds,
+                packet_count=capture.metadata.packet_count,
+                device_ids=tuple(device.device_id for device in session.list_devices()),
+            )
+        finally:
+            session.release_live_capture(live_capture)

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -6,7 +6,7 @@ from _thread import LockType
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, Literal
 
 from bsu_tool.mcp.interfaces import (
     CaptureInterface,
@@ -120,6 +120,9 @@ class LiveCapture:
     output_path: Path
 
 
+_LiveCapturePhase = Literal["starting", "running", "stopping"]
+
+
 @dataclass
 class _DeviceAccumulator:
     bus_num: int
@@ -142,21 +145,40 @@ class Session:
 
     capture: Capture | None = None
     live_capture: LiveCapture | None = field(default=None, init=False)
+    _live_capture_phase: _LiveCapturePhase | None = field(default=None, init=False, repr=False, compare=False)
     _live_capture_lock: LockType = field(default_factory=Lock, init=False, repr=False, compare=False)
 
     def reserve_live_capture(self, live_capture: LiveCapture) -> None:
         """Atomically reserve this session for one live capture."""
         with self._live_capture_lock:
             if self.live_capture is not None:
+                if self._live_capture_phase == "starting":
+                    raise RuntimeError("a capture is already starting; wait for start_capture to finish")
+                if self._live_capture_phase == "stopping":
+                    raise RuntimeError("a capture is still stopping; wait for stop_capture to finish")
                 raise RuntimeError("a capture is already running; call stop_capture first")
             self.live_capture = live_capture
+            self._live_capture_phase = "starting"
+
+    def mark_live_capture_running(self, live_capture: LiveCapture) -> bool:
+        """Mark an owned capture available for a stop operation."""
+        with self._live_capture_lock:
+            if self.live_capture is not live_capture:
+                return False
+            self._live_capture_phase = "running"
+            return True
 
     def begin_stop_live_capture(self) -> LiveCapture:
-        """Return the live capture currently owned by this session."""
+        """Atomically claim the running capture for one stop operation."""
         with self._live_capture_lock:
             live_capture = self.live_capture
             if live_capture is None:
                 raise RuntimeError("no capture is running; call start_capture first")
+            if self._live_capture_phase == "starting":
+                raise RuntimeError("capture is still starting; wait for start_capture to finish")
+            if self._live_capture_phase == "stopping":
+                raise RuntimeError("capture is already stopping; wait for stop_capture to finish")
+            self._live_capture_phase = "stopping"
             return live_capture
 
     def release_live_capture(self, live_capture: LiveCapture) -> None:
@@ -164,6 +186,7 @@ class Session:
         with self._live_capture_lock:
             if self.live_capture is live_capture:
                 self.live_capture = None
+                self._live_capture_phase = None
 
     def load(self, path: Path) -> Capture:
         """Load a pcap-ng capture file and replace the active capture."""

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -120,7 +120,7 @@ class LiveCapture:
     output_path: Path
 
 
-_LiveCapturePhase = Literal["starting", "running", "stopping"]
+_LiveCapturePhase = Literal["starting", "running", "stopping", "stalled"]
 
 
 @dataclass
@@ -147,14 +147,17 @@ class Session:
     live_capture: LiveCapture | None = field(default=None, init=False)
     _live_capture_phase: _LiveCapturePhase | None = field(default=None, init=False, repr=False, compare=False)
     _live_capture_lock: LockType = field(default_factory=Lock, init=False, repr=False, compare=False)
+    _capture_loading: bool = field(default=False, init=False, repr=False, compare=False)
 
     def reserve_live_capture(self, live_capture: LiveCapture) -> None:
         """Atomically reserve this session for one live capture."""
         with self._live_capture_lock:
+            if self._capture_loading:
+                raise RuntimeError("a capture file is currently loading; wait for load_capture to finish")
             if self.live_capture is not None:
                 if self._live_capture_phase == "starting":
                     raise RuntimeError("a capture is already starting; wait for start_capture to finish")
-                if self._live_capture_phase == "stopping":
+                if self._live_capture_phase in ("stopping", "stalled"):
                     raise RuntimeError("a capture is still stopping; wait for stop_capture to finish")
                 raise RuntimeError("a capture is already running; call stop_capture first")
             self.live_capture = live_capture
@@ -168,8 +171,22 @@ class Session:
             self._live_capture_phase = "running"
             return True
 
+    def mark_live_capture_stopping(self, live_capture: LiveCapture) -> bool:
+        """Mark a starting capture as stopping during failed-start cleanup."""
+        with self._live_capture_lock:
+            if self.live_capture is not live_capture or self._live_capture_phase != "starting":
+                return False
+            self._live_capture_phase = "stopping"
+            return True
+
+    def mark_live_capture_stalled(self, live_capture: LiveCapture) -> None:
+        """Keep an active capture reserved after a bounded stop times out."""
+        with self._live_capture_lock:
+            if self.live_capture is live_capture:
+                self._live_capture_phase = "stalled"
+
     def begin_stop_live_capture(self) -> LiveCapture:
-        """Atomically claim the running capture for one stop operation."""
+        """Atomically claim a running or stalled capture for one stop operation."""
         with self._live_capture_lock:
             live_capture = self.live_capture
             if live_capture is None:
@@ -190,49 +207,33 @@ class Session:
 
     def load(self, path: Path) -> Capture:
         """Load a pcap-ng capture file and replace the active capture."""
-        source = _validate_capture_path(path)
-        file_size_bytes = source.stat().st_size
+        return self._load_capture(path, live_capture=None)
 
-        interfaces_seen: list[CaptureInterface] = []
-        current_section_interfaces: list[CaptureInterface] = []
-        packets: list[CapturePacket] = []
-        packet_timestamps: list[float] = []
+    def load_stopped_capture(self, live_capture: LiveCapture) -> Capture:
+        """Load the output owned by the current stopping live capture."""
+        return self._load_capture(live_capture.output_path, live_capture=live_capture)
 
-        with source.open("rb") as stream:
-            for block in PcapNgReader(stream):
-                if isinstance(block, SectionHeaderBlock):
-                    current_section_interfaces = []
-                    continue
-                if isinstance(block, InterfaceDescriptionBlock):
-                    interface = _capture_interface(block, len(current_section_interfaces))
-                    current_section_interfaces.append(interface)
-                    interfaces_seen.append(interface)
-                    continue
-                if isinstance(block, EnhancedPacketBlock):
-                    packet = _capture_enhanced_packet(block, current_section_interfaces)
-                    packets.append(packet)
-                    if packet.pcap_timestamp_seconds is not None:
-                        packet_timestamps.append(packet.pcap_timestamp_seconds)
-                    continue
-                if isinstance(block, SimplePacketBlock):
-                    packets.append(_capture_simple_packet(block, current_section_interfaces))
+    def _load_capture(self, path: Path, *, live_capture: LiveCapture | None) -> Capture:
+        self._begin_capture_load(live_capture)
+        try:
+            capture = _read_capture(path)
+            with self._live_capture_lock:
+                self.capture = capture
+            return capture
+        finally:
+            with self._live_capture_lock:
+                self._capture_loading = False
 
-        metadata = CaptureMetadata(
-            source=str(source),
-            file_size_bytes=file_size_bytes,
-            packet_count=len(packets),
-            capture_duration_seconds=_capture_duration(packet_timestamps),
-            interfaces_seen=tuple(interfaces_seen),
-        )
-        records = _decode_supported_packets(packets)
-        self.capture = Capture(
-            source=source,
-            metadata=metadata,
-            packets=tuple(packets),
-            records=records,
-            transactions=tuple(pair_urbs(records)),
-        )
-        return self.capture
+    def _begin_capture_load(self, live_capture: LiveCapture | None) -> None:
+        with self._live_capture_lock:
+            if self._capture_loading:
+                raise RuntimeError("another capture file is already loading")
+            if live_capture is None:
+                if self.live_capture is not None:
+                    raise RuntimeError("cannot load a capture file while a live capture is active")
+            elif self.live_capture is not live_capture or self._live_capture_phase != "stopping":
+                raise RuntimeError("only the current stopping capture can load its output")
+            self._capture_loading = True
 
     def add_marker(self, name: str, packet_index: int, note: str | None = None) -> Marker:
         """Append a named marker anchored to a decoded packet and return it.
@@ -410,6 +411,50 @@ def _find_marker(markers: list[Marker], name: str) -> Marker:
         if marker.name == name:
             return marker
     raise ValueError(f"no marker named {name!r}")
+
+
+def _read_capture(path: Path) -> Capture:
+    source = _validate_capture_path(path)
+    file_size_bytes = source.stat().st_size
+    interfaces_seen: list[CaptureInterface] = []
+    current_section_interfaces: list[CaptureInterface] = []
+    packets: list[CapturePacket] = []
+    packet_timestamps: list[float] = []
+
+    with source.open("rb") as stream:
+        for block in PcapNgReader(stream):
+            if isinstance(block, SectionHeaderBlock):
+                current_section_interfaces = []
+                continue
+            if isinstance(block, InterfaceDescriptionBlock):
+                interface = _capture_interface(block, len(current_section_interfaces))
+                current_section_interfaces.append(interface)
+                interfaces_seen.append(interface)
+                continue
+            if isinstance(block, EnhancedPacketBlock):
+                packet = _capture_enhanced_packet(block, current_section_interfaces)
+                packets.append(packet)
+                if packet.pcap_timestamp_seconds is not None:
+                    packet_timestamps.append(packet.pcap_timestamp_seconds)
+                continue
+            if isinstance(block, SimplePacketBlock):
+                packets.append(_capture_simple_packet(block, current_section_interfaces))
+
+    metadata = CaptureMetadata(
+        source=str(source),
+        file_size_bytes=file_size_bytes,
+        packet_count=len(packets),
+        capture_duration_seconds=_capture_duration(packet_timestamps),
+        interfaces_seen=tuple(interfaces_seen),
+    )
+    records = _decode_supported_packets(packets)
+    return Capture(
+        source=source,
+        metadata=metadata,
+        packets=tuple(packets),
+        records=records,
+        transactions=tuple(pair_urbs(records)),
+    )
 
 
 def _validate_capture_path(path: Path) -> Path:

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -6,7 +6,7 @@ from _thread import LockType
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, Literal
 
 from bsu_tool.mcp.interfaces import (
     CaptureInterface,
@@ -120,6 +120,9 @@ class LiveCapture:
     output_path: Path
 
 
+_LiveCapturePhase = Literal["starting", "running", "stopping"]
+
+
 @dataclass
 class _DeviceAccumulator:
     bus_num: int
@@ -141,28 +144,49 @@ class Session:
     """Holds the active loaded capture."""
 
     capture: Capture | None = None
-    live_capture: LiveCapture | None = None
+    live_capture: LiveCapture | None = field(default=None, init=False)
+    _live_capture_phase: _LiveCapturePhase | None = field(default=None, init=False, repr=False, compare=False)
     _live_capture_lock: LockType = field(default_factory=Lock, init=False, repr=False, compare=False)
 
     def reserve_live_capture(self, live_capture: LiveCapture) -> None:
         """Atomically reserve this session for one live capture."""
         with self._live_capture_lock:
             if self.live_capture is not None:
+                if self._live_capture_phase == "starting":
+                    raise RuntimeError("a capture is already starting; wait for start_capture to finish")
+                if self._live_capture_phase == "stopping":
+                    raise RuntimeError("a capture is still stopping; wait for stop_capture to finish")
                 raise RuntimeError("a capture is already running; call stop_capture first")
             self.live_capture = live_capture
+            self._live_capture_phase = "starting"
+
+    def mark_live_capture_running(self, live_capture: LiveCapture) -> bool:
+        """Mark a reserved capture running if it still owns the session."""
+        with self._live_capture_lock:
+            if self.live_capture is not live_capture or self._live_capture_phase != "starting":
+                return False
+            self._live_capture_phase = "running"
+            return True
+
+    def begin_stop_live_capture(self) -> LiveCapture:
+        """Atomically claim the running capture for one stop operation."""
+        with self._live_capture_lock:
+            live_capture = self.live_capture
+            if live_capture is None:
+                raise RuntimeError("no capture is running; call start_capture first")
+            if self._live_capture_phase == "starting":
+                raise RuntimeError("capture is still starting; wait for start_capture to finish")
+            if self._live_capture_phase == "stopping":
+                raise RuntimeError("capture is already stopping; wait for stop_capture to finish")
+            self._live_capture_phase = "stopping"
+            return live_capture
 
     def release_live_capture(self, live_capture: LiveCapture) -> None:
         """Release ``live_capture`` if it still owns this session."""
         with self._live_capture_lock:
             if self.live_capture is live_capture:
                 self.live_capture = None
-
-    def pop_live_capture(self) -> LiveCapture | None:
-        """Atomically remove and return the session's live capture."""
-        with self._live_capture_lock:
-            live_capture = self.live_capture
-            self.live_capture = None
-            return live_capture
+                self._live_capture_phase = None
 
     def load(self, path: Path) -> Capture:
         """Load a pcap-ng capture file and replace the active capture."""

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from _thread import LockType
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Final
+from threading import Lock
+from typing import TYPE_CHECKING, Final
 
 from bsu_tool.mcp.interfaces import (
     CaptureInterface,
@@ -33,6 +35,9 @@ from bsu_tool.urb_decoder import (
     decode_urb,
     pair_urbs,
 )
+
+if TYPE_CHECKING:
+    from bsu_tool.sniffer import CaptureController
 
 _PCAPNG_SUFFIX: Final[str] = ".pcapng"
 _IF_TSRESOL_OPTION: Final[int] = 9
@@ -107,6 +112,14 @@ class Capture:
     markers: list[Marker] = field(default_factory=_empty_markers)
 
 
+@dataclass(frozen=True, slots=True)
+class LiveCapture:
+    """A live capture owned by a session until it is stopped."""
+
+    controller: CaptureController
+    output_path: Path
+
+
 @dataclass
 class _DeviceAccumulator:
     bus_num: int
@@ -128,6 +141,28 @@ class Session:
     """Holds the active loaded capture."""
 
     capture: Capture | None = None
+    live_capture: LiveCapture | None = None
+    _live_capture_lock: LockType = field(default_factory=Lock, init=False, repr=False, compare=False)
+
+    def reserve_live_capture(self, live_capture: LiveCapture) -> None:
+        """Atomically reserve this session for one live capture."""
+        with self._live_capture_lock:
+            if self.live_capture is not None:
+                raise RuntimeError("a capture is already running; call stop_capture first")
+            self.live_capture = live_capture
+
+    def release_live_capture(self, live_capture: LiveCapture) -> None:
+        """Release ``live_capture`` if it still owns this session."""
+        with self._live_capture_lock:
+            if self.live_capture is live_capture:
+                self.live_capture = None
+
+    def pop_live_capture(self) -> LiveCapture | None:
+        """Atomically remove and return the session's live capture."""
+        with self._live_capture_lock:
+            live_capture = self.live_capture
+            self.live_capture = None
+            return live_capture
 
     def load(self, path: Path) -> Capture:
         """Load a pcap-ng capture file and replace the active capture."""

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -6,7 +6,7 @@ from _thread import LockType
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Final, Literal
+from typing import TYPE_CHECKING, Final
 
 from bsu_tool.mcp.interfaces import (
     CaptureInterface,
@@ -120,9 +120,6 @@ class LiveCapture:
     output_path: Path
 
 
-_LiveCapturePhase = Literal["starting", "running", "stopping", "stalled"]
-
-
 @dataclass
 class _DeviceAccumulator:
     bus_num: int
@@ -145,57 +142,21 @@ class Session:
 
     capture: Capture | None = None
     live_capture: LiveCapture | None = field(default=None, init=False)
-    _live_capture_phase: _LiveCapturePhase | None = field(default=None, init=False, repr=False, compare=False)
     _live_capture_lock: LockType = field(default_factory=Lock, init=False, repr=False, compare=False)
-    _capture_loading: bool = field(default=False, init=False, repr=False, compare=False)
 
     def reserve_live_capture(self, live_capture: LiveCapture) -> None:
         """Atomically reserve this session for one live capture."""
         with self._live_capture_lock:
-            if self._capture_loading:
-                raise RuntimeError("a capture file is currently loading; wait for load_capture to finish")
             if self.live_capture is not None:
-                if self._live_capture_phase == "starting":
-                    raise RuntimeError("a capture is already starting; wait for start_capture to finish")
-                if self._live_capture_phase in ("stopping", "stalled"):
-                    raise RuntimeError("a capture is still stopping; wait for stop_capture to finish")
                 raise RuntimeError("a capture is already running; call stop_capture first")
             self.live_capture = live_capture
-            self._live_capture_phase = "starting"
-
-    def mark_live_capture_running(self, live_capture: LiveCapture) -> bool:
-        """Mark a reserved capture running if it still owns the session."""
-        with self._live_capture_lock:
-            if self.live_capture is not live_capture or self._live_capture_phase != "starting":
-                return False
-            self._live_capture_phase = "running"
-            return True
-
-    def mark_live_capture_stopping(self, live_capture: LiveCapture) -> bool:
-        """Mark a starting capture as stopping during failed-start cleanup."""
-        with self._live_capture_lock:
-            if self.live_capture is not live_capture or self._live_capture_phase != "starting":
-                return False
-            self._live_capture_phase = "stopping"
-            return True
-
-    def mark_live_capture_stalled(self, live_capture: LiveCapture) -> None:
-        """Keep an active capture reserved after a bounded stop times out."""
-        with self._live_capture_lock:
-            if self.live_capture is live_capture:
-                self._live_capture_phase = "stalled"
 
     def begin_stop_live_capture(self) -> LiveCapture:
-        """Atomically claim a running or stalled capture for one stop operation."""
+        """Return the live capture currently owned by this session."""
         with self._live_capture_lock:
             live_capture = self.live_capture
             if live_capture is None:
                 raise RuntimeError("no capture is running; call start_capture first")
-            if self._live_capture_phase == "starting":
-                raise RuntimeError("capture is still starting; wait for start_capture to finish")
-            if self._live_capture_phase == "stopping":
-                raise RuntimeError("capture is already stopping; wait for stop_capture to finish")
-            self._live_capture_phase = "stopping"
             return live_capture
 
     def release_live_capture(self, live_capture: LiveCapture) -> None:
@@ -203,37 +164,65 @@ class Session:
         with self._live_capture_lock:
             if self.live_capture is live_capture:
                 self.live_capture = None
-                self._live_capture_phase = None
 
     def load(self, path: Path) -> Capture:
         """Load a pcap-ng capture file and replace the active capture."""
-        return self._load_capture(path, live_capture=None)
+        with self._live_capture_lock:
+            if self.live_capture is not None:
+                raise RuntimeError("cannot load a capture file while a live capture is active")
+        return self._load_capture(path)
 
     def load_stopped_capture(self, live_capture: LiveCapture) -> Capture:
-        """Load the output owned by the current stopping live capture."""
-        return self._load_capture(live_capture.output_path, live_capture=live_capture)
-
-    def _load_capture(self, path: Path, *, live_capture: LiveCapture | None) -> Capture:
-        self._begin_capture_load(live_capture)
-        try:
-            capture = _read_capture(path)
-            with self._live_capture_lock:
-                self.capture = capture
-            return capture
-        finally:
-            with self._live_capture_lock:
-                self._capture_loading = False
-
-    def _begin_capture_load(self, live_capture: LiveCapture | None) -> None:
+        """Load the output owned by the current live capture."""
         with self._live_capture_lock:
-            if self._capture_loading:
-                raise RuntimeError("another capture file is already loading")
-            if live_capture is None:
-                if self.live_capture is not None:
-                    raise RuntimeError("cannot load a capture file while a live capture is active")
-            elif self.live_capture is not live_capture or self._live_capture_phase != "stopping":
-                raise RuntimeError("only the current stopping capture can load its output")
-            self._capture_loading = True
+            if self.live_capture is not live_capture:
+                raise RuntimeError("capture no longer owns this session")
+        return self._load_capture(live_capture.output_path)
+
+    def _load_capture(self, path: Path) -> Capture:
+        source = _validate_capture_path(path)
+        file_size_bytes = source.stat().st_size
+
+        interfaces_seen: list[CaptureInterface] = []
+        current_section_interfaces: list[CaptureInterface] = []
+        packets: list[CapturePacket] = []
+        packet_timestamps: list[float] = []
+
+        with source.open("rb") as stream:
+            for block in PcapNgReader(stream):
+                if isinstance(block, SectionHeaderBlock):
+                    current_section_interfaces = []
+                    continue
+                if isinstance(block, InterfaceDescriptionBlock):
+                    interface = _capture_interface(block, len(current_section_interfaces))
+                    current_section_interfaces.append(interface)
+                    interfaces_seen.append(interface)
+                    continue
+                if isinstance(block, EnhancedPacketBlock):
+                    packet = _capture_enhanced_packet(block, current_section_interfaces)
+                    packets.append(packet)
+                    if packet.pcap_timestamp_seconds is not None:
+                        packet_timestamps.append(packet.pcap_timestamp_seconds)
+                    continue
+                if isinstance(block, SimplePacketBlock):
+                    packets.append(_capture_simple_packet(block, current_section_interfaces))
+
+        metadata = CaptureMetadata(
+            source=str(source),
+            file_size_bytes=file_size_bytes,
+            packet_count=len(packets),
+            capture_duration_seconds=_capture_duration(packet_timestamps),
+            interfaces_seen=tuple(interfaces_seen),
+        )
+        records = _decode_supported_packets(packets)
+        self.capture = Capture(
+            source=source,
+            metadata=metadata,
+            packets=tuple(packets),
+            records=records,
+            transactions=tuple(pair_urbs(records)),
+        )
+        return self.capture
 
     def add_marker(self, name: str, packet_index: int, note: str | None = None) -> Marker:
         """Append a named marker anchored to a decoded packet and return it.
@@ -411,50 +400,6 @@ def _find_marker(markers: list[Marker], name: str) -> Marker:
         if marker.name == name:
             return marker
     raise ValueError(f"no marker named {name!r}")
-
-
-def _read_capture(path: Path) -> Capture:
-    source = _validate_capture_path(path)
-    file_size_bytes = source.stat().st_size
-    interfaces_seen: list[CaptureInterface] = []
-    current_section_interfaces: list[CaptureInterface] = []
-    packets: list[CapturePacket] = []
-    packet_timestamps: list[float] = []
-
-    with source.open("rb") as stream:
-        for block in PcapNgReader(stream):
-            if isinstance(block, SectionHeaderBlock):
-                current_section_interfaces = []
-                continue
-            if isinstance(block, InterfaceDescriptionBlock):
-                interface = _capture_interface(block, len(current_section_interfaces))
-                current_section_interfaces.append(interface)
-                interfaces_seen.append(interface)
-                continue
-            if isinstance(block, EnhancedPacketBlock):
-                packet = _capture_enhanced_packet(block, current_section_interfaces)
-                packets.append(packet)
-                if packet.pcap_timestamp_seconds is not None:
-                    packet_timestamps.append(packet.pcap_timestamp_seconds)
-                continue
-            if isinstance(block, SimplePacketBlock):
-                packets.append(_capture_simple_packet(block, current_section_interfaces))
-
-    metadata = CaptureMetadata(
-        source=str(source),
-        file_size_bytes=file_size_bytes,
-        packet_count=len(packets),
-        capture_duration_seconds=_capture_duration(packet_timestamps),
-        interfaces_seen=tuple(interfaces_seen),
-    )
-    records = _decode_supported_packets(packets)
-    return Capture(
-        source=source,
-        metadata=metadata,
-        packets=tuple(packets),
-        records=records,
-        transactions=tuple(pair_urbs(records)),
-    )
 
 
 def _validate_capture_path(path: Path) -> Path:

--- a/bsu_tool/sniffer.py
+++ b/bsu_tool/sniffer.py
@@ -137,57 +137,75 @@ def capture(
     stats = CaptureStats(output_path=output_path)
     start_time = time.monotonic()
     last_progress_time = start_time
+    output_created = False
+    capture_live = False
 
-    # "xb" fails atomically if the path exists, so the caller needn't do
-    # its own check-then-open (which would race).
-    with output_path.open("xb") as out_fp:
-        writer = PcapNgWriter(out_fp)
-        writer.write_section_header()
-        interface_id = writer.write_interface_description(
-            link_type=LINKTYPE_USB_LINUX_MMAPPED,
-        )
+    if output_path.exists():
+        raise FileExistsError(output_path)
 
+    try:
         with UsbmonSource(bus_number=bus, stop_event=stop_event) as source:
-            # File open and device polling: the capture is live. Signal any
-            # waiter that it's now safe to tell the user to operate the device.
-            if ready_event is not None:
-                ready_event.set()
+            if stop_event.is_set():
+                stats.elapsed_seconds = time.monotonic() - start_time
+                return stats
 
-            for header, data in source:
-                stats.seen += 1
+            # "xb" remains the atomic guard against a path created while the
+            # usbmon source was opening.
+            with output_path.open("xb") as out_fp:
+                output_created = True
+                writer = PcapNgWriter(out_fp)
+                writer.write_section_header()
+                interface_id = writer.write_interface_description(
+                    link_type=LINKTYPE_USB_LINUX_MMAPPED,
+                )
+                capture_live = True
+                # File open and device polling: the capture is live. Signal any
+                # waiter that it's now safe to tell the user to operate the device.
+                if ready_event is not None:
+                    ready_event.set()
 
-                if device is not None and header[_DEVNUM_OFFSET] != device:
-                    # Another device on the bus. Still tick progress so a wrong
-                    # --device shows climbing "seen" against stuck "matched".
+                for header, data in source:
+                    stats.seen += 1
+
+                    if device is not None and header[_DEVNUM_OFFSET] != device:
+                        # Another device on the bus. Still tick progress so a wrong
+                        # --device shows climbing "seen" against stuck "matched".
+                        now = time.monotonic()
+                        if on_progress is not None and now - last_progress_time >= _PROGRESS_INTERVAL_SECONDS:
+                            stats.elapsed_seconds = now - start_time
+                            stats.output_bytes = out_fp.tell()
+                            on_progress(stats)
+                            last_progress_time = now
+                        continue
+
+                    # Derive the EPB timestamp from the usbmon header rather than
+                    # time.time(), so a reader sees consistent values whether it
+                    # reads the EPB header or the URB header.
+                    ts_sec = int.from_bytes(header[16:24], "little", signed=True)
+                    ts_usec = int.from_bytes(header[24:28], "little", signed=True)
+                    timestamp_us = ts_sec * 1_000_000 + ts_usec
+
+                    packet_data = header + data
+                    writer.write_enhanced_packet(
+                        interface_id=interface_id,
+                        timestamp_us=timestamp_us,
+                        packet_data=packet_data,
+                    )
+                    stats.matched += 1
+
                     now = time.monotonic()
                     if on_progress is not None and now - last_progress_time >= _PROGRESS_INTERVAL_SECONDS:
                         stats.elapsed_seconds = now - start_time
                         stats.output_bytes = out_fp.tell()
                         on_progress(stats)
                         last_progress_time = now
-                    continue
-
-                # Derive the EPB timestamp from the usbmon header rather than
-                # time.time(), so a reader sees consistent values whether it
-                # reads the EPB header or the URB header.
-                ts_sec = int.from_bytes(header[16:24], "little", signed=True)
-                ts_usec = int.from_bytes(header[24:28], "little", signed=True)
-                timestamp_us = ts_sec * 1_000_000 + ts_usec
-
-                packet_data = header + data
-                writer.write_enhanced_packet(
-                    interface_id=interface_id,
-                    timestamp_us=timestamp_us,
-                    packet_data=packet_data,
-                )
-                stats.matched += 1
-
-                now = time.monotonic()
-                if on_progress is not None and now - last_progress_time >= _PROGRESS_INTERVAL_SECONDS:
-                    stats.elapsed_seconds = now - start_time
-                    stats.output_bytes = out_fp.tell()
-                    on_progress(stats)
-                    last_progress_time = now
+    except BaseException as exc:  # noqa: BLE001 - preserve the original capture failure
+        if output_created and not capture_live:
+            try:
+                output_path.unlink()
+            except OSError as cleanup_error:
+                exc.add_note(f"could not remove incomplete output {output_path}: {cleanup_error}")
+        raise
 
     # Final update after close, so output_bytes is the true file size
     # rather than a possibly-still-buffered tell().
@@ -216,6 +234,10 @@ def capture(
 #: capture to go live. Startup should take milliseconds; this only guards
 #: against a pathological hang.
 _DEFAULT_READY_TIMEOUT_SECONDS: float = 5.0
+
+#: Default ceiling on how long :meth:`CaptureController.stop` waits for the
+#: capture thread to finish after it has been signalled.
+_DEFAULT_STOP_TIMEOUT_SECONDS: float = 5.0
 
 #: Poll granularity of the start-time wait loop: prompt enough to notice a fast
 #: startup failure, coarse enough not to busy-spin.
@@ -268,6 +290,11 @@ class CaptureController:
     def is_running(self) -> bool:
         """Whether a capture is live (started, gone ready, not yet finished)."""
         return self._ready.is_set() and not self._finished.is_set()
+
+    @property
+    def is_active(self) -> bool:
+        """Whether the capture thread has started and not yet finished."""
+        return self._thread is not None and self._thread.is_alive()
 
     def start(
         self,
@@ -344,20 +371,22 @@ class CaptureController:
             raise self._exc
         if deadline_reached:
             raise TimeoutError(f"capture did not go live within {ready_timeout:.1f}s")
-        # _finished set, no exception, never went ready: capture returned
-        # immediately (e.g. stop_event somehow pre-set). Nothing to wait on.
+        raise CaptureStateError("capture finished before becoming live")
 
-    def stop(self) -> CaptureStats:
+    def stop(self, *, timeout: float = _DEFAULT_STOP_TIMEOUT_SECONDS) -> CaptureStats:
         """Stop the capture, wait for the thread, and return final stats.
 
-        Signals the capture to stop and joins the thread. If the capture raised
-        after going live, that exception is re-raised here.
+        Signals the capture to stop and waits up to ``timeout`` seconds for the
+        thread. If the capture raised after going live, that exception is
+        re-raised here.
 
         Raises
         ------
         CaptureStateError
             If called before :meth:`start`, or if the capture produced neither
             stats nor an exception (should not happen).
+        TimeoutError
+            If the capture thread does not finish within ``timeout`` seconds.
         Exception
             Any error raised by ``capture`` after the capture went live.
         """
@@ -365,7 +394,9 @@ class CaptureController:
             raise CaptureStateError("stop() called before start()")
 
         self._stop.set()
-        self._thread.join()
+        self._thread.join(timeout)
+        if self._thread.is_alive():
+            raise TimeoutError(f"capture did not stop within {timeout:.1f}s")
 
         if self._exc is not None:
             raise self._exc

--- a/tests/unit/mcp/test_live_capture.py
+++ b/tests/unit/mcp/test_live_capture.py
@@ -1,0 +1,338 @@
+"""Tests for the live-capture MCP tools (start_capture / stop_capture).
+
+Most tests replace the controller, while the readiness test uses the real
+controller with a monkeypatched capture function. No usbmon access is required.
+Both paths copy a real Goodix fixture so stop_capture still exercises the real
+decode pipeline with capture-specific values.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Event
+from typing import Any, ClassVar
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import TextContent
+
+from bsu_tool.mcp.server import build_server
+from bsu_tool.session import Session
+from bsu_tool.sniffer import CaptureController, CaptureStateError, CaptureStats, ProgressCallback
+from bsu_tool.usbmon_source import UsbmonBusNotAvailableError, UsbmonIoctlError, UsbmonPermissionError
+
+_GOODIX = (
+    pathlib.Path(__file__).parent.parent.parent.parent
+    / "test_data"
+    / "captures"
+    / "goodix_enum_and_enroll_sanitized.pcapng"
+)
+
+
+class _FakeController:
+    """Stands in for sniffer.CaptureController without touching usbmon."""
+
+    instances: ClassVar[list[_FakeController]] = []
+    start_error: ClassVar[Exception | None] = None
+    stop_error: ClassVar[Exception | None] = None
+    start_entered: ClassVar[Event | None] = None
+    start_release: ClassVar[Event | None] = None
+    running_after_start: ClassVar[bool] = True
+
+    def __init__(self) -> None:
+        self.start_args: tuple[int, int | None, Path] | None = None
+        self.stop_calls = 0
+        _FakeController.instances.append(self)
+
+    def start(self, bus: int, device: int | None, output_path: Path) -> None:
+        self.start_args = (bus, device, output_path)
+        if _FakeController.start_entered is not None:
+            _FakeController.start_entered.set()
+            assert _FakeController.start_release is not None
+            assert _FakeController.start_release.wait(timeout=1.0)
+        if _FakeController.start_error is not None:
+            raise _FakeController.start_error
+        shutil.copyfile(_GOODIX, output_path)
+
+    @property
+    def is_running(self) -> bool:
+        return (
+            self.start_args is not None
+            and self.stop_calls == 0
+            and _FakeController.start_error is None
+            and _FakeController.running_after_start
+        )
+
+    def stop(self) -> CaptureStats:
+        self.stop_calls += 1
+        if _FakeController.stop_error is not None:
+            raise _FakeController.stop_error
+        assert self.start_args is not None
+        return CaptureStats(
+            output_path=self.start_args[2],
+            seen=500,
+            matched=253,
+            elapsed_seconds=2.5,
+            output_bytes=4242,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _fake_controller(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    _FakeController.instances = []
+    _FakeController.start_error = None
+    _FakeController.stop_error = None
+    _FakeController.start_entered = None
+    _FakeController.start_release = None
+    _FakeController.running_after_start = True
+    monkeypatch.setattr("bsu_tool.sniffer.CaptureController", _FakeController)
+
+
+def _call(server: FastMCP, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    content = asyncio.run(server.call_tool(tool, arguments))
+    assert isinstance(content, list)
+    assert len(content) == 1
+    block = content[0]
+    assert isinstance(block, TextContent)
+    payload: dict[str, Any] = json.loads(block.text)
+    return payload
+
+
+def test_start_capture_starts_controller_and_reports(tmp_path: Path) -> None:
+    """start_capture drives the controller with the given target and echoes it back."""
+    server = build_server(session=Session())
+    out = tmp_path / "live.pcapng"
+
+    payload = _call(server, "start_capture", {"bus": 1, "output_path": str(out)})
+
+    assert payload == {"bus": 1, "device": None, "output_path": str(out)}
+    (controller,) = _FakeController.instances
+    assert controller.start_args == (1, None, out)
+
+
+def test_start_capture_reservation_is_shared_across_servers(tmp_path: Path) -> None:
+    """Servers using one Session reject a second start while the first is starting."""
+    session = Session()
+    first_server = build_server(session=session)
+    second_server = build_server(session=session)
+    _FakeController.start_entered = Event()
+    _FakeController.start_release = Event()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        first_start = executor.submit(
+            _call,
+            first_server,
+            "start_capture",
+            {"bus": 1, "output_path": str(tmp_path / "a.pcapng")},
+        )
+        assert _FakeController.start_entered.wait(timeout=1.0)
+        assert session.live_capture is not None
+        try:
+            with pytest.raises(ToolError, match="already running"):
+                asyncio.run(
+                    second_server.call_tool(
+                        "start_capture",
+                        {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
+                    )
+                )
+        finally:
+            _FakeController.start_release.set()
+        first_start.result(timeout=1.0)
+
+    _call(second_server, "stop_capture", {})
+    assert session.live_capture is None
+
+
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        (FileExistsError("output already exists"), "capture output already exists"),
+        (UsbmonBusNotAvailableError("bus 9 not available"), "usbmon capture could not start"),
+        (UsbmonPermissionError("permission denied"), "usbmon capture could not start"),
+        (CaptureStateError("capture already started"), "capture could not start"),
+    ],
+)
+def test_start_capture_error_surfaces_and_frees_the_slot(
+    tmp_path: Path,
+    error: Exception,
+    message: str,
+) -> None:
+    """A startup failure becomes a clear tool error and does not wedge the capture slot."""
+    _FakeController.start_error = error
+    server = build_server(session=Session())
+
+    with pytest.raises(ToolError, match=message):
+        asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "x.pcapng")}))
+
+    _FakeController.start_error = None
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "y.pcapng")})
+
+
+def test_start_capture_timeout_stops_controller_and_frees_slot(tmp_path: Path) -> None:
+    """A readiness timeout stops the background capture before freeing the session."""
+    _FakeController.start_error = TimeoutError("capture did not go live")
+    session = Session()
+    server = build_server(session=session)
+
+    with pytest.raises(ToolError, match="capture startup timed out"):
+        asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "x.pcapng")}))
+
+    assert _FakeController.instances[0].stop_calls == 1
+    assert session.live_capture is None
+    _FakeController.start_error = None
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "y.pcapng")})
+
+
+def test_start_capture_timeout_reports_cleanup_failure(tmp_path: Path) -> None:
+    """A failed timeout cleanup is reported without retaining the session slot."""
+    _FakeController.start_error = TimeoutError("capture did not go live")
+    _FakeController.stop_error = UsbmonIoctlError("cleanup failed")
+    session = Session()
+    server = build_server(session=session)
+
+    with pytest.raises(ToolError, match="capture startup timed out and cleanup failed"):
+        asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "x.pcapng")}))
+
+    assert _FakeController.instances[0].stop_calls == 1
+    assert session.live_capture is None
+
+
+def test_start_capture_rejects_controller_that_is_not_running(tmp_path: Path) -> None:
+    """start_capture does not report success after the controller has already stopped."""
+    _FakeController.running_after_start = False
+    session = Session()
+    server = build_server(session=session)
+
+    with pytest.raises(ToolError, match="before the capture was live"):
+        asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "x.pcapng")}))
+
+    assert session.live_capture is None
+    _FakeController.running_after_start = True
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "y.pcapng")})
+
+
+def test_stop_capture_without_start_reports_error() -> None:
+    """stop_capture with no capture in flight fails gracefully."""
+    server = build_server(session=Session())
+
+    with pytest.raises(ToolError, match="no capture is running"):
+        asyncio.run(server.call_tool("stop_capture", {}))
+
+
+def test_stop_capture_returns_stats_and_autoloads(tmp_path: Path) -> None:
+    """stop_capture returns the stats, loads the file into the shared session, and frees the slot."""
+    session = Session()
+    server = build_server(session=session)
+    out = tmp_path / "live.pcapng"
+    _call(server, "start_capture", {"bus": 1, "device": 11, "output_path": str(out)})
+    assert _FakeController.instances[0].start_args == (1, 11, out)
+
+    payload = _call(server, "stop_capture", {})
+
+    assert payload["output_path"] == str(out)
+    assert payload["events_seen"] == 500
+    assert payload["events_matched"] == 253
+    assert payload["elapsed_seconds"] == 2.5
+    assert payload["output_bytes"] == 4242
+    # the summary comes from a real decode of the captured file
+    assert payload["packet_count"] == 253
+    assert "dev_001_011" in payload["device_ids"]
+    # the SHARED session now holds that capture for the other tools
+    assert session.capture is not None
+    assert len(session.capture.records) == 253
+    devices_payload = _call(server, "list_devices", {})
+    assert "dev_001_011" in {device["device_id"] for device in devices_payload["devices"]}
+    # the capture slot is free again
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "next.pcapng")})
+
+
+def test_start_capture_rejects_non_pcapng_output(tmp_path: Path) -> None:
+    """A wrong output suffix fails at start, before the analyst operates the device.
+
+    stop_capture's auto-load only accepts .pcapng; discovering that after the
+    physical capture work would waste the whole run.
+    """
+    server = build_server(session=Session())
+
+    with pytest.raises(ToolError, match="pcapng"):
+        asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "cap.pcap")}))
+
+    assert _FakeController.instances == []  # rejected before any capture was started
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "cap.pcapng")})
+
+
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        (UsbmonIoctlError("usbmon read failed mid-capture"), "usbmon capture failed while stopping"),
+        (CaptureStateError("capture finished without stats"), "capture could not stop"),
+    ],
+)
+def test_stop_capture_error_still_frees_the_slot(tmp_path: Path, error: Exception, message: str) -> None:
+    """A capture that died after going live reports its error without wedging the slot."""
+    server = build_server(session=Session())
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "a.pcapng")})
+    _FakeController.stop_error = error
+
+    with pytest.raises(ToolError, match=message):
+        asyncio.run(server.call_tool("stop_capture", {}))
+
+    _FakeController.stop_error = None
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")})
+
+
+def test_start_capture_waits_for_monkeypatched_capture_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The real controller returns through MCP only after capture signals readiness."""
+
+    def fake_capture(
+        bus: int,
+        device: int | None,
+        output_path: Path,
+        *,
+        stop_event: Event,
+        ready_event: Event | None = None,
+        on_progress: ProgressCallback | None = None,
+    ) -> CaptureStats:
+        del bus, device, on_progress
+        shutil.copyfile(_GOODIX, output_path)
+        assert ready_event is not None
+        ready_event.set()
+        assert stop_event.wait(timeout=1.0)
+        return CaptureStats(
+            output_path=output_path,
+            seen=253,
+            matched=253,
+            elapsed_seconds=0.1,
+            output_bytes=output_path.stat().st_size,
+        )
+
+    monkeypatch.setattr("bsu_tool.sniffer.capture", fake_capture)
+    monkeypatch.setattr("bsu_tool.sniffer.CaptureController", CaptureController)
+    server = build_server(session=Session())
+    out = tmp_path / "ready.pcapng"
+
+    assert _call(server, "start_capture", {"bus": 1, "output_path": str(out)})["output_path"] == str(out)
+    assert _call(server, "stop_capture", {})["packet_count"] == 253
+
+
+def test_server_import_does_not_import_sniffer() -> None:
+    """Importing the MCP server must not pull in the Unix-only usbmon stack.
+
+    bsu_tool.sniffer transitively imports fcntl, which does not exist on
+    Windows; the live-capture tools promise to import it only inside
+    start_capture. Run in a subprocess so modules imported by other tests
+    cannot mask a regression.
+    """
+    code = "import sys; import bsu_tool.mcp.server; assert 'bsu_tool.sniffer' not in sys.modules"
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/tests/unit/mcp/test_live_capture.py
+++ b/tests/unit/mcp/test_live_capture.py
@@ -14,7 +14,6 @@ import pathlib
 import shutil
 import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Event
 from typing import Any, ClassVar
@@ -24,9 +23,8 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import TextContent
 
-import bsu_tool.session as session_module
 from bsu_tool.mcp.server import build_server
-from bsu_tool.session import Capture, Session
+from bsu_tool.session import Session
 from bsu_tool.sniffer import CaptureController, CaptureStateError, CaptureStats, ProgressCallback
 from bsu_tool.usbmon_source import UsbmonBusNotAvailableError, UsbmonIoctlError, UsbmonPermissionError
 
@@ -45,10 +43,6 @@ class _FakeController:
     instances: ClassVar[list[_FakeController]] = []
     start_error: ClassVar[Exception | None] = None
     stop_error: ClassVar[Exception | None] = None
-    start_entered: ClassVar[Event | None] = None
-    start_release: ClassVar[Event | None] = None
-    stop_entered: ClassVar[Event | None] = None
-    stop_release: ClassVar[Event | None] = None
     running_after_start: ClassVar[bool] = True
     active_after_stop_error: ClassVar[bool] = False
 
@@ -59,10 +53,6 @@ class _FakeController:
 
     def start(self, bus: int, device: int | None, output_path: Path) -> None:
         self.start_args = (bus, device, output_path)
-        if _FakeController.start_entered is not None:
-            _FakeController.start_entered.set()
-            assert _FakeController.start_release is not None
-            assert _FakeController.start_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
         if _FakeController.start_error is not None:
             raise _FakeController.start_error
         shutil.copyfile(_GOODIX, output_path)
@@ -84,10 +74,6 @@ class _FakeController:
 
     def stop(self) -> CaptureStats:
         self.stop_calls += 1
-        if _FakeController.stop_entered is not None:
-            _FakeController.stop_entered.set()
-            assert _FakeController.stop_release is not None
-            assert _FakeController.stop_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
         if _FakeController.stop_error is not None:
             raise _FakeController.stop_error
         assert self.start_args is not None
@@ -105,10 +91,6 @@ def _fake_controller(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignor
     _FakeController.instances = []
     _FakeController.start_error = None
     _FakeController.stop_error = None
-    _FakeController.start_entered = None
-    _FakeController.start_release = None
-    _FakeController.stop_entered = None
-    _FakeController.stop_release = None
     _FakeController.running_after_start = True
     _FakeController.active_after_stop_error = False
     monkeypatch.setattr("bsu_tool.sniffer.CaptureController", _FakeController)
@@ -147,117 +129,6 @@ def test_start_capture_normalizes_relative_output_path(monkeypatch: pytest.Monke
     assert payload["output_path"] == str(expected)
     assert _FakeController.instances[0].start_args == (1, None, expected)
     _call(server, "stop_capture", {})
-
-
-def test_start_capture_does_not_block_the_event_loop(tmp_path: Path) -> None:
-    """Controller readiness waiting runs outside the MCP event loop."""
-    server = build_server(session=Session())
-    _FakeController.start_entered = Event()
-    _FakeController.start_release = Event()
-
-    async def run_start() -> None:
-        call = asyncio.create_task(
-            server.call_tool(
-                "start_capture",
-                {"bus": 1, "output_path": str(tmp_path / "live.pcapng")},
-            )
-        )
-        assert _FakeController.start_entered is not None
-        assert await asyncio.to_thread(_FakeController.start_entered.wait, _SYNC_TIMEOUT_SECONDS)
-        try:
-            await asyncio.sleep(0)
-            assert not call.done()
-        finally:
-            assert _FakeController.start_release is not None
-            _FakeController.start_release.set()
-        await call
-
-    asyncio.run(run_start())
-    _call(server, "stop_capture", {})
-
-
-def test_cancelled_start_capture_stops_background_controller(tmp_path: Path) -> None:
-    """Cancelling the MCP request cannot leave an orphan capture running."""
-    session = Session()
-    server = build_server(session=session)
-    _FakeController.start_entered = Event()
-    _FakeController.start_release = Event()
-
-    async def cancel_start() -> None:
-        call = asyncio.create_task(
-            server.call_tool(
-                "start_capture",
-                {"bus": 1, "output_path": str(tmp_path / "live.pcapng")},
-            )
-        )
-        assert _FakeController.start_entered is not None
-        assert await asyncio.to_thread(_FakeController.start_entered.wait, _SYNC_TIMEOUT_SECONDS)
-        call.cancel()
-        assert _FakeController.start_release is not None
-        _FakeController.start_release.set()
-        with pytest.raises(asyncio.CancelledError):
-            await call
-
-    asyncio.run(cancel_start())
-    assert _FakeController.instances[0].stop_calls == 1
-    assert session.live_capture is None
-
-
-def test_stop_capture_does_not_block_the_event_loop(tmp_path: Path) -> None:
-    """Controller shutdown and auto-load run outside the MCP event loop."""
-    server = build_server(session=Session())
-    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "live.pcapng")})
-    _FakeController.stop_entered = Event()
-    _FakeController.stop_release = Event()
-
-    async def run_stop() -> None:
-        call = asyncio.create_task(server.call_tool("stop_capture", {}))
-        assert _FakeController.stop_entered is not None
-        assert await asyncio.to_thread(_FakeController.stop_entered.wait, _SYNC_TIMEOUT_SECONDS)
-        try:
-            await asyncio.sleep(0)
-            assert not call.done()
-        finally:
-            assert _FakeController.stop_release is not None
-            _FakeController.stop_release.set()
-        await call
-
-    asyncio.run(run_stop())
-
-
-def test_start_capture_reservation_is_shared_across_servers(tmp_path: Path) -> None:
-    """Servers using one Session reject a second start while the first is starting."""
-    session = Session()
-    first_server = build_server(session=session)
-    second_server = build_server(session=session)
-    _FakeController.start_entered = Event()
-    _FakeController.start_release = Event()
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        first_start = executor.submit(
-            _call,
-            first_server,
-            "start_capture",
-            {"bus": 1, "output_path": str(tmp_path / "a.pcapng")},
-        )
-        assert _FakeController.start_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
-        assert session.live_capture is not None
-        try:
-            with pytest.raises(ToolError, match="already starting"):
-                asyncio.run(
-                    second_server.call_tool(
-                        "start_capture",
-                        {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
-                    )
-                )
-            with pytest.raises(ToolError, match="still starting"):
-                asyncio.run(second_server.call_tool("stop_capture", {}))
-        finally:
-            _FakeController.start_release.set()
-        first_start.result(timeout=_SYNC_TIMEOUT_SECONDS)
-
-    _call(second_server, "stop_capture", {})
-    assert session.live_capture is None
 
 
 def test_start_capture_rejects_second_capture_while_running(tmp_path: Path) -> None:
@@ -341,7 +212,7 @@ def test_start_capture_cleanup_timeout_keeps_slot_reserved_and_can_be_retried(tm
         asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(out)}))
 
     assert session.live_capture is not None
-    with pytest.raises(ToolError, match="still stopping"):
+    with pytest.raises(ToolError, match="already running"):
         asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "y.pcapng")}))
 
     shutil.copyfile(_GOODIX, out)
@@ -401,96 +272,6 @@ def test_stop_capture_returns_stats_and_autoloads(tmp_path: Path) -> None:
     _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "next.pcapng")})
 
 
-def test_stop_capture_keeps_session_reserved_until_autoload_finishes(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """A stopping capture rejects concurrent start and stop calls until completion."""
-    session = Session()
-    first_server = build_server(session=session)
-    second_server = build_server(session=session)
-    _call(first_server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "a.pcapng")})
-    _FakeController.stop_entered = Event()
-    _FakeController.stop_release = Event()
-    load_entered = Event()
-    load_release = Event()
-    original_read = session_module._read_capture  # pyright: ignore[reportPrivateUsage]
-
-    def blocking_read(path: Path) -> Capture:
-        load_entered.set()
-        assert load_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
-        return original_read(path)
-
-    monkeypatch.setattr(session_module, "_read_capture", blocking_read)
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        first_stop = executor.submit(_call, first_server, "stop_capture", {})
-        assert _FakeController.stop_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
-        assert session.live_capture is not None
-        try:
-            with pytest.raises(ToolError, match="still stopping"):
-                asyncio.run(
-                    second_server.call_tool(
-                        "start_capture",
-                        {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
-                    )
-                )
-            with pytest.raises(ToolError, match="already stopping"):
-                asyncio.run(second_server.call_tool("stop_capture", {}))
-            _FakeController.stop_release.set()
-            assert load_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
-            with pytest.raises(ToolError, match="currently loading"):
-                asyncio.run(
-                    second_server.call_tool(
-                        "start_capture",
-                        {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
-                    )
-                )
-            with pytest.raises(ToolError, match="already loading"):
-                asyncio.run(second_server.call_tool("load_capture", {"path": str(_GOODIX)}))
-        finally:
-            _FakeController.stop_release.set()
-            load_release.set()
-        assert first_stop.result(timeout=_SYNC_TIMEOUT_SECONDS)["packet_count"] == 253
-
-    assert session.live_capture is None
-    _call(second_server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")})
-
-
-def test_start_capture_rejects_while_capture_file_is_loading(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """A manual load reserves the session until its active capture is installed."""
-    session = Session()
-    server = build_server(session=session)
-    load_entered = Event()
-    load_release = Event()
-    original_read = session_module._read_capture  # pyright: ignore[reportPrivateUsage]
-
-    def blocking_read(path: Path) -> Capture:
-        load_entered.set()
-        assert load_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
-        return original_read(path)
-
-    monkeypatch.setattr(session_module, "_read_capture", blocking_read)
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        loading = executor.submit(session.load, _GOODIX)
-        assert load_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
-        try:
-            with pytest.raises(ToolError, match="currently loading"):
-                asyncio.run(
-                    server.call_tool(
-                        "start_capture",
-                        {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
-                    )
-                )
-        finally:
-            load_release.set()
-        assert loading.result(timeout=_SYNC_TIMEOUT_SECONDS).metadata.packet_count == 253
-
-
 def test_start_capture_rejects_non_pcapng_output(tmp_path: Path) -> None:
     """A wrong output suffix fails at start, before the analyst operates the device.
 
@@ -539,7 +320,7 @@ def test_stop_capture_timeout_keeps_slot_reserved_and_can_be_retried(tmp_path: P
         asyncio.run(server.call_tool("stop_capture", {}))
 
     assert session.live_capture is not None
-    with pytest.raises(ToolError, match="still stopping"):
+    with pytest.raises(ToolError, match="already running"):
         asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")}))
 
     _FakeController.stop_error = None

--- a/tests/unit/mcp/test_live_capture.py
+++ b/tests/unit/mcp/test_live_capture.py
@@ -25,7 +25,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import TextContent
 
 from bsu_tool.mcp.server import build_server
-from bsu_tool.session import Session
+from bsu_tool.session import Capture, Session
 from bsu_tool.sniffer import CaptureController, CaptureStateError, CaptureStats, ProgressCallback
 from bsu_tool.usbmon_source import UsbmonBusNotAvailableError, UsbmonIoctlError, UsbmonPermissionError
 
@@ -35,6 +35,7 @@ _GOODIX = (
     / "captures"
     / "goodix_enum_and_enroll_sanitized.pcapng"
 )
+_SYNC_TIMEOUT_SECONDS = 5.0
 
 
 class _FakeController:
@@ -45,6 +46,8 @@ class _FakeController:
     stop_error: ClassVar[Exception | None] = None
     start_entered: ClassVar[Event | None] = None
     start_release: ClassVar[Event | None] = None
+    stop_entered: ClassVar[Event | None] = None
+    stop_release: ClassVar[Event | None] = None
     running_after_start: ClassVar[bool] = True
 
     def __init__(self) -> None:
@@ -57,7 +60,7 @@ class _FakeController:
         if _FakeController.start_entered is not None:
             _FakeController.start_entered.set()
             assert _FakeController.start_release is not None
-            assert _FakeController.start_release.wait(timeout=1.0)
+            assert _FakeController.start_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
         if _FakeController.start_error is not None:
             raise _FakeController.start_error
         shutil.copyfile(_GOODIX, output_path)
@@ -73,6 +76,10 @@ class _FakeController:
 
     def stop(self) -> CaptureStats:
         self.stop_calls += 1
+        if _FakeController.stop_entered is not None:
+            _FakeController.stop_entered.set()
+            assert _FakeController.stop_release is not None
+            assert _FakeController.stop_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
         if _FakeController.stop_error is not None:
             raise _FakeController.stop_error
         assert self.start_args is not None
@@ -92,6 +99,8 @@ def _fake_controller(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignor
     _FakeController.stop_error = None
     _FakeController.start_entered = None
     _FakeController.start_release = None
+    _FakeController.stop_entered = None
+    _FakeController.stop_release = None
     _FakeController.running_after_start = True
     monkeypatch.setattr("bsu_tool.sniffer.CaptureController", _FakeController)
 
@@ -133,22 +142,35 @@ def test_start_capture_reservation_is_shared_across_servers(tmp_path: Path) -> N
             "start_capture",
             {"bus": 1, "output_path": str(tmp_path / "a.pcapng")},
         )
-        assert _FakeController.start_entered.wait(timeout=1.0)
+        assert _FakeController.start_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
         assert session.live_capture is not None
         try:
-            with pytest.raises(ToolError, match="already running"):
+            with pytest.raises(ToolError, match="already starting"):
                 asyncio.run(
                     second_server.call_tool(
                         "start_capture",
                         {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
                     )
                 )
+            with pytest.raises(ToolError, match="still starting"):
+                asyncio.run(second_server.call_tool("stop_capture", {}))
         finally:
             _FakeController.start_release.set()
-        first_start.result(timeout=1.0)
+        first_start.result(timeout=_SYNC_TIMEOUT_SECONDS)
 
     _call(second_server, "stop_capture", {})
     assert session.live_capture is None
+
+
+def test_start_capture_rejects_second_capture_while_running(tmp_path: Path) -> None:
+    """A running capture keeps the session reserved until stop_capture completes."""
+    server = build_server(session=Session())
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "a.pcapng")})
+
+    with pytest.raises(ToolError, match="already running"):
+        asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")}))
+
+    _call(server, "stop_capture", {})
 
 
 @pytest.mark.parametrize(
@@ -254,6 +276,60 @@ def test_stop_capture_returns_stats_and_autoloads(tmp_path: Path) -> None:
     _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "next.pcapng")})
 
 
+def test_stop_capture_keeps_session_reserved_until_autoload_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A stopping capture rejects concurrent start and stop calls until completion."""
+    session = Session()
+    first_server = build_server(session=session)
+    second_server = build_server(session=session)
+    _call(first_server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "a.pcapng")})
+    _FakeController.stop_entered = Event()
+    _FakeController.stop_release = Event()
+    load_entered = Event()
+    load_release = Event()
+    original_load = session.load
+
+    def blocking_load(path: Path) -> Capture:
+        load_entered.set()
+        assert load_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+        return original_load(path)
+
+    monkeypatch.setattr(session, "load", blocking_load)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        first_stop = executor.submit(_call, first_server, "stop_capture", {})
+        assert _FakeController.stop_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+        assert session.live_capture is not None
+        try:
+            with pytest.raises(ToolError, match="still stopping"):
+                asyncio.run(
+                    second_server.call_tool(
+                        "start_capture",
+                        {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
+                    )
+                )
+            with pytest.raises(ToolError, match="already stopping"):
+                asyncio.run(second_server.call_tool("stop_capture", {}))
+            _FakeController.stop_release.set()
+            assert load_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+            with pytest.raises(ToolError, match="still stopping"):
+                asyncio.run(
+                    second_server.call_tool(
+                        "start_capture",
+                        {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
+                    )
+                )
+        finally:
+            _FakeController.stop_release.set()
+            load_release.set()
+        assert first_stop.result(timeout=_SYNC_TIMEOUT_SECONDS)["packet_count"] == 253
+
+    assert session.live_capture is None
+    _call(second_server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")})
+
+
 def test_start_capture_rejects_non_pcapng_output(tmp_path: Path) -> None:
     """A wrong output suffix fails at start, before the analyst operates the device.
 
@@ -308,7 +384,7 @@ def test_start_capture_waits_for_monkeypatched_capture_readiness(
         shutil.copyfile(_GOODIX, output_path)
         assert ready_event is not None
         ready_event.set()
-        assert stop_event.wait(timeout=1.0)
+        assert stop_event.wait(timeout=_SYNC_TIMEOUT_SECONDS)
         return CaptureStats(
             output_path=output_path,
             seen=253,

--- a/tests/unit/mcp/test_live_capture.py
+++ b/tests/unit/mcp/test_live_capture.py
@@ -24,6 +24,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import TextContent
 
+import bsu_tool.session as session_module
 from bsu_tool.mcp.server import build_server
 from bsu_tool.session import Capture, Session
 from bsu_tool.sniffer import CaptureController, CaptureStateError, CaptureStats, ProgressCallback
@@ -49,6 +50,7 @@ class _FakeController:
     stop_entered: ClassVar[Event | None] = None
     stop_release: ClassVar[Event | None] = None
     running_after_start: ClassVar[bool] = True
+    active_after_stop_error: ClassVar[bool] = False
 
     def __init__(self) -> None:
         self.start_args: tuple[int, int | None, Path] | None = None
@@ -73,6 +75,12 @@ class _FakeController:
             and _FakeController.start_error is None
             and _FakeController.running_after_start
         )
+
+    @property
+    def is_active(self) -> bool:
+        if _FakeController.stop_error is not None:
+            return _FakeController.active_after_stop_error
+        return self.is_running
 
     def stop(self) -> CaptureStats:
         self.stop_calls += 1
@@ -102,6 +110,7 @@ def _fake_controller(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignor
     _FakeController.stop_entered = None
     _FakeController.stop_release = None
     _FakeController.running_after_start = True
+    _FakeController.active_after_stop_error = False
     monkeypatch.setattr("bsu_tool.sniffer.CaptureController", _FakeController)
 
 
@@ -125,6 +134,95 @@ def test_start_capture_starts_controller_and_reports(tmp_path: Path) -> None:
     assert payload == {"bus": 1, "device": None, "output_path": str(out)}
     (controller,) = _FakeController.instances
     assert controller.start_args == (1, None, out)
+
+
+def test_start_capture_normalizes_relative_output_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The stored output path remains stable if later code changes the cwd."""
+    monkeypatch.chdir(tmp_path)
+    server = build_server(session=Session())
+    expected = (tmp_path / "live.pcapng").resolve()
+
+    payload = _call(server, "start_capture", {"bus": 1, "output_path": "live.pcapng"})
+
+    assert payload["output_path"] == str(expected)
+    assert _FakeController.instances[0].start_args == (1, None, expected)
+    _call(server, "stop_capture", {})
+
+
+def test_start_capture_does_not_block_the_event_loop(tmp_path: Path) -> None:
+    """Controller readiness waiting runs outside the MCP event loop."""
+    server = build_server(session=Session())
+    _FakeController.start_entered = Event()
+    _FakeController.start_release = Event()
+
+    async def run_start() -> None:
+        call = asyncio.create_task(
+            server.call_tool(
+                "start_capture",
+                {"bus": 1, "output_path": str(tmp_path / "live.pcapng")},
+            )
+        )
+        assert _FakeController.start_entered is not None
+        assert await asyncio.to_thread(_FakeController.start_entered.wait, _SYNC_TIMEOUT_SECONDS)
+        try:
+            await asyncio.sleep(0)
+            assert not call.done()
+        finally:
+            assert _FakeController.start_release is not None
+            _FakeController.start_release.set()
+        await call
+
+    asyncio.run(run_start())
+    _call(server, "stop_capture", {})
+
+
+def test_cancelled_start_capture_stops_background_controller(tmp_path: Path) -> None:
+    """Cancelling the MCP request cannot leave an orphan capture running."""
+    session = Session()
+    server = build_server(session=session)
+    _FakeController.start_entered = Event()
+    _FakeController.start_release = Event()
+
+    async def cancel_start() -> None:
+        call = asyncio.create_task(
+            server.call_tool(
+                "start_capture",
+                {"bus": 1, "output_path": str(tmp_path / "live.pcapng")},
+            )
+        )
+        assert _FakeController.start_entered is not None
+        assert await asyncio.to_thread(_FakeController.start_entered.wait, _SYNC_TIMEOUT_SECONDS)
+        call.cancel()
+        assert _FakeController.start_release is not None
+        _FakeController.start_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await call
+
+    asyncio.run(cancel_start())
+    assert _FakeController.instances[0].stop_calls == 1
+    assert session.live_capture is None
+
+
+def test_stop_capture_does_not_block_the_event_loop(tmp_path: Path) -> None:
+    """Controller shutdown and auto-load run outside the MCP event loop."""
+    server = build_server(session=Session())
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "live.pcapng")})
+    _FakeController.stop_entered = Event()
+    _FakeController.stop_release = Event()
+
+    async def run_stop() -> None:
+        call = asyncio.create_task(server.call_tool("stop_capture", {}))
+        assert _FakeController.stop_entered is not None
+        assert await asyncio.to_thread(_FakeController.stop_entered.wait, _SYNC_TIMEOUT_SECONDS)
+        try:
+            await asyncio.sleep(0)
+            assert not call.done()
+        finally:
+            assert _FakeController.stop_release is not None
+            _FakeController.stop_release.set()
+        await call
+
+    asyncio.run(run_stop())
 
 
 def test_start_capture_reservation_is_shared_across_servers(tmp_path: Path) -> None:
@@ -169,6 +267,8 @@ def test_start_capture_rejects_second_capture_while_running(tmp_path: Path) -> N
 
     with pytest.raises(ToolError, match="already running"):
         asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")}))
+    with pytest.raises(ToolError, match="while a live capture is active"):
+        asyncio.run(server.call_tool("load_capture", {"path": str(_GOODIX)}))
 
     _call(server, "stop_capture", {})
 
@@ -180,6 +280,7 @@ def test_start_capture_rejects_second_capture_while_running(tmp_path: Path) -> N
         (UsbmonBusNotAvailableError("bus 9 not available"), "usbmon capture could not start"),
         (UsbmonPermissionError("permission denied"), "usbmon capture could not start"),
         (CaptureStateError("capture already started"), "capture could not start"),
+        (RuntimeError("cannot start thread"), "cannot start thread"),
     ],
 )
 def test_start_capture_error_surfaces_and_frees_the_slot(
@@ -224,6 +325,30 @@ def test_start_capture_timeout_reports_cleanup_failure(tmp_path: Path) -> None:
         asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "x.pcapng")}))
 
     assert _FakeController.instances[0].stop_calls == 1
+    assert session.live_capture is None
+
+
+def test_start_capture_cleanup_timeout_keeps_slot_reserved_and_can_be_retried(tmp_path: Path) -> None:
+    """A wedged startup returns an error without admitting a second capture."""
+    out = tmp_path / "x.pcapng"
+    _FakeController.start_error = TimeoutError("capture did not go live")
+    _FakeController.stop_error = TimeoutError("capture did not stop within 5.0s")
+    _FakeController.active_after_stop_error = True
+    session = Session()
+    server = build_server(session=session)
+
+    with pytest.raises(ToolError, match="startup timed out and cleanup failed"):
+        asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(out)}))
+
+    assert session.live_capture is not None
+    with pytest.raises(ToolError, match="still stopping"):
+        asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "y.pcapng")}))
+
+    shutil.copyfile(_GOODIX, out)
+    _FakeController.start_error = None
+    _FakeController.stop_error = None
+    _FakeController.active_after_stop_error = False
+    assert _call(server, "stop_capture", {})["packet_count"] == 253
     assert session.live_capture is None
 
 
@@ -289,14 +414,14 @@ def test_stop_capture_keeps_session_reserved_until_autoload_finishes(
     _FakeController.stop_release = Event()
     load_entered = Event()
     load_release = Event()
-    original_load = session.load
+    original_read = session_module._read_capture  # pyright: ignore[reportPrivateUsage]
 
-    def blocking_load(path: Path) -> Capture:
+    def blocking_read(path: Path) -> Capture:
         load_entered.set()
         assert load_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
-        return original_load(path)
+        return original_read(path)
 
-    monkeypatch.setattr(session, "load", blocking_load)
+    monkeypatch.setattr(session_module, "_read_capture", blocking_read)
 
     with ThreadPoolExecutor(max_workers=1) as executor:
         first_stop = executor.submit(_call, first_server, "stop_capture", {})
@@ -314,13 +439,15 @@ def test_stop_capture_keeps_session_reserved_until_autoload_finishes(
                 asyncio.run(second_server.call_tool("stop_capture", {}))
             _FakeController.stop_release.set()
             assert load_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
-            with pytest.raises(ToolError, match="still stopping"):
+            with pytest.raises(ToolError, match="currently loading"):
                 asyncio.run(
                     second_server.call_tool(
                         "start_capture",
                         {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
                     )
                 )
+            with pytest.raises(ToolError, match="already loading"):
+                asyncio.run(second_server.call_tool("load_capture", {"path": str(_GOODIX)}))
         finally:
             _FakeController.stop_release.set()
             load_release.set()
@@ -328,6 +455,40 @@ def test_stop_capture_keeps_session_reserved_until_autoload_finishes(
 
     assert session.live_capture is None
     _call(second_server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")})
+
+
+def test_start_capture_rejects_while_capture_file_is_loading(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A manual load reserves the session until its active capture is installed."""
+    session = Session()
+    server = build_server(session=session)
+    load_entered = Event()
+    load_release = Event()
+    original_read = session_module._read_capture  # pyright: ignore[reportPrivateUsage]
+
+    def blocking_read(path: Path) -> Capture:
+        load_entered.set()
+        assert load_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+        return original_read(path)
+
+    monkeypatch.setattr(session_module, "_read_capture", blocking_read)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        loading = executor.submit(session.load, _GOODIX)
+        assert load_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+        try:
+            with pytest.raises(ToolError, match="currently loading"):
+                asyncio.run(
+                    server.call_tool(
+                        "start_capture",
+                        {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
+                    )
+                )
+        finally:
+            load_release.set()
+        assert loading.result(timeout=_SYNC_TIMEOUT_SECONDS).metadata.packet_count == 253
 
 
 def test_start_capture_rejects_non_pcapng_output(tmp_path: Path) -> None:
@@ -363,6 +524,28 @@ def test_stop_capture_error_still_frees_the_slot(tmp_path: Path, error: Exceptio
 
     _FakeController.stop_error = None
     _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")})
+    _call(server, "stop_capture", {})
+
+
+def test_stop_capture_timeout_keeps_slot_reserved_and_can_be_retried(tmp_path: Path) -> None:
+    """A bounded stop timeout cannot admit another capture and permits a later retry."""
+    session = Session()
+    server = build_server(session=session)
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "a.pcapng")})
+    _FakeController.stop_error = TimeoutError("capture did not stop within 5.0s")
+    _FakeController.active_after_stop_error = True
+
+    with pytest.raises(ToolError, match="did not stop in time"):
+        asyncio.run(server.call_tool("stop_capture", {}))
+
+    assert session.live_capture is not None
+    with pytest.raises(ToolError, match="still stopping"):
+        asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")}))
+
+    _FakeController.stop_error = None
+    _FakeController.active_after_stop_error = False
+    assert _call(server, "stop_capture", {})["packet_count"] == 253
+    assert session.live_capture is None
 
 
 def test_start_capture_waits_for_monkeypatched_capture_readiness(

--- a/tests/unit/mcp/test_live_capture.py
+++ b/tests/unit/mcp/test_live_capture.py
@@ -14,6 +14,7 @@ import pathlib
 import shutil
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Event
 from typing import Any, ClassVar
@@ -24,7 +25,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import TextContent
 
 from bsu_tool.mcp.server import build_server
-from bsu_tool.session import Session
+from bsu_tool.session import Capture, LiveCapture, Session
 from bsu_tool.sniffer import CaptureController, CaptureStateError, CaptureStats, ProgressCallback
 from bsu_tool.usbmon_source import UsbmonBusNotAvailableError, UsbmonIoctlError, UsbmonPermissionError
 
@@ -43,8 +44,10 @@ class _FakeController:
     instances: ClassVar[list[_FakeController]] = []
     start_error: ClassVar[Exception | None] = None
     stop_error: ClassVar[Exception | None] = None
+    start_entered: ClassVar[Event | None] = None
+    start_release: ClassVar[Event | None] = None
     running_after_start: ClassVar[bool] = True
-    active_after_stop_error: ClassVar[bool] = False
+    active_results: ClassVar[list[bool]] = []
 
     def __init__(self) -> None:
         self.start_args: tuple[int, int | None, Path] | None = None
@@ -53,6 +56,10 @@ class _FakeController:
 
     def start(self, bus: int, device: int | None, output_path: Path) -> None:
         self.start_args = (bus, device, output_path)
+        if _FakeController.start_entered is not None:
+            _FakeController.start_entered.set()
+            assert _FakeController.start_release is not None
+            assert _FakeController.start_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
         if _FakeController.start_error is not None:
             raise _FakeController.start_error
         shutil.copyfile(_GOODIX, output_path)
@@ -68,8 +75,8 @@ class _FakeController:
 
     @property
     def is_active(self) -> bool:
-        if _FakeController.stop_error is not None:
-            return _FakeController.active_after_stop_error
+        if _FakeController.active_results:
+            return _FakeController.active_results.pop(0)
         return self.is_running
 
     def stop(self) -> CaptureStats:
@@ -91,8 +98,10 @@ def _fake_controller(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignor
     _FakeController.instances = []
     _FakeController.start_error = None
     _FakeController.stop_error = None
+    _FakeController.start_entered = None
+    _FakeController.start_release = None
     _FakeController.running_after_start = True
-    _FakeController.active_after_stop_error = False
+    _FakeController.active_results = []
     monkeypatch.setattr("bsu_tool.sniffer.CaptureController", _FakeController)
 
 
@@ -128,6 +137,31 @@ def test_start_capture_normalizes_relative_output_path(monkeypatch: pytest.Monke
 
     assert payload["output_path"] == str(expected)
     assert _FakeController.instances[0].start_args == (1, None, expected)
+    _call(server, "stop_capture", {})
+
+
+def test_stop_capture_rejects_while_start_capture_is_starting(tmp_path: Path) -> None:
+    """A capture cannot be stopped before its start call confirms readiness."""
+    session = Session()
+    server = build_server(session=session)
+    _FakeController.start_entered = Event()
+    _FakeController.start_release = Event()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        starting = executor.submit(
+            _call,
+            server,
+            "start_capture",
+            {"bus": 1, "output_path": str(tmp_path / "a.pcapng")},
+        )
+        assert _FakeController.start_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+        try:
+            with pytest.raises(ToolError, match="still starting"):
+                asyncio.run(server.call_tool("stop_capture", {}))
+        finally:
+            _FakeController.start_release.set()
+        starting.result(timeout=_SYNC_TIMEOUT_SECONDS)
+
     _call(server, "stop_capture", {})
 
 
@@ -192,7 +226,7 @@ def test_start_capture_timeout_reports_cleanup_failure(tmp_path: Path) -> None:
     session = Session()
     server = build_server(session=session)
 
-    with pytest.raises(ToolError, match="capture startup timed out and cleanup failed"):
+    with pytest.raises(ToolError, match="no longer active"):
         asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "x.pcapng")}))
 
     assert _FakeController.instances[0].stop_calls == 1
@@ -204,11 +238,11 @@ def test_start_capture_cleanup_timeout_keeps_slot_reserved_and_can_be_retried(tm
     out = tmp_path / "x.pcapng"
     _FakeController.start_error = TimeoutError("capture did not go live")
     _FakeController.stop_error = TimeoutError("capture did not stop within 5.0s")
-    _FakeController.active_after_stop_error = True
+    _FakeController.active_results = [True]
     session = Session()
     server = build_server(session=session)
 
-    with pytest.raises(ToolError, match="startup timed out and cleanup failed"):
+    with pytest.raises(ToolError, match="retry stop_capture"):
         asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(out)}))
 
     assert session.live_capture is not None
@@ -218,7 +252,6 @@ def test_start_capture_cleanup_timeout_keeps_slot_reserved_and_can_be_retried(tm
     shutil.copyfile(_GOODIX, out)
     _FakeController.start_error = None
     _FakeController.stop_error = None
-    _FakeController.active_after_stop_error = False
     assert _call(server, "stop_capture", {})["packet_count"] == 253
     assert session.live_capture is None
 
@@ -272,6 +305,45 @@ def test_stop_capture_returns_stats_and_autoloads(tmp_path: Path) -> None:
     _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "next.pcapng")})
 
 
+def test_stopping_capture_rejects_second_stop_and_start_until_autoload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The stop claim remains exclusive until its automatic load completes."""
+    session = Session()
+    server = build_server(session=session)
+    _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "a.pcapng")})
+    load_entered = Event()
+    load_release = Event()
+    original_load = session.load_stopped_capture
+
+    def blocking_load(live_capture: LiveCapture) -> Capture:
+        load_entered.set()
+        assert load_release.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+        return original_load(live_capture)
+
+    monkeypatch.setattr(session, "load_stopped_capture", blocking_load)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        stopping = executor.submit(_call, server, "stop_capture", {})
+        assert load_entered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+        try:
+            with pytest.raises(ToolError, match="already stopping"):
+                asyncio.run(server.call_tool("stop_capture", {}))
+            with pytest.raises(ToolError, match="still stopping"):
+                asyncio.run(
+                    server.call_tool(
+                        "start_capture",
+                        {"bus": 1, "output_path": str(tmp_path / "b.pcapng")},
+                    )
+                )
+        finally:
+            load_release.set()
+        assert stopping.result(timeout=_SYNC_TIMEOUT_SECONDS)["packet_count"] == 253
+
+    assert session.live_capture is None
+
+
 def test_start_capture_rejects_non_pcapng_output(tmp_path: Path) -> None:
     """A wrong output suffix fails at start, before the analyst operates the device.
 
@@ -314,7 +386,6 @@ def test_stop_capture_timeout_keeps_slot_reserved_and_can_be_retried(tmp_path: P
     server = build_server(session=session)
     _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "a.pcapng")})
     _FakeController.stop_error = TimeoutError("capture did not stop within 5.0s")
-    _FakeController.active_after_stop_error = True
 
     with pytest.raises(ToolError, match="did not stop in time"):
         asyncio.run(server.call_tool("stop_capture", {}))
@@ -324,7 +395,6 @@ def test_stop_capture_timeout_keeps_slot_reserved_and_can_be_retried(tmp_path: P
         asyncio.run(server.call_tool("start_capture", {"bus": 1, "output_path": str(tmp_path / "b.pcapng")}))
 
     _FakeController.stop_error = None
-    _FakeController.active_after_stop_error = False
     assert _call(server, "stop_capture", {})["packet_count"] == 253
     assert session.live_capture is None
 

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -103,3 +103,15 @@ def test_get_packets_without_capture_reports_error() -> None:
 
     with pytest.raises(ToolError, match="No capture loaded"):
         asyncio.run(call_tool())
+
+
+def test_build_server_registers_live_capture_tools() -> None:
+    """build_server registers the Issue #80 start_capture and stop_capture tools."""
+
+    async def tool_names() -> set[str]:
+        tools = await build_server().list_tools()
+        return {tool.name for tool in tools}
+
+    names = asyncio.run(tool_names())
+    assert "start_capture" in names
+    assert "stop_capture" in names

--- a/tests/unit/test_sniffer.py
+++ b/tests/unit/test_sniffer.py
@@ -12,7 +12,7 @@ reading it back with :class:`~bsu_tool.pcapng_reader.PcapNgReader`.
 from __future__ import annotations
 
 from pathlib import Path
-from threading import Event
+from threading import Event, Thread
 from types import TracebackType
 
 import pytest
@@ -181,9 +181,20 @@ def test_output_bytes_matches_file_size(monkeypatch: pytest.MonkeyPatch, tmp_pat
 def test_existing_output_path_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _install_source(monkeypatch, _FakeSource([]))
     out = tmp_path / "cap.pcapng"
-    out.write_bytes(b"")  # already exists -> "xb" open fails
+    out.write_bytes(b"existing")  # already exists -> "xb" open fails
     with pytest.raises(FileExistsError):
         capture(bus=3, device=None, output_path=out, stop_event=Event())
+    assert out.read_bytes() == b"existing"
+
+
+def test_startup_failure_does_not_create_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install_source(monkeypatch, _FakeSource([], enter_error=UsbmonPermissionError("denied")))
+    out = tmp_path / "cap.pcapng"
+
+    with pytest.raises(UsbmonPermissionError):
+        capture(bus=3, device=None, output_path=out, stop_event=Event())
+
+    assert not out.exists()
 
 
 def test_ready_event_is_set_once_live(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -253,10 +264,12 @@ def test_controller_post_live_error_surfaces_from_stop(monkeypatch: pytest.Monke
     # Goes live (ready set), then raises while iterating -> stop() re-raises.
     source = _FakeSource([(_header(), b"\x01")], iter_error=RuntimeError("bus vanished"))
     _install_source(monkeypatch, source)
+    out = tmp_path / "c.pcapng"
     controller = CaptureController()
-    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+    controller.start(bus=3, device=None, output_path=out)
     with pytest.raises(RuntimeError, match="bus vanished"):
         controller.stop()
+    assert out.exists()
 
 
 def test_controller_start_times_out_when_never_live(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -264,10 +277,63 @@ def test_controller_start_times_out_when_never_live(monkeypatch: pytest.MonkeyPa
     source = _FakeSource([], block_enter=gate)
     _install_source(monkeypatch, source)
     controller = CaptureController()
+    out = tmp_path / "c.pcapng"
     with pytest.raises(TimeoutError):
-        controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng", ready_timeout=0.15)
-    gate.set()  # let the daemon thread unwind
-    controller.stop()
+        controller.start(bus=3, device=None, output_path=out, ready_timeout=0.15)
+    assert not out.exists()
+    with pytest.raises(TimeoutError):
+        controller.stop(timeout=0.01)
+    gate.set()
+    controller.stop(timeout=1.0)
+    assert not out.exists()
+
+
+def test_controller_thread_start_failure_is_not_active(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def fail_start(_thread: Thread) -> None:
+        raise RuntimeError("cannot start thread")
+
+    monkeypatch.setattr(sniffer.Thread, "start", fail_start)
+    controller = CaptureController()
+
+    with pytest.raises(RuntimeError, match="cannot start thread"):
+        controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+
+    assert not controller.is_active
+
+
+def test_controller_stop_times_out_without_losing_active_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    release = Event()
+
+    def blocked_capture(
+        bus: int,
+        device: int | None,
+        output_path: Path,
+        *,
+        stop_event: Event,
+        ready_event: Event | None = None,
+        on_progress: sniffer.ProgressCallback | None = None,
+    ) -> CaptureStats:
+        del bus, device, stop_event, on_progress
+        output_path.write_bytes(b"capture")
+        assert ready_event is not None
+        ready_event.set()
+        release.wait()
+        return CaptureStats(output_path=output_path)
+
+    monkeypatch.setattr(sniffer, "capture", blocked_capture)
+    controller = CaptureController()
+    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+
+    with pytest.raises(TimeoutError, match="did not stop"):
+        controller.stop(timeout=0.01)
+    assert controller.is_active
+
+    release.set()
+    controller.stop(timeout=1.0)
+    assert not controller.is_active
 
 
 def test_is_running_reflects_lifecycle(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

Implements MCP `start_capture` and `stop_capture`.

- Starts live usbmon capture with optional device filtering
- Stores the active controller in the shared Session
- Rejects a second active capture
- Stops and automatically loads the resulting `.pcapng`
- Returns capture stats, packet count, and discovered devices
- Maps capture and usbmon failures to clear tool errors
- Preserves lazy imports for cross-platform MCP server startup

closes #80

## How was it tested?

```bash
source .venv/bin/activate
ruff check .
ruff format --check .
pyright
pytest
```

All checks passed: ruff, pyright, and 274 tests with 98% coverage. Tests use monkeypatched capture infrastructure and the checked-in Goodix capture; real usbmon hardware was not tested locally.

## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR