### PR TITLE
style: apply ruff format to markdown code blocks

### DIFF
--- a/docs/mcp-tool-design.md
+++ b/docs/mcp-tool-design.md
@@ -307,11 +307,7 @@ Initial error codes:
 Example usage:
 
 ```python
-load_capture(
-    path="/captures/device_trace.pcapng",
-    force_reload=False,
-    assume_format="auto"
-)
+load_capture(path="/captures/device_trace.pcapng", force_reload=False, assume_format="auto")
 ```
 
 Example `structuredContent.data`:
@@ -569,7 +565,7 @@ get_packets(
     offset=0,
     limit=100,
     include_data_preview=True,
-    data_preview_bytes=32
+    data_preview_bytes=32,
 )
 ```
 
@@ -647,9 +643,7 @@ Example usage:
 
 ```python
 mark_session_marker(
-    name="suspected_runtime_loop",
-    packet_index=421,
-    note="Possible start of repeated runtime communication."
+    name="suspected_runtime_loop", packet_index=421, note="Possible start of repeated runtime communication."
 )
 ```
 
@@ -682,10 +676,7 @@ Likely output:
 Example usage:
 
 ```python
-list_session_markers(
-    offset=0,
-    limit=100
-)
+list_session_markers(offset=0, limit=100)
 ```
 
 ---
@@ -718,10 +709,7 @@ Likely output:
 Example usage:
 
 ```python
-list_endpoints(
-    device_id="dev_01",
-    include_ep0=True
-)
+list_endpoints(device_id="dev_01", include_ep0=True)
 ```
 
 ---
@@ -754,11 +742,7 @@ Likely output:
 Example usage:
 
 ```python
-get_control_transfer_details(
-    packet_index=12,
-    include_descriptor_decode=True,
-    include_paired_event=True
-)
+get_control_transfer_details(packet_index=12, include_descriptor_decode=True, include_paired_event=True)
 ```
 
 ---
@@ -787,11 +771,7 @@ Likely output:
 Example usage:
 
 ```python
-infer_traffic_phase(
-    device_id="dev_01",
-    method="heuristic_v1",
-    include_reasons=True
-)
+infer_traffic_phase(device_id="dev_01", method="heuristic_v1", include_reasons=True)
 ```
 
 ---
@@ -825,10 +805,7 @@ Example usage:
 
 ```python
 summarize_device_activity(
-    device_id="dev_01",
-    traffic_phase="any",
-    include_repeated_payload_previews=False,
-    top_n_previews=10
+    device_id="dev_01", traffic_phase="any", include_repeated_payload_previews=False, top_n_previews=10
 )
 ```
 
@@ -914,11 +891,7 @@ load_capture(path="/captures/device_trace.pcapng")
 
 list_devices(include_descriptor_summary=True)
 
-get_packets(
-    device_id="dev_01",
-    limit=40,
-    include_data_preview=True
-)
+get_packets(device_id="dev_01", limit=40, include_data_preview=True)
 
 get_packets(
     device_id="dev_01",
@@ -928,53 +901,32 @@ get_packets(
     urb_event="complete",
     offset=0,
     limit=100,
-    include_data_preview=True
+    include_data_preview=True,
 )
 ```
 
 ## Extended workflow if supporting tools are available
 
 ```python
-list_endpoints(
-    device_id="dev_01",
-    include_ep0=True
-)
+list_endpoints(device_id="dev_01", include_ep0=True)
 
-infer_traffic_phase(
-    device_id="dev_01",
-    method="heuristic_v1",
-    include_reasons=True
-)
+infer_traffic_phase(device_id="dev_01", method="heuristic_v1", include_reasons=True)
 
 get_packets(
-    device_id="dev_01",
-    transfer_type="control",
-    traffic_phase="enumeration",
-    limit=40,
-    include_setup_summary=True
+    device_id="dev_01", transfer_type="control", traffic_phase="enumeration", limit=40, include_setup_summary=True
 )
 
-get_control_transfer_details(
-    packet_index=12,
-    include_descriptor_decode=True
-)
+get_control_transfer_details(packet_index=12, include_descriptor_decode=True)
 
 mark_session_marker(
     name="suspected_runtime_loop",
     packet_index=421,
     device_id="dev_01",
     note="Possible start of repeated runtime communication.",
-    tags=["hypothesis", "runtime"]
+    tags=["hypothesis", "runtime"],
 )
 
-list_session_markers(
-    device_id="dev_01",
-    tag="runtime"
-)
+list_session_markers(device_id="dev_01", tag="runtime")
 
-summarize_device_activity(
-    device_id="dev_01",
-    traffic_phase="any",
-    include_repeated_payload_previews=False
-)
+summarize_device_activity(device_id="dev_01", traffic_phase="any", include_repeated_payload_previews=False)
 ```

--- a/docs/session-roadmap-issues.md
+++ b/docs/session-roadmap-issues.md
@@ -276,8 +276,7 @@ Update `add_marker()` so marker names are unique within a capture session.
 Suggested behavior:
 
 ```python
-def add_marker(self, name: str, packet_index: int, note: str = "") -> None:
-    ...
+def add_marker(self, name: str, packet_index: int, note: str = "") -> None: ...
 ```
 
 Raise `ValueError` if the marker name already exists.


### PR DESCRIPTION
CI on `main` is red at the `ruff format --check .` step (run 30498346277, sha 42c81ed — the merge commit of #99).

## cause

`pyproject.toml` pins only `ruff>=0.15`, so CI resolves whatever the latest ruff is (currently 0.16.0). Recent ruff versions format python code blocks embedded in markdown, which older versions left alone. Two long-standing docs immediately went out of compliance:

- `docs/mcp-tool-design.md`
- `docs/session-roadmap-issues.md`

This is version drift, not a regression from #99. None of #99's own files (`bsu_tool/usb_enum.py`, `tests/unit/mcp/test_server.py`, `tests/unit/test_usb_enum.py`) were implicated in the failure.

## change

Ran `ruff format .` and committed only the two markdown docs. No hand edits, no source changes — the diff is entirely collapsed multi-line call signatures and added trailing commas inside ` ```python ` fences.

## verification

Full CI suite run locally against ruff 0.16.0, in workflow order:

- `ruff check .` — passed (all checks passed)
- `ruff format --check .` — passed (63 files already formatted)
- `pyright` — passed (0 errors, 0 warnings)
- `pytest` — passed (320 passed, 4 skipped)

## follow-up

Worth considering pinning `ruff` to an exact version in `pyproject.toml` so a new ruff release can't turn `main` red without a code change. Not done here to keep this PR to the red-CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)