### PR TITLE
Add bsu-tool detect-device command. Closes #108

### DIFF
--- a/bsu_tool/__main__.py
+++ b/bsu_tool/__main__.py
@@ -14,6 +14,7 @@ from bsu_tool.pcapng_reader import (
     PcapNgReader,
 )
 from bsu_tool.session import CaptureSession, USBDevice, USBEndpoint
+from bsu_tool.usb_enum import DEFAULT_SYSFS_ROOT
 
 # ---------------------------------------------------------------------------
 # Link-layer type constants
@@ -226,6 +227,18 @@ def main(argv: list[str] | None = None) -> None:
         help="Destination .pcapng file (must not already exist)",
     )
 
+    detect_cmd = subparsers.add_parser(
+        "detect-device",
+        help="Detect a newly attached USB device by diffing before/after snapshots (Linux only)",
+    )
+
+    detect_cmd.add_argument(
+        "--sysfs-root",
+        type=Path,
+        default=None,
+        help=argparse.SUPPRESS,  # hidden: for testing only
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "mcp":
@@ -245,6 +258,13 @@ def main(argv: list[str] | None = None) -> None:
         from bsu_tool.sniff_command import run_sniff
 
         run_sniff(args.bus, args.device, Path(args.output))
+        return
+
+    if args.command == "detect-device":
+        from bsu_tool.detect_device import run_detect
+
+        sysfs_root = args.sysfs_root if args.sysfs_root is not None else DEFAULT_SYSFS_ROOT
+        sys.exit(run_detect(sysfs_root))
         return
 
     parser.print_help()

--- a/bsu_tool/detect_device.py
+++ b/bsu_tool/detect_device.py
@@ -1,0 +1,120 @@
+"""Detect a newly attached USB device by diffing two sysfs snapshots.
+
+Workflow
+--------
+1. Snapshot the currently attached USB devices.
+2. Prompt the analyst to plug in the target device and press Enter.
+3. Snapshot again.
+4. Diff the two snapshots and report what appeared.
+
+This removes the "which of these is mine" problem by isolating the newly
+attached device rather than listing everything on the bus.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from bsu_tool.usb_enum import (
+    DEFAULT_SYSFS_ROOT,
+    LiveUsbDevice,
+    UsbEnumerationError,
+    enumerate_usb_devices,
+)
+
+
+def diff_snapshots(
+    before: tuple[LiveUsbDevice, ...],
+    after: tuple[LiveUsbDevice, ...],
+) -> tuple[LiveUsbDevice, ...]:
+    """Return devices present in *after* that were not present in *before*.
+
+    Comparison is by ``device_id`` (``dev_bbb_ddd``), which is stable across
+    snapshots for the same physical device address.
+
+    Args:
+        before: Snapshot taken before the device was plugged in.
+        after: Snapshot taken after the device was plugged in.
+
+    Returns:
+        A tuple of :class:`~bsu_tool.usb_enum.LiveUsbDevice` that appeared
+        between the two snapshots, in the order they appear in *after*.
+    """
+    before_ids = {d.device_id for d in before}
+    return tuple(d for d in after if d.device_id not in before_ids)
+
+
+def _format_device(device: LiveUsbDevice) -> str:
+    """Format a single device as a multiline human-readable block."""
+    lines = [
+        f"  Device:      {device.device_id}",
+        f"  VID:PID:     {device.vendor_id}:{device.product_id}",
+        f"  Bus:         {device.bus_num}",
+        f"  usbmon path: {device.usbmon_path}",
+    ]
+    if device.description:
+        lines.append(f"  Description: {device.description}")
+    return "\n".join(lines)
+
+
+def run_detect(sysfs_root: Path = DEFAULT_SYSFS_ROOT) -> int:
+    """Run the detect-device workflow.
+
+    Args:
+        sysfs_root: Root of the sysfs USB device tree. Defaults to the real
+            Linux path; tests inject a fixture tree here.
+
+    Returns:
+        Exit code — 0 on success, 1 on any error.
+    """
+    # --- Before snapshot ---------------------------------------------------
+    try:
+        before = enumerate_usb_devices(sysfs_root)
+    except UsbEnumerationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    # --- Prompt ------------------------------------------------------------
+    print("Snapshot taken. Plug in your target device, then press Enter...")
+    try:
+        input()
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted.", file=sys.stderr)
+        return 1
+
+    # --- After snapshot ----------------------------------------------------
+    try:
+        after = enumerate_usb_devices(sysfs_root)
+    except UsbEnumerationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    # --- Diff --------------------------------------------------------------
+    new_devices = diff_snapshots(before, after)
+
+    if len(new_devices) == 1:
+        print("\nDetected new device:")
+        print(_format_device(new_devices[0]))
+        return 0
+
+    if len(new_devices) > 1:
+        print(
+            f"\nError: {len(new_devices)} new devices detected. Unplug all but the target device and run again.",
+            file=sys.stderr,
+        )
+        print("\nCurrently attached devices:", file=sys.stderr)
+        for device in after:
+            print(_format_device(device), file=sys.stderr)
+            print(file=sys.stderr)
+        return 1
+
+    # --- No change ---------------------------------------------------------
+    print("\nError: No new USB device detected.", file=sys.stderr)
+    print("Make sure the device was plugged in after the prompt appeared.", file=sys.stderr)
+    if after:
+        print("\nCurrently attached devices:", file=sys.stderr)
+        for device in after:
+            print(_format_device(device), file=sys.stderr)
+            print(file=sys.stderr)
+    return 1

--- a/tests/unit/test_detect_device.py
+++ b/tests/unit/test_detect_device.py
@@ -1,0 +1,204 @@
+"""Unit tests for USB device detection via before/after sysfs snapshot diff."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from bsu_tool.detect_device import diff_snapshots, run_detect
+from bsu_tool.usb_enum import LiveUsbDevice, enumerate_usb_devices
+
+
+def _make_fake_enumerate(roots: Iterator[Path]) -> Callable[[Path], tuple[LiveUsbDevice, ...]]:
+    def _fake(sysfs_root: Path) -> tuple[LiveUsbDevice, ...]:
+        return enumerate_usb_devices(next(roots))
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# Fixture helper (mirrors test_usb_enum.py's _write_device)
+# ---------------------------------------------------------------------------
+
+
+def _write_device(
+    root: Path,
+    name: str,
+    *,
+    busnum: str | None = None,
+    devnum: str | None = None,
+    id_vendor: str | None = None,
+    id_product: str | None = None,
+    manufacturer: str | None = None,
+    product: str | None = None,
+) -> Path:
+    """Create a sysfs-style device directory populated with the given files."""
+    device_dir = root / name
+    device_dir.mkdir()
+    files = {
+        "busnum": busnum,
+        "devnum": devnum,
+        "idVendor": id_vendor,
+        "idProduct": id_product,
+        "manufacturer": manufacturer,
+        "product": product,
+    }
+    for filename, value in files.items():
+        if value is not None:
+            (device_dir / filename).write_text(value, encoding="utf-8")
+    return device_dir
+
+
+def _make_device(
+    bus_num: int,
+    dev_num: int,
+    vendor_id: str = "0x1d6b",
+    product_id: str = "0x0002",
+    description: str | None = None,
+) -> LiveUsbDevice:
+    """Build a LiveUsbDevice directly for diff_snapshots tests."""
+    return LiveUsbDevice(
+        device_id=f"dev_{bus_num:03d}_{dev_num:03d}",
+        bus_num=bus_num,
+        dev_num=dev_num,
+        vendor_id=vendor_id,
+        product_id=product_id,
+        description=description,
+        usbmon_path=f"/dev/usbmon{bus_num}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# diff_snapshots unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_diff_returns_new_device() -> None:
+    """A device present in after but not before is returned."""
+    before = (_make_device(1, 2),)
+    after = (_make_device(1, 2), _make_device(1, 4))
+
+    new = diff_snapshots(before, after)
+
+    assert len(new) == 1
+    assert new[0].device_id == "dev_001_004"
+
+
+def test_diff_returns_empty_when_no_change() -> None:
+    """No new devices when before and after are identical."""
+    before = (_make_device(1, 2),)
+    after = (_make_device(1, 2),)
+
+    new = diff_snapshots(before, after)
+
+    assert new == ()
+
+
+def test_diff_returns_multiple_new_devices() -> None:
+    """Multiple new devices are all returned."""
+    before = (_make_device(1, 2),)
+    after = (_make_device(1, 2), _make_device(1, 4), _make_device(2, 1))
+
+    new = diff_snapshots(before, after)
+
+    assert len(new) == 2
+    assert {d.device_id for d in new} == {"dev_001_004", "dev_002_001"}
+
+
+def test_diff_empty_before() -> None:
+    """All devices in after are new when before is empty."""
+    before: tuple[LiveUsbDevice, ...] = ()
+    after = (_make_device(1, 2), _make_device(1, 4))
+
+    new = diff_snapshots(before, after)
+
+    assert len(new) == 2
+
+
+def test_diff_preserves_after_order() -> None:
+    """New devices are returned in the order they appear in after."""
+    before: tuple[LiveUsbDevice, ...] = ()
+    after = (_make_device(1, 2), _make_device(2, 1), _make_device(3, 5))
+
+    new = diff_snapshots(before, after)
+
+    assert [d.device_id for d in new] == ["dev_001_002", "dev_002_001", "dev_003_005"]
+
+
+# ---------------------------------------------------------------------------
+# run_detect integration tests (fixture sysfs tree)
+# ---------------------------------------------------------------------------
+
+
+def test_run_detect_missing_sysfs(tmp_path: Path) -> None:
+    """Missing sysfs root exits with code 1 and prints an error."""
+    result = run_detect(sysfs_root=tmp_path / "does-not-exist")
+    assert result == 1
+
+
+def test_run_detect_no_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No new device after prompt exits with code 1."""
+    before_root = tmp_path / "before"
+    before_root.mkdir()
+    after_root = tmp_path / "after"
+    after_root.mkdir()
+
+    _write_device(before_root, "1-1", busnum="1", devnum="2", id_vendor="0781", id_product="5567")
+    _write_device(after_root, "1-1", busnum="1", devnum="2", id_vendor="0781", id_product="5567")
+
+    roots = iter([before_root, after_root])
+    monkeypatch.setattr("bsu_tool.detect_device.enumerate_usb_devices", _make_fake_enumerate(roots))
+    monkeypatch.setattr("builtins.input", lambda: None)
+
+    result = run_detect(sysfs_root=before_root)
+    assert result == 1
+
+
+def test_run_detect_single_new_device(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exactly one new device exits with code 0."""
+    before_root = tmp_path / "before"
+    before_root.mkdir()
+    after_root = tmp_path / "after"
+    after_root.mkdir()
+
+    _write_device(before_root, "1-1", busnum="1", devnum="2", id_vendor="0781", id_product="5567")
+    _write_device(after_root, "1-1", busnum="1", devnum="2", id_vendor="0781", id_product="5567")
+    _write_device(
+        after_root,
+        "1-2",
+        busnum="1",
+        devnum="4",
+        id_vendor="1d6b",
+        id_product="0002",
+        manufacturer="Acme",
+        product="Relay Board",
+    )
+
+    roots = iter([before_root, after_root])
+    monkeypatch.setattr("bsu_tool.detect_device.enumerate_usb_devices", _make_fake_enumerate(roots))
+    monkeypatch.setattr("builtins.input", lambda: None)
+
+    result = run_detect(sysfs_root=before_root)
+    assert result == 0
+
+
+def test_run_detect_multiple_new_devices(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Multiple new devices exits with code 1."""
+    before_root = tmp_path / "before"
+    before_root.mkdir()
+    after_root = tmp_path / "after"
+    after_root.mkdir()
+
+    _write_device(before_root, "1-1", busnum="1", devnum="2", id_vendor="0781", id_product="5567")
+    _write_device(after_root, "1-1", busnum="1", devnum="2", id_vendor="0781", id_product="5567")
+    _write_device(after_root, "1-2", busnum="1", devnum="4", id_vendor="1d6b", id_product="0002")
+    _write_device(after_root, "2-1", busnum="2", devnum="1", id_vendor="abcd", id_product="ef01")
+
+    roots = iter([before_root, after_root])
+    monkeypatch.setattr("bsu_tool.detect_device.enumerate_usb_devices", _make_fake_enumerate(roots))
+    monkeypatch.setattr("builtins.input", lambda: None)
+
+    result = run_detect(sysfs_root=before_root)
+    assert result == 1


### PR DESCRIPTION
hat does this PR do?
Adds the `bsu-tool detect-device` command. It snapshots currently attached
USB devices, prompts the analyst to plug in the target device, takes a
second snapshot, diffs the two, and reports the newly attached device
along with its vid:pid, bus, and `/dev/usbmonN` path. This removes the
"which of these is mine" problem that trips up new users, reusing
`enumerate_usb_devices` for the device data.

Handles the no-change case and the multiple-devices-changed case with
clear messages instead of guessing.

Closes #108

## How was it tested?
- Ran `bsu-tool detect-device` manually on WSL2 to verify the no-device-
  change error path (WSL2 doesn't pass through USB device hotplug
  events, so the actual plug-in/diff flow couldn't be exercised this
  way — only the "no change detected" message)
- Unit tests in `tests/unit/test_detect_device.py` against a fixture
  sysfs tree, covering the plug-in diff, no-change, and multiple-change
  cases, following the existing pattern from `usb_enum.py`'s tests
- `ruff check .` — clean
- `pyright --strict` — passes
- `pytest` — all passing

## Checklist
- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR
