### PR TITLE
Add capture workflow and device record specs

### DIFF
--- a/docs/architecture/capture-workflow-spec-sections.md
+++ b/docs/architecture/capture-workflow-spec-sections.md
@@ -1,0 +1,239 @@
+# Capture Workflow Specification: Sessions, Prompting, and Triage
+
+*Companion to the corpus naming and manifest sections already on this branch
+(`capture-workflow-spec.md`, section N). Together they are the capture spec that
+issue #104 calls for. Section numbers are placeholders and will be fixed when the
+whole spec is assembled.*
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are
+to be interpreted as described in RFC 2119 and RFC 8174 when, and only when, they appear
+in all capitals.
+
+---
+
+## P.1 What This Covers
+
+Section N defines what a capture is called and what its manifest holds. This section
+defines how captures get made: the order of steps in a session, what the tool asks the
+analyst at each step, how it decides who or what will make the device talk, and where it
+stops.
+
+The whole workflow rests on one idea. Protocol analysis is differential. A byte's meaning
+is learned by comparing captures, so each capture must hold exactly one known event,
+cleanly labeled. Everything below serves that.
+
+## P.2 Two Kinds of Device Context
+
+The workflow needs two kinds of information about a device, and only one of them can be
+read off the wire.
+
+**Electrical context** comes from the descriptors: vendor and product id, device and
+interface classes, endpoints and their transfer types. The tool reads this from an
+enumeration capture with `get_enumeration`.
+
+**Physical context** comes from the analyst: LEDs, buttons, switches, screw terminals,
+chip markings, the label on the case. No descriptor reports any of it. A descriptor will
+never say the device has a button, and "press the button" is the entire stimulus for some
+devices.
+
+Both are required. The tool MUST ask the analyst for physical context. The record's
+`physical` section MUST be populated from analyst answers, and `physical.operable_by_hand`
+MUST derive from an analyst answer, never from descriptor fields.
+
+## P.3 Session State Machine
+
+A guided session moves through these states. The tool drives the order. The analyst acts
+only when asked.
+
+```
+identify -> intake -> classify -> enumeration -> idle -> disconnect
+   -> re-enumeration -> [stimulus loop] -> summarize
+```
+
+The ordering matters and is physically constrained. The device starts unplugged, so the
+first capture that can run is the enumeration (the tool starts the sniffer, then the
+analyst plugs in). Only after the device is attached and settled can the idle baseline be
+taken. Building tools (#108, #109, #111, #112) supply the steps that no MCP tool covers
+today, named below.
+
+1. **identify.** Determine which physical device is the target and which bus carries it.
+   Use `enumerate_usb_devices` on an already-attached device, or the plug-in diff of
+   `detect-device` (#108) when the analyst cannot tell which entry is theirs. When the
+   target is not yet plugged in, the bus is resolved during the enumeration step.
+2. **intake.** Ask the analyst for physical context (P.2). Record it toward the device
+   record.
+3. **classify.** Run the provocation ladder (P.5) to decide who provides the stimulus and
+   which mode the device is in (P.6). This decides whether the session can proceed to
+   stimulus at all.
+4. **enumeration.** Start the capture, then tell the analyst to plug in. Capture through
+   `SET_CONFIGURATION`. Capture kind `enumeration`.
+5. **idle.** With the device now attached, capture it untouched for `IDLE_BASELINE_SECONDS`.
+   Capture kind `idle`. This is the control. Without it, background polling cannot be told
+   from signal.
+6. **disconnect.** Tell the analyst to unplug. Capture it as its own capture, kind
+   `disconnect`.
+7. **re-enumeration.** Tell the analyst to plug in again. Kind `enumeration`. Diffing this
+   against the first enumeration shows what is stable and what is not. What varies is the
+   device number, which is a location and not an identity.
+8. **stimulus loop.** For each event under test, run one stimulus capture (P.3.1). After
+   the whole set of single-event captures, run at least one `ordering` capture and one
+   `repeat` capture (section N.2.2), so a stateful protocol is not described as stateless.
+9. **summarize.** Write the device record and the corpus manifests. The manifest writer
+   (#111) resolves the post-close fields of section N.5 and applies the section N.2 naming
+   rule.
+
+The tool MUST start the sniffer before telling the analyst to plug in. Enumeration happens
+the instant the device connects and cannot be replayed. The tool MUST NOT let a single
+capture span an unplug. A replug inside one capture makes one physical device look like
+two.
+
+### P.3.1 One Stimulus Capture
+
+Each event under test produces one capture of kind `stimulus`, holding
+`MIN_EVENT_REPETITIONS` repetitions of that one event (section N.2.2). The repetitions are
+separated by marks placed live, one at each repetition boundary, through the `mark_now`
+tool (see the mark_now issue). `add_marker` cannot do this, because it anchors to a decoded
+packet in a loaded capture, and a live capture is not decoded until `stop_capture`.
+`mark_now` records the wall and monotonic clocks at the moment of the mark and resolves it
+to a packet index at capture close (section N.4). The capture's event label follows the
+`<subject>-<action>` form of section N.2.1, for example `relay1-on`.
+
+## P.4 Prompting Protocol
+
+Every point where the session needs the analyst, the tool asks a question and waits for a
+typed answer through the `wait_for_human` tool (#109). The tool MUST wait for the answer
+before proceeding, and MUST NOT assume an action happened because time passed.
+
+Questions fall into fixed kinds:
+
+| Kind | Example | When |
+|---|---|---|
+| physical intake | "what do you see on the board? LEDs, buttons, chip markings?" | intake |
+| plug in | "starting capture now, plug the device in" | enumeration |
+| unplug | "unplug the device now" | disconnect |
+| stimulus confirm | "did anything happen? what did you see or hear?" | after each stimulus |
+| safety check | "is anything hot, or does the device smell or look wrong?" | whenever an analyst answer mentions heat, smell, smoke, or an unresponsive device |
+
+The tool has no channel from the analyst except the answers to its own questions, so the
+safety check MUST be asked whenever any analyst answer mentions a hazard.
+
+After a stimulus, the analyst's answer sets the capture outcome (section N.4.2):
+
+- a described physical change with traffic present is `confirmed`
+- "nothing happened" with traffic present is `silent`
+- "nothing happened" with no traffic is `no-effect`
+- a described physical change with no traffic present is `traffic-missing`, which usually
+  means the capture ran on the wrong bus
+
+`human.physical_change` MUST be recorded for every stimulus capture, matching section
+N.4.1.
+
+## P.5 Provocation Ladder
+
+Before any stimulus, the tool works down a ladder to answer one question: who or what will
+make this device talk? The five rungs of this ladder are exactly the five classification
+checks in the device record spec (section M.4.3), in the same order. Ahead of the five is a
+prior-knowledge check, described first.
+
+**Prior-knowledge check (before rung 1).** Find out whether this device is already
+understood, from two sources. First, search the local record index (`device-records/INDEX.md`,
+device record spec section M.10) by vendor and product id and by chip family. This is the
+sixth classification check named in the record spec, run here at the start rather than the
+end. Second, search online for existing drivers, prior reverse-engineering writeups, and
+partial or complete protocol descriptions. A description found here saves the rest of the
+session.
+
+> Web search is a core part of the workflow. Bart, on 2026-08-05: first see if the
+> internet has already solved your problem.
+
+A prior-knowledge result has no field in `driver_search` (section M.4.3), which covers only
+the five checks. Record a found protocol description in the record's `prior_software` and
+`protocol` sections instead.
+
+**Rung 1: descriptors.** A vendor-specific interface (class `0xff`) is a protocol worth
+recovering. Interfaces that are all documented standard classes are grounds to decline and
+cite the specification.
+
+**Rung 2: a bound kernel driver.** If a driver is already bound, the device can be driven
+through it. A serial bridge exposing `/dev/ttyUSB0` is the common case.
+
+**Rung 3: a driver outside the kernel.** A scanner's driver lives in a SANE backend, a
+fingerprint reader's in libfprint. This rung is what keeps a solvable device from being
+declared a dead end.
+
+**Rung 4: the analyst's own software or history.** Vendor software on another partition, an
+old install disc, a repository the analyst already found.
+
+**Rung 5: a physical affordance.** A button or switch a human can operate. If it has one,
+the stimulus problem is already solved.
+
+Rung 1 also decides class A. When rung 1 finds every interface is a documented standard
+class and no vendor-specific interface, the device is class A: the tool declines and cites
+the specification (device record spec section M.5), and the session does not proceed to
+stimulus. This test comes before the rest, so a standard-class device with no bound driver
+is class A, not class E.
+
+If no rung produces a way to drive a vendor-specific device, the session MUST record what
+it found and stop. That triage is itself a result, delivered in the device record.
+
+## P.6 Mode
+
+The ladder assigns the device a mode, and the tool MUST record it. The mode follows from
+the device class (device record spec section M.5).
+
+| Class | Mode | Meaning |
+|---|---|---|
+| A | declined | Documented standard class. Out of scope (P.7). The tool cites the spec and stops. |
+| B | A | A driver and a standard tool both drive it. |
+| C | A | A transport driver drives it. The application protocol is the target. |
+| D | A | A physical affordance the analyst operates. |
+| E | B | Nothing found on any rung can drive it. |
+
+**Mode A, the device can be provoked.** A rung produced a way to make the device act. The
+session captures events and moves to analysis. This is the supported path.
+
+**Mode B, nothing can currently drive the device.** Only enumeration is capturable, because
+reverse engineering normally means watching something that already works. The tool MUST NOT
+fall into blind probing here. It names the mode, explains why, and offers the analyst the
+real options: find vendor software and run it under capture to convert the case to Mode A,
+or accept enumeration-only data and stop.
+
+> Naming Mode B correctly is a result worth having. "We checked these rungs and here is why
+> nothing can drive it yet" is stronger than a vague failure.
+
+## P.7 Non-Goals
+
+- **Blind vendor-request probing.** Sweeping the vendor request space to see what does not
+  STALL can put a device into a state it does not recover from. It is out of scope on
+  safety grounds. The tool MUST NOT sweep the vendor request space, and MUST tell the
+  analyst why when the case would otherwise call for it.
+- **Message reassembly.** Reconstructing one logical application message from several URBs
+  is out of scope for the first pass (matching the m3 engine spec).
+- **Driving standard-class devices.** Class A devices are declined. The record MUST cite the
+  specification in `protocol.summary` (device record spec section M.5).
+
+## P.8 Abort
+
+The safety rule from section N.6 governs the whole session, not just one capture. If the
+analyst reports heat, smell, smoke, or an unresponsive device at any point, the session
+MUST stop at once, MUST write the current capture's manifest with outcome `aborted` and
+the analyst's report in the notes, and MUST NOT retry.
+
+## P.9 Configuration Constants
+
+These constants govern the workflow and MUST be named values, not literals in code.
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `MIN_EVENT_REPETITIONS` | 5 | Repetitions of one event within a stimulus capture (section N.2.2) |
+| `IDLE_BASELINE_SECONDS` | 30 | Length of the `idle` control capture |
+| `ENUMERATION_SETTLE_SECONDS` | 2 | Wall-clock time to keep an enumeration capture running after the plug-in prompt is answered, so a slow enumeration is not cut off |
+
+`MIN_EVENT_REPETITIONS` defaults to 5 so a repeated command clears the analysis engine's
+`low_confidence` marker, which fires at exactly two occurrences (m3 engine spec section
+5.3). Two sends would leave every finding low-confidence.
+
+`ENUMERATION_SETTLE_SECONDS` is a wall-clock delay, not a decode trigger. The live sniffer
+does not decode `SET_CONFIGURATION` mid-capture, so the tool keeps the capture running for
+a short fixed time after the analyst confirms the plug-in rather than watching for the
+packet.

--- a/docs/architecture/capture-workflow-spec.md
+++ b/docs/architecture/capture-workflow-spec.md
@@ -1,0 +1,217 @@
+# Capture Workflow Specification, Section N: Corpus Naming and Manifests
+
+*Drafted 2026-07-31 as the seed of the capture spec. These two sections were already
+drifting across informal documents, so they are written normatively first. Section
+numbers will be fixed when the surrounding spec exists.*
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are
+to be interpreted as described in RFC 2119 and RFC 8174 when, and only when, they appear
+in all capitals.
+
+---
+
+## N.1 Corpus Layout
+
+A **corpus** is a directory holding all captures for one analysis session against one
+device. Each capture is a `.pcapng` file paired with a `.json` manifest of the same
+basename.
+
+```
+corpus/
+  0000-1a86_7523-idle.pcapng
+  0000-1a86_7523-idle.json
+  0001-1a86_7523-enumeration.pcapng
+  0001-1a86_7523-enumeration.json
+  0002-1a86_7523-disconnect.pcapng
+  0002-1a86_7523-disconnect.json
+  0003-1a86_7523-enumeration.pcapng
+  0003-1a86_7523-enumeration.json
+  0004-1a86_7523-relay1-on.pcapng
+  0004-1a86_7523-relay1-on.json
+  stim/
+    relay1_on.py
+```
+
+A corpus directory MUST contain captures for exactly one device. Analysing a second device
+MUST use a separate corpus.
+
+During a session a corpus MAY live anywhere. When a corpus is committed to the repository,
+it MUST live at `device-records/<record-id>/corpus/` as defined by the device record spec
+(§M.2), and the two documents MUST agree on this location.
+
+## N.2 Capture Filenames
+
+A capture filename MUST match:
+
+```
+<seq>-<vid>_<pid>-<event>.pcapng
+
+seq    = 4 decimal digits, zero padded
+vid    = 4 lowercase hex digits, no 0x prefix
+pid    = 4 lowercase hex digits, no 0x prefix
+event  = 1..48 characters from [a-z0-9-], MUST NOT begin or end with "-"
+```
+
+Rules:
+
+- `seq` MUST be unique within a corpus and MUST reflect capture order. Sequence numbers
+  MUST NOT be reused, including after a capture is deleted.
+- Filenames MUST be treated as immutable once written. Renaming a capture invalidates its
+  manifest pairing.
+- The manifest filename MUST be the capture filename with `.pcapng` replaced by `.json`.
+- Capitals, spaces, and underscores MUST NOT appear in `event`. Underscore is reserved as
+  the separator between `vid` and `pid`, so that `vid_pid` reads unambiguously as one
+  field.
+- When `vid` or `pid` is not yet known at capture start (see §N.5), the writer MUST use
+  `unknown` in place of the `vid_pid` pair and MUST rename the file at capture close once
+  the values are resolved. This is the single permitted exception to filename immutability.
+
+### N.2.1 Reserved Event Names
+
+These event names have defined meaning and MUST be used for their corresponding captures:
+
+| Event | Meaning |
+|---|---|
+| `idle` | device attached, no analyst action, background traffic only |
+| `enumeration` | capture started before attach, covering plug in through `SET_CONFIGURATION` |
+| `disconnect` | capture of device removal |
+| `ordering` | two or more distinct events performed in an unusual order (§N.2.2) |
+| `repeat` | the same event issued twice or more in a row (§N.2.2) |
+
+An `enumeration` event MAY appear more than once in a corpus, for the initial plug in and
+for later ones. The `seq` prefix distinguishes them.
+
+All other event names describe a single action provoked by the analyst and SHOULD read as
+`<subject>-<action>`, for example `relay1-on`, `relay2-off`, `sensor-touch`.
+
+### N.2.2 Repetition and Ordering Captures
+
+A single capture SHOULD contain **`MIN_EVENT_REPETITIONS` repetitions** (default 5) of one
+event, delimited by markers, rather than one repetition per capture. Repeating an event
+within a capture is what makes byte variance inside that event measurable. Without the
+repeats, fields that change on every send (counters, sequence numbers, checksums) cannot
+be told apart from fields that identify the command.
+
+> Analysis MUST establish the variance inside one event before comparing across events.
+> Comparing `relay1-on` to `relay1-off` without first comparing `relay1-on` to itself
+> blames ordinary send variance on the command, and the result is a confident description
+> of a field that does not exist.
+
+A corpus SHOULD additionally contain at least one **ordering capture** (two or more
+distinct events performed in an unusual order) and one **repeat capture** (the same event
+issued twice or more in a row), so that behaviour depending on device state is detectable.
+Without these, a stateful protocol MAY be described as stateless. These captures use the
+reserved event names `ordering` and `repeat` (§N.2.1).
+
+## N.3 Sequence Allocation and Resume
+
+The corpus directory is the authoritative state. To allocate the next `seq`, the writer
+MUST scan existing filenames, take the highest `seq` present, and add one. Sessions
+therefore resume without restarting numbering, and no session state needs to persist
+between runs.
+
+If a capture file exists without a manifest, the session MUST treat that `seq` as consumed
+and SHOULD report the orphan.
+
+## N.4 Manifest
+
+One manifest per capture. All timestamps used for correlation MUST be monotonic. Wall
+clock values MAY be recorded for human reference but MUST NOT be used for ordering.
+
+```json
+{
+  "capture_id": "0004-1a86_7523-relay1-on",
+  "pcapng": "0004-1a86_7523-relay1-on.pcapng",
+  "schema_version": 1,
+
+  "device": {
+    "vendor_id": "1a86",
+    "product_id": "7523",
+    "bus_num": 1,
+    "device_address": 7,
+    "description": "QinHeng CH340 serial adapter",
+    "bound_driver": "ch341"
+  },
+
+  "event": {
+    "label": "relay1-on",
+    "kind": "stimulus",
+    "trigger": "script",
+    "script": "stim/relay1_on.py",
+    "repetitions": 5
+  },
+
+  "human": {
+    "observed": "audible click, LED 1 lit",
+    "physical_change": true,
+    "notes": "LED stays lit after the command"
+  },
+
+  "timing": {
+    "started_monotonic": 1234.567,
+    "stopped_monotonic": 1236.891,
+    "wall_clock_start": "2026-07-31T04:12:09Z"
+  },
+
+  "environment": {
+    "kernel": "6.8.0-generic",
+    "usbmon_path": "/dev/usbmon1",
+    "snaplen": 0,
+    "truncation_detected": false,
+    "other_devices_on_bus": ["1d6b:0002"]
+  },
+
+  "outcome": "confirmed"
+}
+```
+
+### N.4.1 Field Requirements
+
+- `capture_id`, `pcapng`, `schema_version`, `event.label`, `event.kind`, `timing`, and
+  `outcome` MUST be present.
+- `event.kind` MUST be one of `idle`, `enumeration`, `disconnect`, `stimulus`.
+- `human.physical_change` MUST be recorded for every `stimulus` capture, including when it
+  is `false`.
+- `environment.snaplen` and `environment.truncation_detected` MUST be recorded. A capture
+  where `captured_length < length` for any record MUST set `truncation_detected` to `true`.
+- `environment.other_devices_on_bus` SHOULD be recorded, since capturing a whole bus picks
+  up traffic from unrelated devices.
+
+### N.4.2 Outcome
+
+`outcome` MUST be one of:
+
+| Value | Meaning |
+|---|---|
+| `confirmed` | physical change observed and traffic captured |
+| `silent` | no physical change, but traffic was produced. The device accepted something and did nothing visible |
+| `no-effect` | no physical change and no traffic. The stimulus did not reach the device |
+| `traffic-missing` | physical change observed but no traffic captured. The capture is on the wrong bus, or traffic is being dropped |
+| `aborted` | session halted (see §N.6) |
+
+`silent`, `no-effect`, and `traffic-missing` are **valid results.** A capture with any of
+these outcomes MUST be retained in the corpus and MUST NOT be silently retried and
+discarded. Pay attention to `silent`. It commonly means a correct command was issued with
+the wrong transfer size, or while the device was in the wrong state.
+
+## N.5 Fields Resolved After Capture Close
+
+Some fields cannot exist when a capture starts and MUST be resolved at close by reading the
+capture itself:
+
+| Field | Why it cannot be known at start |
+|---|---|
+| `device.device_address` | during `enumeration` the device sits at address 0 and is assigned its real address partway through the capture by `SET_ADDRESS` |
+| `device.vendor_id`, `device.product_id` | when the capture is the enumeration itself, these arrive in the device descriptor response inside the file |
+| `environment.truncation_detected` | requires the decoded records |
+
+An implementation MUST NOT require these at `start_capture`. Requiring them would make the
+enumeration capture impossible to record, and that capture is the only source of device
+context.
+
+## N.6 Abort
+
+If the analyst reports heat, smell, smoke, a device that has stopped responding, or any
+other alarming condition, the session MUST stop immediately, MUST write the current
+capture's manifest with `outcome: "aborted"` and the analyst's report in `human.notes`, and
+MUST NOT retry the stimulus.

--- a/docs/architecture/capture-workflow-spec.md
+++ b/docs/architecture/capture-workflow-spec.md
@@ -115,8 +115,17 @@ and SHOULD report the orphan.
 
 ## N.4 Manifest
 
-One manifest per capture. All timestamps used for correlation MUST be monotonic. Wall
-clock values MAY be recorded for human reference but MUST NOT be used for ordering.
+One manifest per capture. A marker or event that must be ordered against other marks MUST
+be ordered by a monotonic clock, because a wall clock can step and invert two marks.
+
+Wall clock is not only for human reference. It is required to place a live mark onto a
+packet. The pcapng carries only wall clock: packet timestamps come from the usbmon header
+in epoch seconds. A mark recorded during a capture therefore carries both clocks. Its
+`time.time()` reading resolves it to a packet index, because the packets share that
+realtime clock and a step moves the mark and the packets together. Its `time.monotonic()`
+reading orders it against other marks and survives a clock step. Sampling both clocks once
+at capture start gives the offset needed to report every mark on the monotonic timeline.
+The live-marking tool is specified separately (see the mark_now issue).
 
 ```json
 {

--- a/docs/architecture/device-record-spec.md
+++ b/docs/architecture/device-record-spec.md
@@ -43,36 +43,21 @@ close. Records are partly written by a person (provenance, physical observations
 attempt narratives), and they are reviewed in pull requests, so the format has to support
 comments and produce readable diffs.
 
-Records live **in the bsu-tool repository**, under `device-records/`, keyed by
-`<record-id>` as defined in §M.3.
+Records live **in the bsu-tool repository**, keyed by `<record-id>` as defined in §M.3.
+Everything for one device lives in one directory:
 
-> **Open decision for team review: record placement.** Two layouts are on the table.
-> Reply on the PR with which one we adopt. The spec ships with whichever wins.
->
-> **Option A, everything in one directory per device:**
-> ```
-> device-records/1a86_7523-2ch-relay/
->   record.yaml
->   corpus/
->     0000-1a86_7523-idle.pcapng
->     ...
-> ```
-> One directory holds the record and all its captures. Hand the directory to someone and
-> they have everything, and a project set aside for months can be picked up cold by
-> reading one file. This is also the sponsor's own preferred workflow.
->
-> **Option B, record beside the directory:**
-> ```
-> device-records/1a86_7523-2ch-relay.yaml
-> device-records/1a86_7523-2ch-relay/
->   corpus/
->     ...
-> ```
-> All records sit flat in `device-records/`, so listing the yaml files is itself a crude
-> registry. With the generated index (§M.10) that advantage mostly disappears.
->
-> Section §M.4.9 and the capture spec's rule for committed corpora work unchanged under
-> either option, since the corpus path is the same in both.
+```
+device-records/1a86_7523-2ch-relay/
+  record.yaml
+  corpus/
+    0000-1a86_7523-idle.pcapng
+    ...
+```
+
+The record MUST be at `device-records/<record-id>/record.yaml`, and its corpus at
+`device-records/<record-id>/corpus/`. Hand someone the directory and they have everything,
+and a project set aside for months can be picked up cold by reading `record.yaml`. This is
+the sponsor's own workflow (2026-08-05) and the team's chosen layout.
 
 > Decided: a separate repository would need its own CI configuration, license, and merge
 > policy, and none of that helps the project now. Splitting later would take an

--- a/docs/architecture/device-record-spec.md
+++ b/docs/architecture/device-record-spec.md
@@ -1,0 +1,516 @@
+# Device Record Specification, Section M: Device Records
+
+*Drafted 2026-08-03 as the companion to `capture-spec-naming-and-manifest.md`. Section
+numbers are placeholders and will be fixed when this is placed (target:
+`docs/architecture/`).*
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are
+to be interpreted as described in RFC 2119 and RFC 8174 when, and only when, they appear
+in all capitals.
+
+---
+
+## M.1 Purpose and Scope
+
+A **device record** is the durable output of a bsu-tool session, whether or not a protocol
+was recovered. For a device that nothing can drive, the record is the only output, and
+often the first documentation that device has ever had.
+
+The record grows during the session. The workflow SHOULD update it after each capture and
+after each finding, so that a session interrupted at any point leaves a record a later
+session can resume from by reading it.
+
+Nine sections are defined in §M.4. **Eight of the nine populate with no working driver.**
+A record MUST be written for every completed session. This includes sessions where the
+tool correctly declines a standard class device (class A) and sessions where no way to
+drive the device was found (class E).
+
+The triage ladder runs five classification checks against a new device (§M.4.3), and
+searching existing records is the sixth. Before starting work on a device, an analyst
+SHOULD search existing records by vendor and product id **and by chip family** to see
+whether this device, or one sharing its controller, has been characterised before.
+
+> Records are required even when a session produces no protocol, because discovering that
+> a device is a standard class, or that nothing can drive it, takes real work. The record
+> saves the next person from repeating that work.
+
+---
+
+## M.2 File Format and Location
+
+Records are **YAML**. Manifests (§N.4) are JSON because a machine writes them at capture
+close. Records are partly written by a person (provenance, physical observations, and
+attempt narratives), and they are reviewed in pull requests, so the format has to support
+comments and produce readable diffs.
+
+Records live **in the bsu-tool repository**, under `device-records/`, keyed by
+`<record-id>` as defined in §M.3.
+
+> **Open decision for team review: record placement.** Two layouts are on the table.
+> Reply on the PR with which one we adopt. The spec ships with whichever wins.
+>
+> **Option A, everything in one directory per device:**
+> ```
+> device-records/1a86_7523-2ch-relay/
+>   record.yaml
+>   corpus/
+>     0000-1a86_7523-idle.pcapng
+>     ...
+> ```
+> One directory holds the record and all its captures. Hand the directory to someone and
+> they have everything, and a project set aside for months can be picked up cold by
+> reading one file. This is also the sponsor's own preferred workflow.
+>
+> **Option B, record beside the directory:**
+> ```
+> device-records/1a86_7523-2ch-relay.yaml
+> device-records/1a86_7523-2ch-relay/
+>   corpus/
+>     ...
+> ```
+> All records sit flat in `device-records/`, so listing the yaml files is itself a crude
+> registry. With the generated index (§M.10) that advantage mostly disappears.
+>
+> Section §M.4.9 and the capture spec's rule for committed corpora work unchanged under
+> either option, since the corpus path is the same in both.
+
+> Decided: a separate repository would need its own CI configuration, license, and merge
+> policy, and none of that helps the project now. Splitting later would take an
+> afternoon. Splitting now would cost weeks of setup.
+
+A record MUST be valid YAML 1.2 and MUST parse to a mapping.
+
+## M.3 Record Identity and Keying
+
+```
+record-id = <vid> "_" <pid> [ "-" <discriminator> ]
+
+vid           = 4 lowercase hex digits, no 0x prefix
+pid           = 4 lowercase hex digits, no 0x prefix
+discriminator = 1..32 characters from [a-z0-9-], MUST NOT begin or end with "-"
+```
+
+**A vendor and product id pair MAY have more than one record.** The same product id can
+ship on physically different boards, for example a two relay and a four relay version of
+the same controller. Those are different devices for analysis purposes even though they
+enumerate identically.
+
+Rules:
+
+- When only one record exists for a `vid_pid`, the discriminator SHOULD be omitted.
+- When a second, physically distinct device shares a `vid_pid`, both records MUST carry a
+  discriminator, and the existing record MUST be renamed to add one. Record ids are
+  otherwise immutable.
+- The discriminator MUST describe the **physical** distinction (`2ch-relay`, `4ch-relay`,
+  `rev-b`), not the analyst, the date, or the session.
+- Two records under one `vid_pid` MUST differ in their `physical` section (§M.4.4). If
+  they do not, they are the same device and MUST be merged.
+
+> `vid:pid` is the obvious key, and it is sometimes wrong. The spec keys on it anyway and
+> allows collisions, because future lookups stay simple and the discriminator covers the
+> rare case.
+
+## M.4 Record Structure
+
+A record MUST contain exactly these top level keys. Sections whose content is unavailable
+MUST be present with an explicit `null` or empty collection rather than omitted, so that
+"not investigated" is distinguishable from "investigated and found nothing".
+
+```yaml
+schema_version: 1
+record_id: 1a86_7523-2ch-relay
+device_class: C          # A | B | C | D | E, see M.5
+created: 2026-08-03
+updated: 2026-08-03
+redaction_confirmed: true    # see M.7
+
+identity: {...}              # M.4.1
+descriptor_profile: {...}    # M.4.2
+driver_search: {...}         # M.4.3
+physical: {...}              # M.4.4
+provenance: {...}            # M.4.5
+prior_software: [...]        # M.4.6
+attempts: [...]              # M.4.7
+protocol: null               # M.4.8, null unless a protocol was described
+corpus: {...}                # M.4.9
+```
+
+### M.4.1 `identity` (from enumeration)
+
+```yaml
+identity:
+  vendor_id: "1a86"
+  product_id: "7523"
+  vendor_name: "QinHeng Electronics"     # from usb.ids or the string descriptor
+  product_name: "CH340 serial converter"
+  usb_version: "1.10"
+  device_revision: "2.63"                 # bcdDevice
+  chip_family: "ch34x"                    # see below, null if unknown
+  has_serial: true                        # PRESENCE only, see M.7
+```
+
+`chip_family` MUST be present as a key and SHOULD carry a value when the controller is
+identifiable. This field makes lookup across devices work. A scanner nobody has recorded
+may share its controller with a device that has been recorded.
+
+`has_serial` records **whether** the device reports a serial number. Its **value** MUST
+NOT appear anywhere in the record (§M.7).
+
+### M.4.2 `descriptor_profile` (from enumeration)
+
+```yaml
+descriptor_profile:
+  device_class: 255                       # bDeviceClass
+  configurations: 1
+  interfaces:
+    - number: 0
+      alternate_setting: 0
+      interface_class: 255
+      interface_subclass: 1
+      interface_protocol: 2
+      description: null
+      endpoints:
+        - address: "0x82"
+          number: 2
+          direction: in
+          transfer_type: bulk
+          max_packet_size: 32
+          interval: 0
+```
+
+This section mirrors the `DeviceEnumeration` shape returned by the `get_enumeration` MCP
+tool and MUST be populated from a capture containing the enumeration exchange, not typed
+in by hand. When no such capture exists, the section MUST be `null` and
+`driver_search.check_1.result` MUST record why.
+
+### M.4.3 `driver_search` (one entry per ladder check)
+
+```yaml
+driver_search:
+  check_1_descriptors:
+    result: found
+    detail: "interface class 255 vendor specific, 2 bulk endpoints"
+  check_2_kernel:
+    result: found
+    detail: "ch341 bound, /dev/ttyUSB0 present"
+    driver: ch341
+  check_3_userspace:
+    result: not_found
+    detail: "searched SANE, libfprint, ArgyllCMS, libusb projects by vid:pid and ch34x"
+    searched: [sane, libfprint, argyllcms, libusb-projects]
+  check_4_user:
+    result: found
+    detail: "analyst had a vendor Windows utility and a forum thread with example bytes"
+  check_5_physical:
+    result: found
+    detail: "two relay blocks with indicator LEDs, no buttons"
+
+  recipe:
+    command: null
+    verified_packet_count: null
+    verified_on: null
+```
+
+Each check MUST carry a `result` of `found`, `not_found`, or `not_run`, and a `detail`
+string. `not_run` MUST be used when a check was skipped. It MUST NOT be recorded as
+`not_found`.
+
+> A later analyst reading `not_found` learns that a search happened and failed. Reading
+> `not_run` learns there is unexplored ground.
+
+**`recipe`** is populated for class B devices, where a standard command drives the device.
+It MUST NOT be published without `verified_packet_count`:
+
+```yaml
+  recipe:
+    command: "dd if=/dev/hwrng of=/dev/null bs=1M count=8"
+    alternatives_tested: ["cat /dev/hwrng", "/dev/chaoskey0 direct read"]
+    verified_packet_count: 1284
+    verified_on: "6.8.0-generic"
+```
+
+`verified_packet_count` MUST come from actually running the command under capture and
+counting the packets produced. A recipe without it MUST NOT be published.
+
+> A buffered driver disconnects a userspace read from USB traffic entirely. The kernel
+> `chaoskey` driver refills an internal buffer on its own schedule, so a short
+> `cat /dev/hwrng` returns bytes and produces **zero packets**. A recipe can be obviously
+> correct and capture nothing. Where a device exposes more than one path, every path
+> tested SHOULD be listed in `alternatives_tested` with the chosen one in `command`.
+
+### M.4.4 `physical` (from the analyst)
+
+```yaml
+physical:
+  form_factor: "bare green PCB, ~55x22mm"
+  connectors: ["USB-B", "6-position screw terminal"]
+  indicators: ["power LED", "relay 1 LED", "relay 2 LED"]
+  controls: []                             # buttons, switches, jumpers
+  markings: ["CH340", "SRD-05VDC-SL-C"]
+  operable_by_hand: false
+```
+
+`operable_by_hand` MUST be `true` only when a human can provoke the device without
+software. It is the field that distinguishes class D.
+
+No descriptor reports any of this, which is why the workflow asks the analyst questions.
+
+### M.4.5 `provenance` (from the analyst)
+
+```yaml
+provenance:
+  acquired: "online marketplace, approximately 2026"
+  came_with: "no documentation, no software, no packaging insert"
+  notes: "product listing named a different manufacturer than the chip markings"
+```
+
+Provenance is the section most likely to leak personal detail. See §M.7. Dates SHOULD be
+coarse (year, or year and month). Order numbers, receipts, seller account names, and
+shipping detail MUST NOT appear.
+
+### M.4.6 `prior_software`
+
+```yaml
+prior_software:
+  - name: "vendor control utility"
+    platform: windows
+    still_available: false
+    url: null
+    notes: "analyst had a copy, no public download found"
+  - name: "community relay script"
+    platform: linux
+    still_available: true
+    url: "https://example.invalid/repo"
+    notes: "used as the stimulus source, not read before analysis"
+```
+
+An empty list means a search was performed and found nothing. Where no search was
+performed, `driver_search.check_4_user.result` MUST be `not_run`.
+
+> `notes: "not read before analysis"` is worth recording when a repository was used as a
+> stimulus source under the blind protocol (§M.8). It is what makes a derivation claim
+> checkable later.
+
+### M.4.7 `attempts` (what was tried and what happened)
+
+```yaml
+attempts:
+  - action: "wrote 4-byte frame A0 01 01 A2 to /dev/ttyUSB0 at 9600 8N1"
+    outcome: silent
+    detail: "device returned 2 bytes, no click, no LED change"
+  - action: "ran community relay script, channel 1 on"
+    outcome: confirmed
+    detail: "audible click, LED 1 lit"
+```
+
+`outcome` MUST be one of `confirmed`, `silent`, `no-effect`, `traffic-missing`, or
+`aborted`, matching the manifest outcome vocabulary (§N.4.2).
+
+Failed and inconclusive attempts MUST be retained. An attempt that produced traffic but no
+physical change (`silent`) commonly means a correct command was issued at the wrong
+transfer size, or while the device was in the wrong state. That is the single most useful
+thing to hand the next analyst.
+
+### M.4.8 `protocol` (null unless described)
+
+```yaml
+protocol:
+  summary: "4-byte frames on bulk OUT endpoint 2. byte 1 selects channel, byte 2 sets state"
+  transport_layer: "CH340 vendor control requests, documented, not analysed here"
+  claims:
+    - claim: "byte 1 selects the channel"
+      observed_in: "20 of 20 captures"
+      varies_with: "channel, and nothing else"
+      constant_when: "channel is held fixed"
+      contradicted: never
+      rests_on: "2 distinct channel values only"
+      confidence: high
+```
+
+Each entry in `claims` MUST carry the five evidence fields (`observed_in`, `varies_with`,
+`constant_when`, `contradicted`, `rests_on`). `confidence` MUST be one of `high`,
+`medium`, `low`.
+
+When a claim comes from the analysis engine's output, a pattern the engine marked
+`low_confidence: true` (its marker for evidence resting on exactly two occurrences, m3
+engine spec §5.3) MUST be recorded as `low`. The engine emits no higher grades. `medium`
+and `high` are assigned by the analyst from the evidence fields, and a claim MUST NOT be
+graded above `low` while `rests_on` names an untested contrast.
+
+**A numeric confidence score MUST NOT appear.** A percentage has no calibrated basis and
+an analyst cannot act on it. `rests_on` is the field an analyst can act on, because
+stating the limit of the evidence also states the next experiment to run.
+
+This constraint does not apply to measured statistics. A marker correlation percentage is
+an observed quantity and is reported as measured.
+
+For bridge devices, `transport_layer` MUST state whether the bridge's own protocol was
+analysed or excluded, so that a reader does not mistake application bytes for USB level
+protocol.
+
+### M.4.9 `corpus`
+
+```yaml
+corpus:
+  directory: "device-records/1a86_7523-2ch-relay/corpus/"
+  capture_count: 11
+  events: [idle, enumeration, disconnect, relay1-on, relay1-off, relay2-on, ordering, repeat]
+  contrasts_available: [self, on-off, channel, stimulus-absent, ordering]
+  complete: true
+```
+
+`contrasts_available` MUST list which contrasts (see the capture spec's corpus design
+section) the corpus actually supports.
+
+**A corpus supporting zero contrasts MUST NOT produce a protocol description.** Where
+`contrasts_available` is empty, `protocol` MUST be `null`. A description derived from a
+corpus with no contrasts rests on no comparison and is not a finding.
+
+Where contrasts are missing, the record SHOULD name which additional captures would supply
+which contrast:
+
+```yaml
+corpus:
+  directory: "device-records/1a86_7523-2ch-relay/corpus/"
+  capture_count: 6
+  events: [idle, enumeration, disconnect, relay1-on]
+  contrasts_available: [self, stimulus-absent]
+  contrasts_missing:
+    - contrast: on-off
+      needed: "5x relay1-off"
+    - contrast: channel
+      needed: "5x relay2-on"
+    - contrast: ordering
+      needed: "1x relay2-on then relay1-on"
+  complete: false
+```
+
+> "Byte 1's role is unresolved" is an unexplained gap. "Byte 1's role is unresolved
+> because the corpus has no channel contrast, capture 5x relay2-on" tells the next
+> analyst exactly what to do.
+
+For a class E device, `corpus` MUST record the enumeration captures (the only ones
+possible) and set `complete: false`.
+
+## M.5 Device Class
+
+`device_class` MUST be one of `A`, `B`, `C`, `D`, `E`, and the record MUST make its
+derivation traceable: the class MUST be consistent with the `driver_search` results.
+
+| Class | Condition |
+|---|---|
+| A | Device implements a documented standard class. The record MUST cite the specification in `protocol.summary` |
+| B | A driver and a standard tool both exist. `driver_search.recipe` MUST be populated |
+| C | Transport driver only. Application protocol unknown |
+| D | `physical.operable_by_hand` is `true` and no software driver was found |
+| E | All five checks returned `not_found` |
+
+A record whose `device_class` is `E` while any check reports `found` is invalid.
+
+## M.6 Completeness and Enforcement
+
+A record is **publishable** when:
+
+- every key in §M.4 is present,
+- every `driver_search` check has a `result` that is not `not_run`,
+- any `recipe` present carries a `verified_packet_count`,
+- `device_class` is consistent with `driver_search` per §M.5,
+- `contrasts_available` is not empty whenever `protocol` is not null (§M.4.9), and
+- the redaction gate in §M.7 passes.
+
+**A validator MUST enforce these rules.** A repository CI job MUST run the validator over
+every file under `device-records/` and MUST fail the build when any record is
+unpublishable. Records failing validation MAY exist in a working tree but MUST NOT merge.
+
+> Until the validator runs in CI, nothing enforces these rules. A redaction mistake in
+> particular cannot be repaired once published.
+
+## M.7 Privacy and Redaction
+
+**Serial numbers are device fingerprints and MUST NOT be committed.** Specifically, the
+following MUST NOT appear anywhere in a record, in any section, including free text:
+
+- The value of `iSerialNumber` / `iSerialString`, in any encoding
+- Any identifier printed on the device that is unique to that unit (asset tags, engraved
+  serials)
+- Filesystem paths containing a username or home directory
+- Email addresses, account names, order or receipt identifiers
+- Hostnames or network addresses of the analyst's machine
+
+`identity.has_serial` records presence only. Knowing that the device reports a serial is
+still useful, because it means the descriptor set can identify individual units.
+
+### The redaction gate
+
+`redaction_confirmed` is one half of a gate with two parts. Both MUST pass before a
+record merges:
+
+1. **Attestation.** `redaction_confirmed` MUST be `true`. Tooling that generates a record
+   from a session MUST default it to `false`, so the value is only ever set by a human
+   who looked.
+2. **Automated scan.** The validator (§M.6) MUST reject a record that matches any
+   forbidden pattern above, **regardless of the attestation value.** At minimum it MUST
+   reject: a string equal to the device's reported serial where one was read during the
+   session, a field shaped like `iSerial` anywhere in the mapping, an absolute path
+   containing a home directory (`/home/<name>`, `/Users/<name>`, `C:\Users\<name>`), an
+   email address, and a hostname or IP literal.
+
+A record MUST NOT merge with `redaction_confirmed: false`. A record MUST NOT merge with
+`redaction_confirmed: true` if the scan finds a match.
+
+> Neither half works alone. Anyone can set a boolean, and no pattern set catches prose.
+> Together they give a person who looked plus a machine that checks the mechanical cases.
+
+> This rule is written down before any records exist, because a public repository cannot
+> be redacted after the fact.
+
+## M.8 Blind Derivation Protocol
+
+Where a record's `protocol` section is presented as *derived*, and a prior implementation
+existed (`prior_software` not empty), the record MUST state whether that implementation
+was read before the analysis.
+
+```yaml
+protocol:
+  derivation:
+    blind: true
+    stimulus_source: "community relay script"
+    source_read_before_analysis: false
+```
+
+`blind: true` asserts that the protocol description was produced from captures alone, with
+the stimulus source executed but not inspected.
+
+> This makes a derivation claim checkable. A derived description that converges with an
+> existing implementation is evidence for the method, but only if the record states that
+> the implementation was not consulted.
+
+## M.9 Schema Evolution
+
+`schema_version` MUST be an integer, starting at `1`. Additive changes (new optional keys)
+do not increment it. Any change that invalidates existing records, meaning renaming,
+removing, or changing the meaning of a key, MUST increment it, and the change MUST be
+documented.
+
+Readers MUST reject a record whose `schema_version` exceeds the version they implement.
+
+## M.10 Record Index
+
+The validator (§M.6) MUST regenerate `device-records/INDEX.md` whenever any record under
+`device-records/` changes. The index is a table with one row per record:
+
+| Column | Source |
+|---|---|
+| record id | filename or directory name |
+| device | `identity.vendor_name` + `identity.product_name` |
+| class | `device_class` (A to E, §M.5) |
+| chip family | `identity.chip_family` |
+| protocol | `yes` when `protocol` is not null, otherwise `no` |
+| updated | `updated` |
+
+The index MUST NOT be edited by hand, and the validator MUST fail the build when the
+committed index does not match the regenerated one. To run the sixth classification
+check, read this table and look for the device or its chip family.
+
+> Registries maintained by hand go stale. The validator already parses every record, so
+> generating the table from them is free, and a generated table cannot drift.


### PR DESCRIPTION
part of #104

what this pr contains and what it does not

in scope now: the corpus naming and manifest sections of the capture spec, and the full device record format (schema plus the writer it implies). these are the pieces that were drifting across informal docs, so they are written normatively first.

stretch goal, not in this pr: the record collection, meaning a published and searchable set of records. nothing extra needs to be built for it. if stop_capture writes manifests and the session writes a record, the collection appears on its own as the tool is used.

one open decision is marked inside the record spec at section M.2 (where the record file lives relative to its corpus directory). 

### reply here with option a or option b.
