### PR TITLE
write feat: add byte_count to EndpointSummary for per-endpoint byte volume …

### DIFF
--- a/bsu_tool/mcp/interfaces.py
+++ b/bsu_tool/mcp/interfaces.py
@@ -46,6 +46,7 @@ class EndpointSummary:
 
     address: str
     packet_count: int
+    byte_count: int  # total bytes transferred on this endpoint, summed from completion events only
 
 
 @dataclass(frozen=True, slots=True)

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -748,6 +748,7 @@ def _endpoint_summary_to_dict(endpoint: EndpointSummary) -> JsonDict:
     return {
         "address": endpoint.address,
         "packet_count": endpoint.packet_count,
+        "byte_count": endpoint.byte_count,
     }
 
 

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -87,6 +87,10 @@ def _empty_endpoint_packet_counts() -> dict[int, int]:
     return {}
 
 
+def _empty_endpoint_byte_counts() -> dict[int, int]:
+    return {}
+
+
 def _empty_transfer_types() -> set[TransferType]:
     return set()
 
@@ -113,6 +117,7 @@ class _DeviceAccumulator:
     dev_num: int
     packet_count: int = 0
     endpoint_packet_counts: dict[int, int] = field(default_factory=_empty_endpoint_packet_counts)
+    endpoint_byte_counts: dict[int, int] = field(default_factory=_empty_endpoint_byte_counts)
     transfer_types: set[TransferType] = field(default_factory=_empty_transfer_types)
     vendor_id: str | None = None
     product_id: str | None = None
@@ -524,6 +529,13 @@ def _summarize_devices(
         accumulator.packet_count += 1
         addr = _endpoint_address(record)
         accumulator.endpoint_packet_counts[addr] = accumulator.endpoint_packet_counts.get(addr, 0) + 1
+        # Bytes are tallied only on completion events using the URB-reported full
+        # length (not captured_length, which snaplen truncation would under-report),
+        # so a submission and its completion never double-count the same transfer.
+        # Caveats: control endpoint 0 (address 0x00) mixes IN and OUT traffic under
+        # one address, and in-flight URBs seen only as submissions contribute 0 bytes.
+        if record.event_type == "completion":
+            accumulator.endpoint_byte_counts[addr] = accumulator.endpoint_byte_counts.get(addr, 0) + record.length
         accumulator.transfer_types.add(record.transfer_type)
 
     for transaction in transactions:
@@ -632,7 +644,11 @@ def _device_summary(accumulator: _DeviceAccumulator) -> DeviceSummary:
         dev_num=accumulator.dev_num,
         packet_count=accumulator.packet_count,
         endpoints_seen=tuple(
-            EndpointSummary(address=f"0x{addr:02x}", packet_count=count)
+            EndpointSummary(
+                address=f"0x{addr:02x}",
+                packet_count=count,
+                byte_count=accumulator.endpoint_byte_counts.get(addr, 0),
+            )
             for addr, count in sorted(accumulator.endpoint_packet_counts.items())
         ),
         transfer_types_seen=_sorted_transfer_types(accumulator.transfer_types),

--- a/tests/unit/mcp/test_interfaces.py
+++ b/tests/unit/mcp/test_interfaces.py
@@ -53,8 +53,8 @@ def test_device_summary_contains_list_devices_fields() -> None:
         dev_num=4,
         packet_count=5,
         endpoints_seen=(
-            EndpointSummary(address="0x00", packet_count=3),
-            EndpointSummary(address="0x81", packet_count=2),
+            EndpointSummary(address="0x00", packet_count=3, byte_count=48),
+            EndpointSummary(address="0x81", packet_count=2, byte_count=16),
         ),
         transfer_types_seen=("control", "bulk"),
         vendor_id="0x27c6",
@@ -68,8 +68,8 @@ def test_device_summary_contains_list_devices_fields() -> None:
     assert device.dev_num == 4
     assert device.packet_count == 5
     assert device.endpoints_seen == (
-        EndpointSummary(address="0x00", packet_count=3),
-        EndpointSummary(address="0x81", packet_count=2),
+        EndpointSummary(address="0x00", packet_count=3, byte_count=48),
+        EndpointSummary(address="0x81", packet_count=2, byte_count=16),
     )
     assert device.transfer_types_seen == ("control", "bulk")
     assert device.vendor_id == "0x27c6"

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -995,6 +995,11 @@ def test_session_round_trips_json_safe_dict(tmp_path: Path) -> None:
     assert "interface_class" in devices[0]
     assert capture_data["summary"] == session.summary().to_dict()
 
+    # Endpoint byte_count must survive serialization; 0x81 carries a non-zero
+    # tally so this cannot pass vacuously on the field's 0 default.
+    endpoints = cast(list[JsonDict], devices[0]["endpoints_seen"])
+    assert [(endpoint["address"], endpoint["byte_count"]) for endpoint in endpoints] == [("0x01", 0), ("0x81", 2)]
+
     packet = packets[0]
     assert packet["data_hex"] == "61"
     assert packet["data_preview"] == "61"

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -5,9 +5,10 @@ from pathlib import Path
 
 import pytest
 
-from bsu_tool.mcp.interfaces import EndpointSummary
+from bsu_tool.mcp.interfaces import CaptureMetadata, EndpointSummary
 from bsu_tool.pcapng_reader import PcapNgError
-from bsu_tool.session import Marker, Session
+from bsu_tool.session import Capture, Marker, Session
+from bsu_tool.urb_decoder import Direction, EventType, TransferType, UrbRecord
 
 _USBMON_HEADER_FORMAT = "<QBBBBHBBqiiII8s"
 _SUBMISSION = 0x53
@@ -328,14 +329,14 @@ def test_list_devices_summarizes_multiple_devices(tmp_path: Path) -> None:
     assert [device.device_id for device in device_summaries] == ["dev_001_004", "dev_001_007"]
     assert device_summaries[0].packet_count == 2
     assert device_summaries[0].endpoints_seen == (
-        EndpointSummary(address="0x01", packet_count=1),
-        EndpointSummary(address="0x81", packet_count=1),
+        EndpointSummary(address="0x01", packet_count=1, byte_count=0),
+        EndpointSummary(address="0x81", packet_count=1, byte_count=2),
     )
     assert device_summaries[0].transfer_types_seen == ("bulk",)
     assert device_summaries[1].packet_count == 7
     assert device_summaries[1].endpoints_seen == (
-        EndpointSummary(address="0x00", packet_count=6),
-        EndpointSummary(address="0x02", packet_count=1),
+        EndpointSummary(address="0x00", packet_count=6, byte_count=70),
+        EndpointSummary(address="0x02", packet_count=1, byte_count=0),
     )
     assert device_summaries[1].transfer_types_seen == ("control", "bulk")
     assert device_summaries[1].vendor_id == "0x27c6"
@@ -727,3 +728,115 @@ def test_packets_between_markers_unknown_device_id_is_empty(tmp_path: Path) -> N
 
     assert span.count == 0
     assert span.packets == ()
+
+
+def _byte_count_record(
+    *,
+    urb_id: int,
+    event_type: EventType,
+    endpoint: int,
+    direction: Direction,
+    length: int,
+    captured_length: int | None = None,
+    transfer_type: TransferType = "bulk",
+    status: int = 0,
+) -> UrbRecord:
+    """Build an in-memory UrbRecord for endpoint byte-count tests (no pcap/hardware)."""
+    captured = length if captured_length is None else captured_length
+    return UrbRecord(
+        urb_id=urb_id,
+        event_type=event_type,
+        transfer_type=transfer_type,
+        direction=direction,
+        bus_num=1,
+        dev_num=4,
+        endpoint=endpoint,
+        status=status,
+        length=length,
+        captured_length=captured,
+        data=b"\x00" * captured,
+        setup=None,
+        timestamp=0.0,
+    )
+
+
+def _endpoint_byte_counts(records: tuple[UrbRecord, ...]) -> dict[str, int]:
+    """Summarize in-memory records via the public Session API and map address -> byte_count."""
+    metadata = CaptureMetadata(
+        source="in-memory",
+        file_size_bytes=0,
+        packet_count=len(records),
+        capture_duration_seconds=None,
+        interfaces_seen=(),
+    )
+    session = Session()
+    session.capture = Capture(
+        source=Path("in-memory.pcapng"),
+        metadata=metadata,
+        packets=(),
+        records=records,
+        transactions=(),
+    )
+    (device,) = session.list_devices()
+    return {endpoint.address: endpoint.byte_count for endpoint in device.endpoints_seen}
+
+
+def test_byte_count_in_endpoint_counts_completion_only() -> None:
+    """An IN endpoint (0x81) tallies bytes on completion; the submission adds nothing."""
+    records = (
+        # Submission carries the requested buffer size (64); it must not be counted.
+        _byte_count_record(urb_id=1, event_type="submission", endpoint=1, direction="in", length=64),
+        _byte_count_record(urb_id=1, event_type="completion", endpoint=1, direction="in", length=16),
+    )
+    assert _endpoint_byte_counts(records) == {"0x81": 16}
+
+
+def test_byte_count_out_endpoint_no_double_count() -> None:
+    """An OUT endpoint (0x01) counts only the completion, so submit+complete is not doubled."""
+    records = (
+        _byte_count_record(urb_id=1, event_type="submission", endpoint=1, direction="out", length=8),
+        _byte_count_record(urb_id=1, event_type="completion", endpoint=1, direction="out", length=8),
+    )
+    assert _endpoint_byte_counts(records) == {"0x01": 8}
+
+
+def test_byte_count_control_endpoint_zero() -> None:
+    """Control endpoint 0 accumulates under address 0x00, on completion events only."""
+    records = (
+        _byte_count_record(
+            urb_id=1, event_type="submission", endpoint=0, direction="out", length=18, transfer_type="control"
+        ),
+        _byte_count_record(
+            urb_id=1, event_type="completion", endpoint=0, direction="in", length=18, transfer_type="control"
+        ),
+    )
+    assert _endpoint_byte_counts(records) == {"0x00": 18}
+
+
+def test_byte_count_lone_submission_adds_zero() -> None:
+    """An in-flight URB seen only as a submission contributes 0 bytes."""
+    records = (_byte_count_record(urb_id=1, event_type="submission", endpoint=1, direction="in", length=64),)
+    assert _endpoint_byte_counts(records) == {"0x81": 0}
+
+
+def test_byte_count_uses_length_not_captured_length() -> None:
+    """Byte volume sums the URB-reported length, not the snaplen-truncated captured_length."""
+    records = (
+        _byte_count_record(
+            urb_id=1, event_type="completion", endpoint=1, direction="in", length=100, captured_length=4
+        ),
+    )
+    assert _endpoint_byte_counts(records) == {"0x81": 100}
+
+
+def test_byte_count_failed_completion_counts_actual_length() -> None:
+    """A failed/partial completion (status != 0) still counts the bytes actually moved.
+
+    usbmon reports length = actual_length on completion even when the URB errored, so a
+    short/aborted transfer contributes the real byte volume, not zero.
+    """
+    records = (
+        _byte_count_record(urb_id=1, event_type="submission", endpoint=1, direction="in", length=64),
+        _byte_count_record(urb_id=1, event_type="completion", endpoint=1, direction="in", length=4, status=-71),
+    )
+    assert _endpoint_byte_counts(records) == {"0x81": 4}


### PR DESCRIPTION
this adds a byte_count to EndpointSummary so an endpoint reports not just how many packets it saw but
how much data actually moved across it.

**EndpointSummary.byte_count** is the total bytes transferred on that endpoint, tracked alongside the
existing packet_count. 
it gives claude code a signal for which endpoints carry the real traffic (a chatty bulk-in endpoint vs one that only ever sees short control exchanges) without having to pull every packet.

**caveats documented in the code:** control endpoint 0 (address 0x00) mixes IN and OUT traffic under one
address, so its byte_count is a combined figure; and an in-flight URB seen only as a submission (no
captured completion) contributes 0 bytes, consistent with counting completions only.

**edge cases covered:** endpoints with only zero-length transfers (byte_count 0, packet_count > 0),
submission-only in-flight URBs contributing nothing, and a mixed endpoint summing correctly across
completion events without double counting.

**tested** with pytest; the EndpointSummary / DeviceSummary assertions in `tests/unit/mcp/test_session.py`
and `test_interfaces.py` now pin both packet_count and the new byte_count. 

closes [#47](https://github.com/bsu-tool/bsu-tool/issues/47)