### PR TITLE
Add test for rejecting legacy pcap format

### DIFF
--- a/tests/unit/test_pcapng_reader.py
+++ b/tests/unit/test_pcapng_reader.py
@@ -467,6 +467,7 @@ def test_rejects_pcap_format() -> None:
         ):
             list(PcapNgReader(f))
 
+
 # --- Tests: real capture file (goodix_enroll_sanitized.pcapng) ------------
 
 # LINKTYPE_USB_LINUX_MMAPPED as seen in usbmon captures from modern kernels.

--- a/tests/unit/test_pcapng_reader.py
+++ b/tests/unit/test_pcapng_reader.py
@@ -451,10 +451,20 @@ def test_isb_body_too_small() -> None:
     with pytest.raises(InvalidBlockError, match="ISB body too small"):
         list(PcapNgReader(io.BytesIO(data)))
 
-def test_rejects_pcap_format():
+def test_rejects_pcap_format() -> None:
     """Legacy libpcap (.pcap) files are not supported."""
-    with open("test_data/captures/usb_memory_stick.pcap", "rb") as f:
-        with pytest.raises(InvalidBlockError):
+    capture = (
+        Path(__file__).parent.parent.parent
+        / "test_data"
+        / "captures"
+        / "usb_memory_stick.pcap"
+    )
+
+    with capture.open("rb") as f:
+        with pytest.raises(
+            InvalidBlockError,
+            match="first block is not a Section Header Block",
+        ):
             list(PcapNgReader(f))
 
 # --- Tests: real capture file (goodix_enroll_sanitized.pcapng) ------------

--- a/tests/unit/test_pcapng_reader.py
+++ b/tests/unit/test_pcapng_reader.py
@@ -464,13 +464,6 @@ def test_rejects_pcap_format() -> None:
             list(PcapNgReader(f))
 
 
-def test_rejects_pcap_format():
-    """Legacy libpcap (.pcap) files are not supported."""
-    with open("test_data/captures/usb_memory_stick.pcap", "rb") as f:
-        with pytest.raises(InvalidBlockError):
-            list(PcapNgReader(f))
-
-
 # --- Tests: real capture file (goodix_enroll_sanitized.pcapng) ------------
 
 # LINKTYPE_USB_LINUX_MMAPPED as seen in usbmon captures from modern kernels.

--- a/tests/unit/test_pcapng_reader.py
+++ b/tests/unit/test_pcapng_reader.py
@@ -454,7 +454,7 @@ def test_isb_body_too_small() -> None:
 def test_rejects_pcap_format() -> None:
     """Legacy libpcap (.pcap) files are not supported."""
     capture = (
-        Path(__file__).parent.parent.parent
+        pathlib.Path(__file__).parent.parent.parent
         / "test_data"
         / "captures"
         / "usb_memory_stick.pcap"

--- a/tests/unit/test_pcapng_reader.py
+++ b/tests/unit/test_pcapng_reader.py
@@ -451,6 +451,11 @@ def test_isb_body_too_small() -> None:
     with pytest.raises(InvalidBlockError, match="ISB body too small"):
         list(PcapNgReader(io.BytesIO(data)))
 
+def test_rejects_pcap_format():
+    """Legacy libpcap (.pcap) files are not supported."""
+    with open("test_data/captures/usb_memory_stick.pcap", "rb") as f:
+        with pytest.raises(InvalidBlockError):
+            list(PcapNgReader(f))
 
 # --- Tests: real capture file (goodix_enroll_sanitized.pcapng) ------------
 

--- a/tests/unit/test_pcapng_reader.py
+++ b/tests/unit/test_pcapng_reader.py
@@ -452,6 +452,13 @@ def test_isb_body_too_small() -> None:
         list(PcapNgReader(io.BytesIO(data)))
 
 
+def test_rejects_pcap_format():
+    """Legacy libpcap (.pcap) files are not supported."""
+    with open("test_data/captures/usb_memory_stick.pcap", "rb") as f:
+        with pytest.raises(InvalidBlockError):
+            list(PcapNgReader(f))
+
+
 # --- Tests: real capture file (goodix_enroll_sanitized.pcapng) ------------
 
 # LINKTYPE_USB_LINUX_MMAPPED as seen in usbmon captures from modern kernels.

--- a/tests/unit/test_pcapng_reader.py
+++ b/tests/unit/test_pcapng_reader.py
@@ -451,14 +451,10 @@ def test_isb_body_too_small() -> None:
     with pytest.raises(InvalidBlockError, match="ISB body too small"):
         list(PcapNgReader(io.BytesIO(data)))
 
+
 def test_rejects_pcap_format() -> None:
     """Legacy libpcap (.pcap) files are not supported."""
-    capture = (
-        pathlib.Path(__file__).parent.parent.parent
-        / "test_data"
-        / "captures"
-        / "usb_memory_stick.pcap"
-    )
+    capture = pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures" / "usb_memory_stick.pcap"
 
     with capture.open("rb") as f:
         with pytest.raises(


### PR DESCRIPTION
## What does this PR do?

Adds a regression test to verify that `PcapNgReader` rejects legacy libpcap (`.pcap`) files by raising `InvalidBlockError`.

The existing `test_data/captures/usb_memory_stick.pcap` fixture is now used to confirm that unsupported pcap formats are handled correctly.

closes #46

## How was it tested?

Ran the following locally:

```bash
python -m pytest -q -k test_rejects_pcap_format
```

Result:

```text
1 passed
```

## Checklist

- [x] PR description includes `closes #46`
- [x] No unintended files included in this PR