### PR TITLE
60/descriptor decoding

### DIFF
--- a/bsu_tool/descriptors.py
+++ b/bsu_tool/descriptors.py
@@ -1,0 +1,385 @@
+"""USB descriptor and setup-packet parsing.
+
+This module turns the raw bytes exchanged during device enumeration into
+typed descriptor records. It sits one layer above
+:mod:`bsu_tool.urb_decoder`: the decoder produces
+:class:`~bsu_tool.urb_decoder.UrbRecord` objects carrying the 8-byte
+setup packet (on control submissions) and the completion data payload;
+this module interprets those bytes.
+
+Three descriptor kinds are parsed, per USB 2.0 specification Chapter 9:
+
+* **Device** (:func:`parse_device_descriptor`) — vendor/product id, class
+  triple, and string-descriptor indices.
+* **Configuration** (:func:`parse_configuration`) — walks the concatenated
+  configuration blob, yielding nested :class:`InterfaceDescriptor` and
+  :class:`EndpointDescriptor` records. The vendor-specific interface class
+  that marks an in-scope device lives here, not in the device descriptor.
+* **String** (:func:`parse_string_descriptor`) — UTF-16-LE string values.
+
+:func:`parse_setup_packet` decodes the 8-byte setup packet so callers can
+classify a control transfer (standard vs class vs vendor) and read the
+requested descriptor type/index without indexing raw bytes.
+
+References
+----------
+* USB 2.0 specification, Section 9.3 (setup packet), Section 9.5-9.6
+  (standard descriptor layouts)
+* *USB in a NutShell*, Chapter 5 (descriptors)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
+# --- Public type aliases ---------------------------------------------------
+
+RequestType = Literal["standard", "class", "vendor", "reserved"]
+Direction = Literal["in", "out"]
+EndpointTransferType = Literal["control", "isochronous", "bulk", "interrupt"]
+
+# --- Descriptor-type byte values (bDescriptorType) -------------------------
+
+DEVICE_DESCRIPTOR: Final = 0x01
+CONFIGURATION_DESCRIPTOR: Final = 0x02
+STRING_DESCRIPTOR: Final = 0x03
+INTERFACE_DESCRIPTOR: Final = 0x04
+ENDPOINT_DESCRIPTOR: Final = 0x05
+
+# --- Standard bRequest values ----------------------------------------------
+
+GET_DESCRIPTOR_REQUEST: Final = 0x06
+SET_CONFIGURATION_REQUEST: Final = 0x09
+
+# --- Wire-format masks and sizes -------------------------------------------
+
+_SETUP_PACKET_SIZE: Final = 8
+_REQUEST_TYPE_MASK: Final = 0x60  # bmRequestType bits 5-6 select the request type
+_REQUEST_TYPE_SHIFT: Final = 5
+_ENDPOINT_IN_FLAG: Final = 0x80
+_ENDPOINT_NUMBER_MASK: Final = 0x0F
+_ENDPOINT_ATTR_TRANSFER_MASK: Final = 0x03  # bmAttributes bits 0-1 = transfer type
+_HIGH_BYTE_SHIFT: Final = 8
+_LOW_BYTE_MASK: Final = 0xFF
+
+_DEVICE_DESCRIPTOR_MIN_LEN: Final = 18
+_CONFIG_DESCRIPTOR_MIN_LEN: Final = 9
+_INTERFACE_DESCRIPTOR_MIN_LEN: Final = 9
+_ENDPOINT_DESCRIPTOR_MIN_LEN: Final = 7
+_STRING_DESCRIPTOR_MIN_LEN: Final = 2
+
+_REQUEST_TYPES: Final[tuple[RequestType, RequestType, RequestType, RequestType]] = (
+    "standard",
+    "class",
+    "vendor",
+    "reserved",
+)
+_ENDPOINT_TRANSFER_TYPES: Final[
+    tuple[EndpointTransferType, EndpointTransferType, EndpointTransferType, EndpointTransferType]
+] = ("control", "isochronous", "bulk", "interrupt")
+
+
+# --- Setup packet ----------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SetupPacket:
+    """A decoded 8-byte USB control-transfer setup packet.
+
+    The raw fields are stored verbatim; derived views (request type,
+    requested descriptor type/index) are exposed as properties.
+    """
+
+    bm_request_type: int
+    b_request: int
+    w_value: int
+    w_index: int
+    w_length: int
+
+    @property
+    def request_type(self) -> RequestType:
+        """Return the transfer's request type from ``bmRequestType`` bits 5-6."""
+        return _REQUEST_TYPES[(self.bm_request_type & _REQUEST_TYPE_MASK) >> _REQUEST_TYPE_SHIFT]
+
+    @property
+    def is_standard(self) -> bool:
+        """Return whether this is a standard (non-class, non-vendor) request."""
+        return self.request_type == "standard"
+
+    @property
+    def descriptor_type(self) -> int:
+        """Return the requested descriptor type: the high byte of ``wValue``."""
+        return (self.w_value >> _HIGH_BYTE_SHIFT) & _LOW_BYTE_MASK
+
+    @property
+    def descriptor_index(self) -> int:
+        """Return the requested descriptor index: the low byte of ``wValue``."""
+        return self.w_value & _LOW_BYTE_MASK
+
+
+def parse_setup_packet(setup: bytes) -> SetupPacket | None:
+    """Decode an 8-byte setup packet, or return ``None`` if malformed.
+
+    Args:
+        setup: The raw setup field from a control-transfer submission.
+
+    Returns:
+        A :class:`SetupPacket`, or ``None`` when ``setup`` is not exactly
+        eight bytes long.
+    """
+    if len(setup) != _SETUP_PACKET_SIZE:
+        return None
+    return SetupPacket(
+        bm_request_type=setup[0],
+        b_request=setup[1],
+        w_value=_u16le(setup, 2),
+        w_index=_u16le(setup, 4),
+        w_length=_u16le(setup, 6),
+    )
+
+
+# --- Descriptor records ----------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceDescriptor:
+    """A parsed USB device descriptor (bDescriptorType 0x01).
+
+    Note that :attr:`device_class` is frequently ``0x00`` (class defined at
+    the interface level) or ``0xEF`` (composite); the class that identifies
+    a vendor-specific device is usually the interface class in the
+    configuration descriptor, not this field.
+    """
+
+    usb_version: str
+    device_class: int
+    device_subclass: int
+    device_protocol: int
+    max_packet_size0: int
+    vendor_id: int
+    product_id: int
+    device_version: str
+    manufacturer_index: int | None
+    product_index: int | None
+    serial_number_index: int | None
+    num_configurations: int
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointDescriptor:
+    """A parsed USB endpoint descriptor (bDescriptorType 0x05)."""
+
+    address: int  # full bEndpointAddress including the direction bit
+    number: int  # endpoint number, low nibble of the address
+    direction: Direction
+    transfer_type: EndpointTransferType
+    max_packet_size: int
+    interval: int
+
+
+@dataclass(frozen=True, slots=True)
+class InterfaceDescriptor:
+    """A parsed USB interface descriptor (bDescriptorType 0x04) and its endpoints."""
+
+    number: int
+    alternate_setting: int
+    interface_class: int
+    interface_subclass: int
+    interface_protocol: int
+    interface_index: int | None
+    endpoints: tuple[EndpointDescriptor, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigurationDescriptor:
+    """A parsed USB configuration descriptor (bDescriptorType 0x02) and its interfaces."""
+
+    configuration_value: int
+    total_length: int
+    num_interfaces: int
+    configuration_index: int | None
+    attributes: int
+    max_power_ma: int
+    interfaces: tuple[InterfaceDescriptor, ...]
+
+
+# --- Descriptor parsers ----------------------------------------------------
+
+
+def parse_device_descriptor(data: bytes) -> DeviceDescriptor | None:
+    """Parse a device descriptor from the completion payload of a GET_DESCRIPTOR.
+
+    Args:
+        data: The data phase returned by a ``GET_DESCRIPTOR(DEVICE)`` control
+            transfer.
+
+    Returns:
+        A :class:`DeviceDescriptor`, or ``None`` if ``data`` is too short or
+        does not carry a device descriptor.
+    """
+    if len(data) < _DEVICE_DESCRIPTOR_MIN_LEN or data[1] != DEVICE_DESCRIPTOR:
+        return None
+    return DeviceDescriptor(
+        usb_version=_format_bcd(_u16le(data, 2)),
+        device_class=data[4],
+        device_subclass=data[5],
+        device_protocol=data[6],
+        max_packet_size0=data[7],
+        vendor_id=_u16le(data, 8),
+        product_id=_u16le(data, 10),
+        device_version=_format_bcd(_u16le(data, 12)),
+        manufacturer_index=_string_index(data[14]),
+        product_index=_string_index(data[15]),
+        serial_number_index=_string_index(data[16]),
+        num_configurations=data[17],
+    )
+
+
+def parse_configuration(data: bytes) -> ConfigurationDescriptor | None:
+    """Parse a configuration descriptor and its nested interface/endpoint descriptors.
+
+    Walks the concatenated configuration blob returned by a full
+    ``GET_DESCRIPTOR(CONFIGURATION)`` — the configuration header followed by
+    interface and endpoint descriptors (and any class-specific descriptors,
+    which are skipped). Endpoints are attached to the most recently seen
+    interface. Parsing stops at the end of the captured data, so a truncated
+    blob yields whatever complete descriptors it contained.
+
+    Args:
+        data: The data phase returned by a ``GET_DESCRIPTOR(CONFIGURATION)``
+            control transfer.
+
+    Returns:
+        A :class:`ConfigurationDescriptor`, or ``None`` if ``data`` does not
+        begin with a configuration descriptor.
+    """
+    if len(data) < _CONFIG_DESCRIPTOR_MIN_LEN or data[1] != CONFIGURATION_DESCRIPTOR:
+        return None
+
+    interfaces: list[InterfaceDescriptor] = []
+    pending: _InterfaceBuilder | None = None
+    endpoints: list[EndpointDescriptor] = []
+
+    offset = data[0]  # skip past the configuration header to the first sub-descriptor
+    while offset + 2 <= len(data):
+        length = data[offset]
+        if length == 0 or offset + length > len(data):
+            break  # zero-length guards against an infinite loop; overrun means truncation
+        descriptor_type = data[offset + 1]
+        block = data[offset : offset + length]
+        if descriptor_type == INTERFACE_DESCRIPTOR:
+            if pending is not None:
+                interfaces.append(pending.build(tuple(endpoints)))
+            pending = _parse_interface_builder(block)
+            endpoints = []
+        elif descriptor_type == ENDPOINT_DESCRIPTOR and pending is not None:
+            endpoint = _parse_endpoint(block)
+            if endpoint is not None:
+                endpoints.append(endpoint)
+        offset += length
+    if pending is not None:
+        interfaces.append(pending.build(tuple(endpoints)))
+
+    return ConfigurationDescriptor(
+        configuration_value=data[5],
+        total_length=_u16le(data, 2),
+        num_interfaces=data[4],
+        configuration_index=_string_index(data[6]),
+        attributes=data[7],
+        max_power_ma=data[8] * 2,  # bMaxPower is expressed in 2 mA units
+        interfaces=tuple(interfaces),
+    )
+
+
+def parse_string_descriptor(data: bytes) -> str | None:
+    """Parse a UTF-16-LE string descriptor into text.
+
+    Args:
+        data: The data phase returned by a ``GET_DESCRIPTOR(STRING)`` control
+            transfer for a non-zero string index.
+
+    Returns:
+        The decoded string with trailing NULs stripped, or ``None`` if the
+        payload is not a non-empty string descriptor.
+    """
+    if len(data) < _STRING_DESCRIPTOR_MIN_LEN or data[1] != STRING_DESCRIPTOR:
+        return None
+    descriptor_length = min(data[0], len(data))
+    if descriptor_length <= _STRING_DESCRIPTOR_MIN_LEN:
+        return None
+    payload = data[2:descriptor_length]
+    if len(payload) % 2 != 0:
+        payload = payload[:-1]
+    try:
+        decoded = payload.decode("utf-16-le")
+    except UnicodeDecodeError:
+        return None
+    decoded = decoded.rstrip("\x00")
+    return decoded or None
+
+
+# --- Internal helpers ------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _InterfaceBuilder:
+    number: int
+    alternate_setting: int
+    interface_class: int
+    interface_subclass: int
+    interface_protocol: int
+    interface_index: int | None
+
+    def build(self, endpoints: tuple[EndpointDescriptor, ...]) -> InterfaceDescriptor:
+        return InterfaceDescriptor(
+            number=self.number,
+            alternate_setting=self.alternate_setting,
+            interface_class=self.interface_class,
+            interface_subclass=self.interface_subclass,
+            interface_protocol=self.interface_protocol,
+            interface_index=self.interface_index,
+            endpoints=endpoints,
+        )
+
+
+def _parse_interface_builder(block: bytes) -> _InterfaceBuilder | None:
+    if len(block) < _INTERFACE_DESCRIPTOR_MIN_LEN:
+        return None
+    return _InterfaceBuilder(
+        number=block[2],
+        alternate_setting=block[3],
+        interface_class=block[5],
+        interface_subclass=block[6],
+        interface_protocol=block[7],
+        interface_index=_string_index(block[8]),
+    )
+
+
+def _parse_endpoint(block: bytes) -> EndpointDescriptor | None:
+    if len(block) < _ENDPOINT_DESCRIPTOR_MIN_LEN:
+        return None
+    address = block[2]
+    return EndpointDescriptor(
+        address=address,
+        number=address & _ENDPOINT_NUMBER_MASK,
+        direction="in" if address & _ENDPOINT_IN_FLAG else "out",
+        transfer_type=_ENDPOINT_TRANSFER_TYPES[block[3] & _ENDPOINT_ATTR_TRANSFER_MASK],
+        max_packet_size=_u16le(block, 4),
+        interval=block[6],
+    )
+
+
+def _u16le(data: bytes, offset: int) -> int:
+    """Read a little-endian unsigned 16-bit integer at ``offset``."""
+    return data[offset] | (data[offset + 1] << _HIGH_BYTE_SHIFT)
+
+
+def _format_bcd(value: int) -> str:
+    """Format a 16-bit BCD version (e.g. ``0x0200``) as ``"2.00"``."""
+    return f"{value >> _HIGH_BYTE_SHIFT}.{(value >> 4) & 0x0F}{value & 0x0F}"
+
+
+def _string_index(value: int) -> int | None:
+    """Return a string-descriptor index, or ``None`` for the absent index 0."""
+    return value or None

--- a/bsu_tool/mcp/interfaces.py
+++ b/bsu_tool/mcp/interfaces.py
@@ -63,6 +63,64 @@ class DeviceSummary:
     manufacturer: str | None = None
     product: str | None = None
     descriptor_summary: str | None = None
+    device_class: int | None = None  # bDeviceClass; often 0x00/0xef for composite devices
+    interface_class: int | None = None  # first interface's bInterfaceClass; 0xff marks vendor-specific
+
+
+@dataclass(frozen=True, slots=True)
+class EnumeratedEndpoint:
+    """An endpoint declared by a device's configuration descriptor."""
+
+    address: str  # full USB address incl. direction bit, e.g. "0x83"
+    number: int
+    direction: Direction
+    transfer_type: str  # "control" | "isochronous" | "bulk" | "interrupt" (as declared)
+    max_packet_size: int
+    interval: int
+
+
+@dataclass(frozen=True, slots=True)
+class EnumeratedInterface:
+    """An interface declared by a device's configuration descriptor."""
+
+    number: int
+    alternate_setting: int
+    interface_class: int
+    interface_subclass: int
+    interface_protocol: int
+    description: str | None  # iInterface string, if captured
+    endpoints: tuple[EnumeratedEndpoint, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceEnumeration:
+    """The descriptors and enumeration-phase span for one device.
+
+    Built from the standard control transfers exchanged on endpoint 0 before
+    the device's runtime traffic begins. ``enumeration_start_index`` /
+    ``enumeration_end_index`` bound the phase in the same decoded-record index
+    space that get_packets reports; ``is_complete`` reports whether a
+    ``SET_CONFIGURATION`` was observed (i.e. the capture caught the full
+    handshake rather than joining mid-stream).
+    """
+
+    device_id: str
+    vendor_id: str | None
+    product_id: str | None
+    usb_version: str | None
+    device_class: int | None
+    device_subclass: int | None
+    device_protocol: int | None
+    manufacturer: str | None
+    product: str | None
+    serial_number: str | None
+    configuration_value: int | None
+    interfaces: tuple[EnumeratedInterface, ...]
+    enumeration_packet_indices: tuple[int, ...]
+    enumeration_start_index: int | None
+    enumeration_end_index: int | None
+    runtime_start_index: int | None
+    is_complete: bool
 
 
 @dataclass(frozen=True, slots=True)

--- a/bsu_tool/mcp/tools/devices.py
+++ b/bsu_tool/mcp/tools/devices.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, replace
 
 from mcp.server.fastmcp import FastMCP
 
-from bsu_tool.mcp.interfaces import DeviceSummary
+from bsu_tool.mcp.interfaces import DeviceEnumeration, DeviceSummary
 from bsu_tool.mcp.tools.pagination import DEFAULT_LIMIT, validate_pagination
 from bsu_tool.session import Session
 
@@ -46,3 +46,17 @@ def register(mcp: FastMCP, session: Session) -> None:
             returned_count=len(page),
             has_more=offset + len(page) < len(devices),
         )
+
+    @mcp.tool()
+    def get_enumeration(device_id: str) -> DeviceEnumeration:  # pyright: ignore[reportUnusedFunction]
+        """Return a device's USB descriptors and enumeration-phase span.
+
+        Decodes the device and configuration descriptors (vendor/product id,
+        class, interfaces, endpoints) exchanged during the device's initial
+        enumeration, and reports the packet-index range of the enumeration
+        phase — the standard endpoint-0 control transfers that precede the
+        device's runtime traffic. Use this to learn what a device is before
+        interpreting its vendor protocol. ``device_id`` is a ``dev_bbb_ddd``
+        id from list_devices.
+        """
+        return session.get_enumeration(device_id)

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -6,12 +6,28 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final
 
+from bsu_tool.descriptors import (
+    CONFIGURATION_DESCRIPTOR,
+    DEVICE_DESCRIPTOR,
+    GET_DESCRIPTOR_REQUEST,
+    SET_CONFIGURATION_REQUEST,
+    STRING_DESCRIPTOR,
+    ConfigurationDescriptor,
+    DeviceDescriptor,
+    parse_configuration,
+    parse_device_descriptor,
+    parse_setup_packet,
+    parse_string_descriptor,
+)
 from bsu_tool.mcp.interfaces import (
     CaptureInterface,
     CaptureMetadata,
     CapturePacket,
+    DeviceEnumeration,
     DeviceSummary,
     EndpointSummary,
+    EnumeratedEndpoint,
+    EnumeratedInterface,
     PacketRecord,
     PacketSelection,
 )
@@ -39,13 +55,11 @@ _IF_TSRESOL_OPTION: Final[int] = 9
 _DEFAULT_TIMESTAMP_RESOLUTION_SECONDS: Final[float] = 1 / 1_000_000
 _BINARY_RESOLUTION_FLAG: Final[int] = 0x80
 _RESOLUTION_VALUE_MASK: Final[int] = 0x7F
-_GET_DESCRIPTOR_REQUEST: Final[int] = 0x06
-_DEVICE_DESCRIPTOR_TYPE: Final[int] = 0x01
-_STRING_DESCRIPTOR_TYPE: Final[int] = 0x03
 _ENDPOINT_IN_FLAG: Final[int] = 0x80
 _ENDPOINT_NUMBER_MASK: Final[int] = 0x0F
 _TRANSFER_TYPE_ORDER: Final[tuple[TransferType, ...]] = ("control", "bulk", "interrupt")
 _DATA_PREVIEW_BYTES: Final[int] = 32
+_CONTROL_ENDPOINT: Final[int] = 0
 
 
 @dataclass(frozen=True)
@@ -93,12 +107,8 @@ class _DeviceAccumulator:
     packet_count: int = 0
     endpoint_packet_counts: dict[int, int] = field(default_factory=_empty_endpoint_packet_counts)
     transfer_types: set[TransferType] = field(default_factory=_empty_transfer_types)
-    vendor_id: str | None = None
-    product_id: str | None = None
-    manufacturer: str | None = None
-    product: str | None = None
-    manufacturer_index: int | None = None
-    product_index: int | None = None
+    device_descriptor: DeviceDescriptor | None = None
+    configuration: ConfigurationDescriptor | None = None
     string_descriptors: dict[int, str] = field(default_factory=_empty_string_descriptors)
 
 
@@ -267,6 +277,31 @@ class Session:
             return None
         return _packet_record(index, records[index])
 
+    def get_enumeration(self, device_id: str) -> DeviceEnumeration:
+        """Return the descriptors and enumeration-phase span for one device.
+
+        Decodes the device and configuration descriptors the device reported
+        during its initial enumeration, and identifies the enumeration/negotiation
+        phase: the standard control transfers on endpoint 0 that precede the
+        device's first runtime traffic. This lets an analyst learn what a device
+        is before interpreting its vendor protocol.
+
+        Args:
+            device_id: The ``dev_bbb_ddd`` id of the device, as reported by
+                :meth:`list_devices`.
+
+        Returns:
+            A :class:`DeviceEnumeration`. When the capture contains no packets for
+            ``device_id``, every descriptor field is ``None``/empty, the index
+            fields are ``None``, and ``is_complete`` is ``False``.
+
+        Raises:
+            RuntimeError: No capture has been loaded.
+        """
+        if self.capture is None:
+            raise RuntimeError("No capture loaded. Call load_capture() first.")
+        return _build_enumeration(self.capture.records, self.capture.transactions, device_id)
+
 
 def _validate_capture_path(path: Path) -> Path:
     source = path.expanduser().resolve()
@@ -429,10 +464,10 @@ def _record_matches(
     return True
 
 
-def _summarize_devices(
+def _accumulate_devices(
     records: tuple[UrbRecord, ...],
     transactions: tuple[UrbTransaction, ...],
-) -> tuple[DeviceSummary, ...]:
+) -> dict[tuple[int, int], _DeviceAccumulator]:
     devices: dict[tuple[int, int], _DeviceAccumulator] = {}
     for record in records:
         accumulator = _device_accumulator(devices, record.bus_num, record.dev_num)
@@ -443,7 +478,14 @@ def _summarize_devices(
 
     for transaction in transactions:
         _apply_descriptor_info(devices, transaction)
+    return devices
 
+
+def _summarize_devices(
+    records: tuple[UrbRecord, ...],
+    transactions: tuple[UrbTransaction, ...],
+) -> tuple[DeviceSummary, ...]:
+    devices = _accumulate_devices(records, transactions)
     return tuple(
         _device_summary(accumulator)
         for _, accumulator in sorted(devices.items(), key=lambda item: (item[0][0], item[0][1]))
@@ -479,68 +521,47 @@ def _apply_descriptor_info(
     completion = transaction.completion
     if submission is None or completion is None or submission.setup is None:
         return
+    setup = parse_setup_packet(submission.setup)
+    if setup is None or not setup.is_standard or setup.b_request != GET_DESCRIPTOR_REQUEST:
+        return
     accumulator = devices.get((submission.bus_num, submission.dev_num))
     if accumulator is None:
         return
 
-    descriptor_type = _requested_descriptor_type(submission.setup)
-    descriptor_index = submission.setup[2]
-    if descriptor_type == _DEVICE_DESCRIPTOR_TYPE:
-        _apply_device_descriptor(accumulator, completion.data)
-        return
-    if descriptor_type == _STRING_DESCRIPTOR_TYPE and descriptor_index > 0:
-        descriptor = _decode_string_descriptor(completion.data)
+    if setup.descriptor_type == DEVICE_DESCRIPTOR:
+        descriptor = parse_device_descriptor(completion.data)
         if descriptor is not None:
-            accumulator.string_descriptors[descriptor_index] = descriptor
+            accumulator.device_descriptor = descriptor
+    elif setup.descriptor_type == CONFIGURATION_DESCRIPTOR:
+        configuration = parse_configuration(completion.data)
+        if configuration is not None and _prefer_configuration(accumulator.configuration, configuration):
+            accumulator.configuration = configuration
+    elif setup.descriptor_type == STRING_DESCRIPTOR and setup.descriptor_index > 0:
+        text = parse_string_descriptor(completion.data)
+        if text is not None:
+            accumulator.string_descriptors[setup.descriptor_index] = text
 
 
-def _requested_descriptor_type(setup: bytes) -> int | None:
-    if len(setup) != 8 or setup[1] != _GET_DESCRIPTOR_REQUEST:
-        return None
-    return setup[3]
+def _prefer_configuration(existing: ConfigurationDescriptor | None, candidate: ConfigurationDescriptor) -> bool:
+    """Return whether ``candidate`` is a more complete configuration than ``existing``.
 
-
-def _apply_device_descriptor(accumulator: _DeviceAccumulator, data: bytes) -> None:
-    if len(data) < 18 or data[1] != _DEVICE_DESCRIPTOR_TYPE:
-        return
-    accumulator.vendor_id = _format_usb_id(data[8], data[9])
-    accumulator.product_id = _format_usb_id(data[10], data[11])
-    accumulator.manufacturer_index = _descriptor_string_index(data[14])
-    accumulator.product_index = _descriptor_string_index(data[15])
-
-
-def _format_usb_id(low: int, high: int) -> str:
-    return f"0x{((high << 8) | low):04x}"
-
-
-def _descriptor_string_index(value: int) -> int | None:
-    if value == 0:
-        return None
-    return value
-
-
-def _decode_string_descriptor(data: bytes) -> str | None:
-    if len(data) < 2 or data[1] != _STRING_DESCRIPTOR_TYPE:
-        return None
-    descriptor_length = min(data[0], len(data))
-    if descriptor_length <= 2:
-        return None
-    payload = data[2:descriptor_length]
-    if len(payload) % 2 != 0:
-        payload = payload[:-1]
-    try:
-        decoded = payload.decode("utf-16-le")
-    except UnicodeDecodeError:
-        return None
-    decoded = decoded.rstrip("\x00")
-    if decoded == "":
-        return None
-    return decoded
+    Enumeration reads the configuration twice — a 9-byte header-only read to
+    learn the total length, then the full blob. Keep whichever carries more
+    interface descriptors so the header-only read never overwrites the full one.
+    """
+    if existing is None:
+        return True
+    return len(candidate.interfaces) > len(existing.interfaces)
 
 
 def _device_summary(accumulator: _DeviceAccumulator) -> DeviceSummary:
-    manufacturer = _descriptor_string(accumulator, accumulator.manufacturer_index)
-    product = _descriptor_string(accumulator, accumulator.product_index)
+    device = accumulator.device_descriptor
+    config = accumulator.configuration
+    manufacturer = _descriptor_string(accumulator, device.manufacturer_index) if device else None
+    product = _descriptor_string(accumulator, device.product_index) if device else None
+    vendor_id = _format_usb_id(device.vendor_id) if device else None
+    product_id = _format_usb_id(device.product_id) if device else None
+    interface_class = config.interfaces[0].interface_class if config and config.interfaces else None
     return DeviceSummary(
         device_id=_device_id(accumulator.bus_num, accumulator.dev_num),
         bus_num=accumulator.bus_num,
@@ -551,11 +572,13 @@ def _device_summary(accumulator: _DeviceAccumulator) -> DeviceSummary:
             for addr, count in sorted(accumulator.endpoint_packet_counts.items())
         ),
         transfer_types_seen=_sorted_transfer_types(accumulator.transfer_types),
-        vendor_id=accumulator.vendor_id,
-        product_id=accumulator.product_id,
+        vendor_id=vendor_id,
+        product_id=product_id,
         manufacturer=manufacturer,
         product=product,
-        descriptor_summary=_descriptor_summary(accumulator, manufacturer, product),
+        descriptor_summary=_descriptor_summary(vendor_id, product_id, manufacturer, product),
+        device_class=device.device_class if device else None,
+        interface_class=interface_class,
     )
 
 
@@ -563,6 +586,10 @@ def _descriptor_string(accumulator: _DeviceAccumulator, index: int | None) -> st
     if index is None:
         return None
     return accumulator.string_descriptors.get(index)
+
+
+def _format_usb_id(value: int) -> str:
+    return f"0x{value:04x}"
 
 
 def _sorted_transfer_types(transfer_types: set[TransferType]) -> tuple[TransferType, ...]:
@@ -574,18 +601,150 @@ def _device_id(bus_num: int, dev_num: int) -> str:
 
 
 def _descriptor_summary(
-    accumulator: _DeviceAccumulator,
+    vendor_id: str | None,
+    product_id: str | None,
     manufacturer: str | None,
     product: str | None,
 ) -> str | None:
-    if accumulator.vendor_id is None and accumulator.product_id is None:
+    if vendor_id is None and product_id is None:
         return None
     label = "USB device"
     if manufacturer is not None and product is not None:
         label = f"{manufacturer} {product}"
     elif product is not None:
         label = product
-    return f"{label} ({accumulator.vendor_id}:{accumulator.product_id})"
+    return f"{label} ({vendor_id}:{product_id})"
+
+
+# ---------------------------------------------------------------------------
+# Enumeration-phase detection and descriptor retrieval
+# ---------------------------------------------------------------------------
+
+
+def _build_enumeration(
+    records: tuple[UrbRecord, ...],
+    transactions: tuple[UrbTransaction, ...],
+    device_id: str,
+) -> DeviceEnumeration:
+    accumulators = _accumulate_devices(records, transactions)
+    accumulator = next(
+        (acc for acc in accumulators.values() if _device_id(acc.bus_num, acc.dev_num) == device_id),
+        None,
+    )
+    device = accumulator.device_descriptor if accumulator else None
+    config = accumulator.configuration if accumulator else None
+    enum_indices, runtime_start, is_complete = _enumeration_indices(records, device_id)
+    return DeviceEnumeration(
+        device_id=device_id,
+        vendor_id=_format_usb_id(device.vendor_id) if device else None,
+        product_id=_format_usb_id(device.product_id) if device else None,
+        usb_version=device.usb_version if device else None,
+        device_class=device.device_class if device else None,
+        device_subclass=device.device_subclass if device else None,
+        device_protocol=device.device_protocol if device else None,
+        manufacturer=_descriptor_string(accumulator, device.manufacturer_index) if accumulator and device else None,
+        product=_descriptor_string(accumulator, device.product_index) if accumulator and device else None,
+        serial_number=(_descriptor_string(accumulator, device.serial_number_index) if accumulator and device else None),
+        configuration_value=config.configuration_value if config else None,
+        interfaces=_enumerated_interfaces(config, accumulator) if config and accumulator else (),
+        enumeration_packet_indices=tuple(enum_indices),
+        enumeration_start_index=min(enum_indices) if enum_indices else None,
+        enumeration_end_index=max(enum_indices) if enum_indices else None,
+        runtime_start_index=runtime_start,
+        is_complete=is_complete,
+    )
+
+
+def _enumerated_interfaces(
+    config: ConfigurationDescriptor,
+    accumulator: _DeviceAccumulator,
+) -> tuple[EnumeratedInterface, ...]:
+    return tuple(
+        EnumeratedInterface(
+            number=interface.number,
+            alternate_setting=interface.alternate_setting,
+            interface_class=interface.interface_class,
+            interface_subclass=interface.interface_subclass,
+            interface_protocol=interface.interface_protocol,
+            description=_descriptor_string(accumulator, interface.interface_index),
+            endpoints=tuple(
+                EnumeratedEndpoint(
+                    address=f"0x{endpoint.address:02x}",
+                    number=endpoint.number,
+                    direction=endpoint.direction,
+                    transfer_type=endpoint.transfer_type,
+                    max_packet_size=endpoint.max_packet_size,
+                    interval=endpoint.interval,
+                )
+                for endpoint in interface.endpoints
+            ),
+        )
+        for interface in config.interfaces
+    )
+
+
+def _enumeration_indices(
+    records: tuple[UrbRecord, ...],
+    device_id: str,
+) -> tuple[list[int], int | None, bool]:
+    """Classify a device's records into its enumeration phase.
+
+    Returns the record indices belonging to the enumeration phase, the index at
+    which the device's runtime traffic begins (``None`` if it never does), and
+    whether a ``SET_CONFIGURATION`` was seen during enumeration.
+    """
+    enum_flags = _classify_enumeration_records(records)
+    runtime_start = next(
+        (
+            index
+            for index, record in enumerate(records)
+            if _device_id(record.bus_num, record.dev_num) == device_id and not enum_flags[index]
+        ),
+        None,
+    )
+
+    enum_indices: list[int] = []
+    is_complete = False
+    for index, record in enumerate(records):
+        if runtime_start is not None and index >= runtime_start:
+            break
+        if _device_id(record.bus_num, record.dev_num) != device_id or not enum_flags[index]:
+            continue
+        enum_indices.append(index)
+        if _is_set_configuration(record):
+            is_complete = True
+    return enum_indices, runtime_start, is_complete
+
+
+def _classify_enumeration_records(records: tuple[UrbRecord, ...]) -> list[bool]:
+    """Flag each record as belonging to enumeration (standard ep0 control) or runtime.
+
+    A record is enumeration when it is a standard control transfer on endpoint 0.
+    Completions carry no setup packet, so each is matched to its own in-flight
+    submission — ``urb_id`` alone is unreliable because the kernel reuses ids
+    across the capture. Unmatched (orphan) control completions default to
+    enumeration rather than being mistaken for runtime traffic.
+    """
+    flags = [False] * len(records)
+    open_standard: dict[int, bool] = {}
+    for index, record in enumerate(records):
+        if record.transfer_type != "control" or record.endpoint != _CONTROL_ENDPOINT:
+            continue  # any transfer off endpoint 0 is runtime traffic
+        if record.event_type == "submission" and record.setup is not None:
+            setup = parse_setup_packet(record.setup)
+            standard = setup is not None and setup.is_standard
+            open_standard[record.urb_id] = standard
+        else:
+            standard = open_standard.pop(record.urb_id, True)
+        flags[index] = standard
+    return flags
+
+
+def _is_set_configuration(record: UrbRecord) -> bool:
+    if record.event_type != "submission" or record.setup is None:
+        return False
+    setup = parse_setup_packet(record.setup)
+    return setup is not None and setup.is_standard and setup.b_request == SET_CONFIGURATION_REQUEST
 
 
 # ---------------------------------------------------------------------------

--- a/tests/int/test_mcp_enumeration_goodix.py
+++ b/tests/int/test_mcp_enumeration_goodix.py
@@ -1,0 +1,94 @@
+"""Integration tests for descriptor decoding and enumeration on a real Goodix capture."""
+
+from __future__ import annotations
+
+import pathlib
+
+from bsu_tool.session import Session
+
+_CAPTURE = (
+    pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures" / "goodix_enum_and_enroll_sanitized.pcapng"
+)
+_GOODIX_DEVICE_ID = "dev_001_011"
+
+
+def test_list_devices_reports_descriptor_classes() -> None:
+    """list_devices surfaces the device and interface classes decoded from descriptors.
+
+    The device class is 0xef (composite); the vendor-specific 0xff class that
+    marks the device as in-scope lives in the interface descriptor.
+    """
+    session = Session()
+    session.load(_CAPTURE)
+
+    goodix = next(device for device in session.list_devices() if device.device_id == _GOODIX_DEVICE_ID)
+
+    assert goodix.device_class == 0xEF
+    assert goodix.interface_class == 0xFF
+
+
+def test_get_enumeration_decodes_goodix_descriptors() -> None:
+    """get_enumeration returns the device, configuration, and endpoint descriptors."""
+    session = Session()
+    session.load(_CAPTURE)
+
+    enumeration = session.get_enumeration(_GOODIX_DEVICE_ID)
+
+    assert enumeration.vendor_id == "0x27c6"
+    assert enumeration.product_id == "0x63ac"
+    assert enumeration.usb_version == "2.00"
+    assert enumeration.device_class == 0xEF
+    assert enumeration.manufacturer == "Goodix Technology Co., Ltd."
+    assert enumeration.product == "Goodix Fingerprint USB Device"
+    assert enumeration.configuration_value == 1
+
+    assert len(enumeration.interfaces) == 1
+    interface = enumeration.interfaces[0]
+    assert interface.interface_class == 0xFF
+    assert [(ep.address, ep.direction, ep.transfer_type) for ep in interface.endpoints] == [
+        ("0x83", "in", "bulk"),
+        ("0x01", "out", "bulk"),
+    ]
+    assert all(ep.max_packet_size == 64 for ep in interface.endpoints)
+
+
+def test_get_enumeration_identifies_phase_boundary() -> None:
+    """The enumeration phase is the standard ep0 control prefix before runtime bulk.
+
+    In this capture the device is enumerated several times before its enrollment
+    traffic begins; the phase spans all of those rounds and ends just before the
+    first bulk transfer at index 146.
+    """
+    session = Session()
+    session.load(_CAPTURE)
+
+    enumeration = session.get_enumeration(_GOODIX_DEVICE_ID)
+
+    assert enumeration.is_complete is True
+    assert enumeration.enumeration_start_index == 30
+    assert enumeration.enumeration_end_index == 145
+    assert enumeration.runtime_start_index == 146
+    # Every enumeration packet precedes the first runtime packet.
+    assert enumeration.enumeration_packet_indices
+    assert max(enumeration.enumeration_packet_indices) < enumeration.runtime_start_index
+    # The phase carries only endpoint-0 control packets.
+    for index in enumeration.enumeration_packet_indices:
+        packet = session.get_packet(index)
+        assert packet is not None
+        assert packet.transfer_type == "control"
+        assert packet.endpoint_number == 0
+
+
+def test_get_enumeration_unknown_device_is_empty() -> None:
+    """Requesting a device absent from the capture yields an empty enumeration."""
+    session = Session()
+    session.load(_CAPTURE)
+
+    enumeration = session.get_enumeration("dev_009_009")
+
+    assert enumeration.vendor_id is None
+    assert enumeration.interfaces == ()
+    assert enumeration.enumeration_packet_indices == ()
+    assert enumeration.enumeration_start_index is None
+    assert enumeration.runtime_start_index is None
+    assert enumeration.is_complete is False

--- a/tests/unit/test_descriptors.py
+++ b/tests/unit/test_descriptors.py
@@ -1,0 +1,190 @@
+"""Unit tests for USB descriptor and setup-packet parsing."""
+
+from __future__ import annotations
+
+from bsu_tool.descriptors import (
+    parse_configuration,
+    parse_device_descriptor,
+    parse_setup_packet,
+    parse_string_descriptor,
+)
+
+# A minimal but complete device descriptor (18 bytes). Vendor 0x27c6,
+# product 0x63ac, composite device class 0xef, one configuration.
+_DEVICE_DESCRIPTOR = bytes(
+    [
+        0x12,  # bLength
+        0x01,  # bDescriptorType = DEVICE
+        0x00,
+        0x02,  # bcdUSB = 0x0200
+        0xEF,  # bDeviceClass
+        0x00,  # bDeviceSubClass
+        0x00,  # bDeviceProtocol
+        0x40,  # bMaxPacketSize0 = 64
+        0xC6,
+        0x27,  # idVendor = 0x27c6
+        0xAC,
+        0x63,  # idProduct = 0x63ac
+        0x00,
+        0x01,  # bcdDevice = 0x0100
+        0x01,  # iManufacturer
+        0x02,  # iProduct
+        0x03,  # iSerialNumber
+        0x01,  # bNumConfigurations
+    ]
+)
+
+# A configuration blob: config header (9) + interface (9) + two endpoint
+# descriptors (7 each) = 32 bytes. Interface class 0xff (vendor-specific),
+# endpoints 0x83 (bulk IN) and 0x01 (bulk OUT), both 64-byte max packet.
+_CONFIGURATION = bytes(
+    [
+        # configuration descriptor
+        0x09,  # bLength
+        0x02,  # bDescriptorType = CONFIGURATION
+        0x20,
+        0x00,  # wTotalLength = 32
+        0x01,  # bNumInterfaces
+        0x01,  # bConfigurationValue
+        0x00,  # iConfiguration
+        0x80,  # bmAttributes
+        0x32,  # bMaxPower = 50 -> 100 mA
+        # interface descriptor
+        0x09,  # bLength
+        0x04,  # bDescriptorType = INTERFACE
+        0x00,  # bInterfaceNumber
+        0x00,  # bAlternateSetting
+        0x02,  # bNumEndpoints
+        0xFF,  # bInterfaceClass = vendor-specific
+        0x00,  # bInterfaceSubClass
+        0x00,  # bInterfaceProtocol
+        0x00,  # iInterface
+        # endpoint descriptor 1: 0x83 bulk IN
+        0x07,  # bLength
+        0x05,  # bDescriptorType = ENDPOINT
+        0x83,  # bEndpointAddress = EP3 IN
+        0x02,  # bmAttributes = bulk
+        0x40,
+        0x00,  # wMaxPacketSize = 64
+        0x00,  # bInterval
+        # endpoint descriptor 2: 0x01 bulk OUT
+        0x07,
+        0x05,
+        0x01,  # bEndpointAddress = EP1 OUT
+        0x02,
+        0x40,
+        0x00,
+        0x00,
+    ]
+)
+
+
+def test_parse_device_descriptor_fields() -> None:
+    """A well-formed device descriptor yields every field."""
+    descriptor = parse_device_descriptor(_DEVICE_DESCRIPTOR)
+    assert descriptor is not None
+    assert descriptor.vendor_id == 0x27C6
+    assert descriptor.product_id == 0x63AC
+    assert descriptor.device_class == 0xEF
+    assert descriptor.usb_version == "2.00"
+    assert descriptor.max_packet_size0 == 64
+    assert descriptor.manufacturer_index == 1
+    assert descriptor.product_index == 2
+    assert descriptor.serial_number_index == 3
+    assert descriptor.num_configurations == 1
+
+
+def test_parse_device_descriptor_rejects_short_payload() -> None:
+    """A payload shorter than 18 bytes is not a device descriptor."""
+    assert parse_device_descriptor(_DEVICE_DESCRIPTOR[:10]) is None
+
+
+def test_parse_device_descriptor_rejects_wrong_type() -> None:
+    """A payload whose descriptor-type byte is not DEVICE is rejected."""
+    mangled = bytearray(_DEVICE_DESCRIPTOR)
+    mangled[1] = 0x02
+    assert parse_device_descriptor(bytes(mangled)) is None
+
+
+def test_parse_configuration_walks_nested_descriptors() -> None:
+    """A configuration blob yields its interface and endpoint descriptors."""
+    config = parse_configuration(_CONFIGURATION)
+    assert config is not None
+    assert config.configuration_value == 1
+    assert config.total_length == 32
+    assert config.num_interfaces == 1
+    assert config.max_power_ma == 100
+    assert len(config.interfaces) == 1
+
+    interface = config.interfaces[0]
+    assert interface.interface_class == 0xFF
+    assert len(interface.endpoints) == 2
+
+    ep_in, ep_out = interface.endpoints
+    assert ep_in.address == 0x83
+    assert ep_in.number == 3
+    assert ep_in.direction == "in"
+    assert ep_in.transfer_type == "bulk"
+    assert ep_in.max_packet_size == 64
+    assert ep_out.address == 0x01
+    assert ep_out.direction == "out"
+
+
+def test_parse_configuration_header_only_has_no_interfaces() -> None:
+    """The 9-byte header-only read (used to learn wTotalLength) parses with no interfaces."""
+    config = parse_configuration(_CONFIGURATION[:9])
+    assert config is not None
+    assert config.total_length == 32
+    assert config.interfaces == ()
+
+
+def test_parse_configuration_rejects_wrong_type() -> None:
+    """A payload that does not begin with a configuration descriptor is rejected."""
+    assert parse_configuration(_DEVICE_DESCRIPTOR) is None
+
+
+def test_parse_configuration_stops_on_zero_length_descriptor() -> None:
+    """A zero-length sub-descriptor terminates the walk instead of looping."""
+    truncated = bytearray(_CONFIGURATION)
+    truncated[9] = 0x00  # zero out the interface descriptor's bLength
+    config = parse_configuration(bytes(truncated))
+    assert config is not None
+    assert config.interfaces == ()
+
+
+def test_parse_string_descriptor_decodes_utf16() -> None:
+    """A UTF-16-LE string descriptor decodes to text."""
+    payload = "Goodix".encode("utf-16-le")
+    descriptor = bytes([len(payload) + 2, 0x03]) + payload
+    assert parse_string_descriptor(descriptor) == "Goodix"
+
+
+def test_parse_string_descriptor_rejects_empty() -> None:
+    """The zero-length language-id descriptor (index 0) yields no string."""
+    assert parse_string_descriptor(bytes([0x02, 0x03])) is None
+
+
+def test_parse_setup_packet_classifies_standard_get_descriptor() -> None:
+    """A standard GET_DESCRIPTOR(CONFIG) setup packet decodes its fields."""
+    setup = bytes([0x80, 0x06, 0x00, 0x02, 0x00, 0x00, 0x20, 0x00])
+    packet = parse_setup_packet(setup)
+    assert packet is not None
+    assert packet.is_standard
+    assert packet.request_type == "standard"
+    assert packet.b_request == 0x06
+    assert packet.descriptor_type == 0x02
+    assert packet.descriptor_index == 0x00
+    assert packet.w_length == 32
+
+
+def test_parse_setup_packet_classifies_class_and_vendor() -> None:
+    """The request-type bits distinguish class and vendor requests."""
+    class_setup = parse_setup_packet(bytes([0xA3, 0x00, 0x00, 0x00, 0x02, 0x00, 0x04, 0x00]))
+    vendor_setup = parse_setup_packet(bytes([0x40, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+    assert class_setup is not None and class_setup.request_type == "class"
+    assert vendor_setup is not None and vendor_setup.request_type == "vendor"
+
+
+def test_parse_setup_packet_rejects_wrong_length() -> None:
+    """A setup field that is not exactly eight bytes is rejected."""
+    assert parse_setup_packet(bytes(7)) is None


### PR DESCRIPTION
Closes #60

## What does this PR do?

Decodes the USB descriptors exchanged during device enumeration and attaches
them to the session, so Claude can learn what a device is before analyzing its
runtime traffic.

- **New `bsu_tool/descriptors.py`** — pure parsers for the setup packet and the
  device, configuration, interface, and endpoint descriptors (VID/PID, class
  triple, bcdUSB, string indices; nested interfaces/endpoints with transfer
  type, direction, and max packet size).
- **`Session.get_enumeration(device_id)`** — returns a device's decoded
  descriptors plus the enumeration/negotiation phase: the standard endpoint-0
  control transfers that precede the device's first runtime traffic, reported
  as a packet-index span (`enumeration_start/end_index`, `runtime_start_index`)
  with an `is_complete` flag (whether a `SET_CONFIGURATION` was observed).
- **`list_devices` enrichment** — `DeviceSummary` now carries `device_class` and
  `interface_class`. This matters because the vendor-specific `0xFF` class that
  marks an in-scope device lives in the *interface* descriptor, not the device
  descriptor (whose class is often `0x00`/`0xEF`) — the previous device-only
  parse missed it.
- **New MCP tool `get_enumeration`** exposing the above to Claude Code.

Notes on the enumeration heuristic:
- Classification is per-device and content-based (standard vs class/vendor
  requests on ep0), so interleaved hub port-management traffic is correctly
  attributed to the hub, not the target device.
- Completions are matched to their own in-flight submission rather than by
  `urb_id` alone, since usbmon reuses `urb_id`s across the capture.
- Devices are keyed on their assigned address (no address-0 stitching); the
  full descriptors are always read at the assigned address anyway.
- `urb_decoder.py` was intentionally left untouched — descriptor decoding is a
  layer above the URB decoder and consumes its existing output.

## How was it tested?

Ran locally on the feature branch (merged with latest `main`):

- `ruff check .` and `ruff format --check .` — clean
- `pyright` (strict mode) — 0 errors, 0 warnings
- `pytest` — 298 passed, 3 skipped

Coverage:
- **Unit** (`tests/unit/test_descriptors.py`) — device/configuration/string
  descriptor and setup-packet parsing against hand-built byte blobs, including
  multi-endpoint configs, header-only reads, and malformed input.
- **Integration** (`tests/int/test_mcp_enumeration_goodix.py`) — validated
  against the Goodix enumeration capture: device class `0xEF`, interface class
  `0xFF`, VID `0x27c6` / PID `0x63ac`, bulk endpoints `0x83`/`0x01`, and the
  enumeration phase span `[30, 145]` with runtime beginning at packet 146.
- `test_annotations.py` confirms full type annotations + docstrings on the new
  module.

## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR
