### PR TITLE
feat: command/response pairing across endpoint lanes

### DIFF
--- a/bsu_tool/analysis/pairing.py
+++ b/bsu_tool/analysis/pairing.py
@@ -182,8 +182,18 @@ def pair_command_responses(
     vendor_requests: list[int] = []
     vendor_endpoints: set[int] = set()
     failed_count = 0
+    capture_end = 0.0
 
     for transaction in transactions:
+        # The end of the capture is the last timestamp across all traffic,
+        # including control transfers and boundary orphans that never enter a
+        # lane. Deriving it from the filtered lane events would let a capture
+        # whose tail is control traffic suppress real unanswered commands near
+        # that tail (spec section 4.1 step 5).
+        for boundary_record in (transaction.submission, transaction.completion):
+            if boundary_record is not None:
+                capture_end = max(capture_end, boundary_record.timestamp)
+
         record = transaction.submission or transaction.completion
         if record is None:
             continue
@@ -214,7 +224,6 @@ def pair_command_responses(
     # Sort by timestamp, and on an exact tie put OUT before IN so a command and
     # its same-microsecond response are not inverted into unsolicited/unanswered.
     events.sort(key=lambda event: (event.timestamp, 0 if event.direction == "out" else 1))
-    capture_end = max((event.timestamp for event in events), default=0.0)
 
     pairs: list[CommandResponsePair] = []
     unanswered: list[UnpairedCommand] = []
@@ -279,7 +288,7 @@ def _pair_lane(
         while pending and event.timestamp - pending[0].timestamp > timeout_seconds:
             _flush_out(pending.popleft(), capture_end, timeout_seconds, unanswered)
         if pending:
-            command = pending.popleft()
+            command = _take_command(pending)
             if command.successful and event.successful:
                 pairs.append(_build_pair(command, event))
             # else: one side failed, the pair is explained by failed traffic.
@@ -290,6 +299,21 @@ def _pair_lane(
 
     while pending:
         _flush_out(pending.popleft(), capture_end, timeout_seconds, unanswered)
+
+
+def _take_command(pending: deque[AnalysisEvent]) -> AnalysisEvent:
+    """Remove and return the pending OUT this IN answers.
+
+    Prefers the oldest successful command, because spec section 4.1 step 3 pairs
+    a successful OUT with a successful IN and a failed OUT can never be the
+    command half of a pair. Only when no successful command is outstanding does
+    the oldest failed one come out, so it still explains the IN under step 4.
+    """
+    for index, candidate in enumerate(pending):
+        if candidate.successful:
+            del pending[index]
+            return candidate
+    return pending.popleft()
 
 
 def _flush_out(
@@ -417,7 +441,8 @@ def _incomplete_from(transaction: UrbTransaction) -> IncompleteTransferEvent:
         record = transaction.submission
         reason: IncompleteTransferReason = "orphan_submission"
     else:
-        assert transaction.completion is not None  # pair_urbs guarantees one side is present
+        if transaction.completion is None:
+            raise ValueError("pair_urbs guarantees a transaction has a submission or a completion")
         record = transaction.completion
         reason = "orphan_completion"
     return IncompleteTransferEvent(

--- a/bsu_tool/analysis/pairing.py
+++ b/bsu_tool/analysis/pairing.py
@@ -1,0 +1,475 @@
+"""Command/response pairing across endpoint lanes (m3 engine spec, section 4).
+
+Links an OUT analysis event from one :class:`~bsu_tool.urb_decoder.UrbTransaction`
+to a later IN analysis event from a separate transaction on the same device and
+endpoint number. Pairing starts from the transactions ``pair_urbs()`` already
+built. It never rebuilds submit/complete pairs with a FIFO queue, because USB
+allows multiple outstanding URBs and completions can arrive out of submit order.
+
+A single transaction is never a pair. One transaction is one URB id lifecycle,
+while a command/response pair is a protocol level relationship between two
+directional events.
+
+Scope, per spec section 4.2: standard Control transfers are excluded entirely.
+Vendor specific Control transfers are counted and reported in the result notes,
+and are not fed into pairing.
+
+Output shapes: unpaired events are reported one per event. Aggregating them into
+the spec's section 5.8 and 5.9 forms (occurrence counts keyed by payload
+signature) requires the normalization layer from section 2, which lives with the
+detection engine (#63) and the description assembly (#66). This module hands
+those layers everything they need and nothing they must undo.
+
+Known integration point: the spec's section 5.8 and 5.9 output carries indices
+into ``Capture.records``, which a ``UrbTransaction`` alone cannot provide. The
+detection engine (#63) already builds analysis events that carry ``packet_index``.
+When the shared analysis event type from #66 lands, this module should consume
+it rather than its own :class:`AnalysisEvent`, and the results here gain those
+indices. Until then, events are located by timestamp, which markers also use.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import deque
+from dataclasses import dataclass
+from typing import Final
+
+from bsu_tool.analysis.models import IncompleteTransferReason, ResponseTimingStats
+from bsu_tool.urb_decoder import Direction, TransferType, UrbTransaction
+
+COMMAND_RESPONSE_TIMEOUT_SECONDS: Final[float] = 5.0
+"""Maximum capture-time gap between an OUT and the IN that answers it."""
+
+MAX_DIFF_BYTES_REPORTED: Final[int] = 32
+"""Cap on differing byte indices reported per pair."""
+
+_VENDOR_REQUEST_TYPE: Final[int] = 0x02  # bmRequestType bits 6:5 == 0b10
+_REQUEST_TYPE_SHIFT: Final[int] = 5
+_REQUEST_TYPE_MASK: Final[int] = 0x03
+
+# This module produces the per-event evidence a later assembly step aggregates
+# into the public output models. The types below are that raw evidence, one
+# object per event. The assembly step groups them by payload signature and emits
+# the aggregated forms in bsu_tool.analysis.models (UnansweredCommand,
+# UnsolicitedResponse, IncompleteTransfer), which carry occurrence counts and
+# signatures this layer does not compute. ResponseTimingStats has the same shape
+# at both layers, so it is imported from models rather than redefined.
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisEvent:
+    """One directional, payload-bearing event derived from a transaction."""
+
+    bus_num: int
+    dev_num: int
+    endpoint_number: int
+    endpoint_address: str
+    direction: Direction
+    transfer_type: TransferType
+    timestamp: float
+    data: bytes
+    status: int | None
+    successful: bool
+    boundary_orphan: bool
+    """True when the other half of the transaction fell outside the capture."""
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResponsePair:
+    """A likely command and its response on one endpoint lane."""
+
+    bus_num: int
+    dev_num: int
+    endpoint_number: int
+    command: AnalysisEvent
+    response: AnalysisEvent
+    response_time_ms: float
+    echoed_prefix_length: int
+    """Leading bytes of the response equal to the command's leading bytes."""
+    differing_byte_indices: tuple[int, ...]
+    """Positions where command and response bytes differ, within the shorter payload."""
+    differing_bytes_truncated: bool
+    """True when more than ``MAX_DIFF_BYTES_REPORTED`` positions differed."""
+
+
+@dataclass(frozen=True, slots=True)
+class UnpairedCommand:
+    """A successful OUT event with no IN answer inside the timeout window.
+
+    Per-event evidence. An assembly step groups these by payload signature into
+    the aggregated :class:`bsu_tool.analysis.models.UnansweredCommand`.
+    """
+
+    bus_num: int
+    dev_num: int
+    endpoint_number: int
+    endpoint_address: str
+    transfer_type: TransferType
+    timestamp: float
+    data_length: int
+
+
+@dataclass(frozen=True, slots=True)
+class UnpairedResponse:
+    """A successful IN event with no preceding OUT inside the timeout window.
+
+    Per-event evidence. An assembly step groups these by payload signature into
+    the aggregated :class:`bsu_tool.analysis.models.UnsolicitedResponse`.
+    """
+
+    bus_num: int
+    dev_num: int
+    endpoint_number: int
+    endpoint_address: str
+    transfer_type: TransferType
+    timestamp: float
+    data_length: int
+
+
+@dataclass(frozen=True, slots=True)
+class IncompleteTransferEvent:
+    """Capture-boundary or malformed-lifecycle evidence for one transaction.
+
+    Per-event evidence. An assembly step counts these into the aggregated
+    :class:`bsu_tool.analysis.models.IncompleteTransfer`.
+    """
+
+    bus_num: int
+    dev_num: int
+    endpoint_number: int
+    endpoint_address: str
+    direction: Direction
+    transfer_type: TransferType
+    reason: IncompleteTransferReason
+
+
+@dataclass(frozen=True, slots=True)
+class PairingResult:
+    """Everything the pairing pass produced from one set of transactions."""
+
+    pairs: tuple[CommandResponsePair, ...]
+    unanswered_commands: tuple[UnpairedCommand, ...]
+    unsolicited_responses: tuple[UnpairedResponse, ...]
+    incomplete_transfers: tuple[IncompleteTransferEvent, ...]
+    response_timing: ResponseTimingStats | None
+    vendor_control_count: int
+    vendor_control_requests: tuple[int, ...]
+    failed_event_count: int
+    analysis_notes: tuple[str, ...]
+
+
+def pair_command_responses(
+    transactions: tuple[UrbTransaction, ...],
+    *,
+    timeout_seconds: float = COMMAND_RESPONSE_TIMEOUT_SECONDS,
+) -> PairingResult:
+    """Run the section 4.1 pairing pass over decoded transactions.
+
+    Args:
+        transactions: The ``UrbTransaction`` objects from a loaded capture,
+            exactly as ``Capture.transactions`` holds them.
+        timeout_seconds: Maximum capture-time gap for an IN to answer an OUT.
+
+    Returns:
+        A :class:`PairingResult`. Failed events and standard Control traffic
+        are counted, never promoted. Events whose missing half fell outside
+        the capture are reported as incomplete transfers instead of unanswered
+        or unsolicited, because a capture boundary explains them.
+    """
+    events: list[AnalysisEvent] = []
+    incomplete: list[IncompleteTransferEvent] = []
+    vendor_requests: list[int] = []
+    vendor_endpoints: set[int] = set()
+    failed_count = 0
+
+    for transaction in transactions:
+        record = transaction.submission or transaction.completion
+        if record is None:
+            continue
+        if record.transfer_type == "control":
+            request = _vendor_control_request(transaction)
+            if request is not None:
+                vendor_requests.append(request)
+                vendor_endpoints.add(record.endpoint)
+            continue
+
+        event = _to_event(transaction)
+        if event is None:
+            incomplete.append(_incomplete_from(transaction))
+            continue
+        if event.boundary_orphan:
+            # A URB in flight at a capture edge is a lifecycle orphan, not a
+            # protocol-level unanswered or unsolicited event.
+            reason: IncompleteTransferReason = "orphan_submission" if event.direction == "out" else "orphan_completion"
+            incomplete.append(_incomplete_from_event(event, reason))
+            continue
+        if not event.successful:
+            failed_count += 1
+        # Failed events stay in the lane. Spec section 4.1 step 2 keeps them
+        # visible so a failed OUT or IN does not turn a nearby event into a
+        # false unanswered command or unsolicited response.
+        events.append(event)
+
+    # Sort by timestamp, and on an exact tie put OUT before IN so a command and
+    # its same-microsecond response are not inverted into unsolicited/unanswered.
+    events.sort(key=lambda event: (event.timestamp, 0 if event.direction == "out" else 1))
+    capture_end = max((event.timestamp for event in events), default=0.0)
+
+    pairs: list[CommandResponsePair] = []
+    unanswered: list[UnpairedCommand] = []
+    unsolicited: list[UnpairedResponse] = []
+
+    # Scope is device and endpoint number only, per spec section 4.1. Transfer
+    # type is determined by (device, endpoint number, direction) in USB, so it
+    # is not part of the key.
+    lanes: dict[tuple[int, int, int], list[AnalysisEvent]] = {}
+    for event in events:
+        key = (event.bus_num, event.dev_num, event.endpoint_number)
+        lanes.setdefault(key, []).append(event)
+
+    for lane_events in lanes.values():
+        _pair_lane(lane_events, timeout_seconds, capture_end, pairs, unanswered, unsolicited)
+
+    notes: list[str] = []
+    if vendor_requests:
+        codes = ", ".join(f"0x{code:02X}" for code in sorted(set(vendor_requests)))
+        endpoints = ", ".join(f"ep{number}" for number in sorted(vendor_endpoints))
+        notes.append(
+            f"{len(vendor_requests)} vendor-specific control transfers seen on {endpoints} "
+            f"(requests {codes}), not included in pattern detection"
+        )
+    if failed_count:
+        notes.append(f"{failed_count} failed bulk/interrupt events kept visible, not promoted into pairs")
+
+    return PairingResult(
+        pairs=tuple(pairs),
+        unanswered_commands=tuple(unanswered),
+        unsolicited_responses=tuple(unsolicited),
+        incomplete_transfers=tuple(incomplete),
+        response_timing=_timing_stats(pairs),
+        vendor_control_count=len(vendor_requests),
+        vendor_control_requests=tuple(sorted(set(vendor_requests))),
+        failed_event_count=failed_count,
+        analysis_notes=tuple(notes),
+    )
+
+
+def _pair_lane(
+    lane_events: list[AnalysisEvent],
+    timeout_seconds: float,
+    capture_end: float,
+    pairs: list[CommandResponsePair],
+    unanswered: list[UnpairedCommand],
+    unsolicited: list[UnpairedResponse],
+) -> None:
+    """Pair one endpoint lane's events in timestamp order.
+
+    Failed events stay in the lane and suppress false results. A failed OUT or
+    IN consumes its slot without producing a pair, an unanswered command, or an
+    unsolicited response, because the failure explains the missing counterpart
+    (spec section 4.1 steps 4 and 5).
+    """
+    pending: deque[AnalysisEvent] = deque()
+    for event in lane_events:
+        if event.direction == "out":
+            pending.append(event)
+            continue
+
+        while pending and event.timestamp - pending[0].timestamp > timeout_seconds:
+            _flush_out(pending.popleft(), capture_end, timeout_seconds, unanswered)
+        if pending:
+            command = pending.popleft()
+            if command.successful and event.successful:
+                pairs.append(_build_pair(command, event))
+            # else: one side failed, the pair is explained by failed traffic.
+        elif event.successful:
+            _record_unsolicited(event, unsolicited)
+        # A failed IN with no pending OUT is explained by failed traffic, not
+        # unsolicited.
+
+    while pending:
+        _flush_out(pending.popleft(), capture_end, timeout_seconds, unanswered)
+
+
+def _flush_out(
+    event: AnalysisEvent,
+    capture_end: float,
+    timeout_seconds: float,
+    unanswered: list[UnpairedCommand],
+) -> None:
+    """File a still-pending OUT once no IN can answer it.
+
+    A failed OUT is explained by failed traffic and is dropped. A successful
+    OUT whose timeout window would extend past the end of the capture is
+    explained by the capture boundary and is dropped, because whether it was
+    answered is unknowable. Only a successful OUT that went a full timeout
+    window without an answer inside the capture is a real unanswered command.
+    """
+    if not event.successful:
+        return
+    if capture_end - event.timestamp < timeout_seconds:
+        return
+    _record_unanswered(event, unanswered)
+
+
+def _record_unanswered(
+    event: AnalysisEvent,
+    unanswered: list[UnpairedCommand],
+) -> None:
+    """File an unpaired OUT as an unanswered command."""
+    unanswered.append(
+        UnpairedCommand(
+            bus_num=event.bus_num,
+            dev_num=event.dev_num,
+            endpoint_number=event.endpoint_number,
+            endpoint_address=event.endpoint_address,
+            transfer_type=event.transfer_type,
+            timestamp=event.timestamp,
+            data_length=len(event.data),
+        )
+    )
+
+
+def _record_unsolicited(
+    event: AnalysisEvent,
+    unsolicited: list[UnpairedResponse],
+) -> None:
+    """File an unpaired IN as an unsolicited response."""
+    unsolicited.append(
+        UnpairedResponse(
+            bus_num=event.bus_num,
+            dev_num=event.dev_num,
+            endpoint_number=event.endpoint_number,
+            endpoint_address=event.endpoint_address,
+            transfer_type=event.transfer_type,
+            timestamp=event.timestamp,
+            data_length=len(event.data),
+        )
+    )
+
+
+def _build_pair(command: AnalysisEvent, response: AnalysisEvent) -> CommandResponsePair:
+    """Assemble a pair record with the byte relationship between the two payloads."""
+    compare = min(len(command.data), len(response.data))
+    echoed = 0
+    while echoed < compare and command.data[echoed] == response.data[echoed]:
+        echoed += 1
+    differing = tuple(index for index in range(compare) if command.data[index] != response.data[index])
+    return CommandResponsePair(
+        bus_num=command.bus_num,
+        dev_num=command.dev_num,
+        endpoint_number=command.endpoint_number,
+        command=command,
+        response=response,
+        response_time_ms=(response.timestamp - command.timestamp) * 1000.0,
+        echoed_prefix_length=echoed,
+        differing_byte_indices=differing[:MAX_DIFF_BYTES_REPORTED],
+        differing_bytes_truncated=len(differing) > MAX_DIFF_BYTES_REPORTED,
+    )
+
+
+def _to_event(transaction: UrbTransaction) -> AnalysisEvent | None:
+    """Build the payload-bearing analysis event for one transaction.
+
+    OUT commands take their payload from the submission record. IN responses
+    take theirs from the completion record. Returns ``None`` when the payload
+    side is missing, which the caller records as an incomplete transfer.
+    """
+    record = transaction.submission or transaction.completion
+    if record is None:
+        return None
+
+    if record.direction == "out":
+        payload = transaction.submission
+        other = transaction.completion
+    else:
+        payload = transaction.completion
+        other = transaction.submission
+    if payload is None:
+        return None
+
+    status = transaction.completion.status if transaction.completion is not None else None
+    successful = status == 0
+    return AnalysisEvent(
+        bus_num=payload.bus_num,
+        dev_num=payload.dev_num,
+        endpoint_number=payload.endpoint,
+        endpoint_address=_endpoint_address(payload.endpoint, payload.direction),
+        direction=payload.direction,
+        transfer_type=payload.transfer_type,
+        timestamp=payload.timestamp,
+        data=payload.data,
+        status=status,
+        successful=successful,
+        boundary_orphan=other is None,
+    )
+
+
+def _incomplete_from(transaction: UrbTransaction) -> IncompleteTransferEvent:
+    """Build an incomplete-transfer record for a transaction with no payload side.
+
+    The reason follows which half survived. A submission with no completion is
+    an ``orphan_submission`` (in flight at capture end), a completion with no
+    submission is an ``orphan_completion`` (started before the capture).
+    """
+    if transaction.submission is not None:
+        record = transaction.submission
+        reason: IncompleteTransferReason = "orphan_submission"
+    else:
+        assert transaction.completion is not None  # pair_urbs guarantees one side is present
+        record = transaction.completion
+        reason = "orphan_completion"
+    return IncompleteTransferEvent(
+        bus_num=record.bus_num,
+        dev_num=record.dev_num,
+        endpoint_number=record.endpoint,
+        endpoint_address=_endpoint_address(record.endpoint, record.direction),
+        direction=record.direction,
+        transfer_type=record.transfer_type,
+        reason=reason,
+    )
+
+
+def _incomplete_from_event(event: AnalysisEvent, reason: IncompleteTransferReason) -> IncompleteTransferEvent:
+    """Build an incomplete-transfer record from an event at a capture boundary."""
+    return IncompleteTransferEvent(
+        bus_num=event.bus_num,
+        dev_num=event.dev_num,
+        endpoint_number=event.endpoint_number,
+        endpoint_address=event.endpoint_address,
+        direction=event.direction,
+        transfer_type=event.transfer_type,
+        reason=reason,
+    )
+
+
+def _vendor_control_request(transaction: UrbTransaction) -> int | None:
+    """Return the bRequest code when a control transaction is vendor specific."""
+    for record in (transaction.submission, transaction.completion):
+        if record is None or record.setup is None or len(record.setup) < 2:
+            continue
+        request_type = (record.setup[0] >> _REQUEST_TYPE_SHIFT) & _REQUEST_TYPE_MASK
+        if request_type == _VENDOR_REQUEST_TYPE:
+            return record.setup[1]
+        return None
+    return None
+
+
+def _timing_stats(pairs: list[CommandResponsePair]) -> ResponseTimingStats | None:
+    """Aggregate response times across pairs, or ``None`` with no pairs."""
+    if not pairs:
+        return None
+    times = [pair.response_time_ms for pair in pairs]
+    return ResponseTimingStats(
+        mean_ms=statistics.fmean(times),
+        median_ms=statistics.median(times),
+        min_ms=min(times),
+        max_ms=max(times),
+    )
+
+
+def _endpoint_address(endpoint_number: int, direction: Direction) -> str:
+    """Render the display endpoint address, for example ``0x01`` OUT or ``0x81`` IN."""
+    value = endpoint_number | (0x80 if direction == "in" else 0x00)
+    return f"0x{value:02x}"

--- a/tests/unit/test_pairing.py
+++ b/tests/unit/test_pairing.py
@@ -1,0 +1,437 @@
+"""Locked tests for command/response pairing (m3 engine spec, section 4)."""
+
+from __future__ import annotations
+
+from bsu_tool.analysis.pairing import (
+    COMMAND_RESPONSE_TIMEOUT_SECONDS,
+    PairingResult,
+    pair_command_responses,
+)
+from bsu_tool.urb_decoder import Direction, EventType, TransferType, UrbRecord, UrbTransaction
+
+_BASE_TIME = 1_000_000.0
+
+
+def _record(
+    *,
+    urb_id: int,
+    event_type: EventType,
+    direction: Direction,
+    timestamp: float,
+    transfer_type: TransferType = "bulk",
+    endpoint: int = 1,
+    bus_num: int = 1,
+    dev_num: int = 5,
+    status: int = 0,
+    data: bytes = b"",
+    setup: bytes | None = None,
+) -> UrbRecord:
+    """Build one UrbRecord with test defaults."""
+    return UrbRecord(
+        urb_id=urb_id,
+        event_type=event_type,
+        transfer_type=transfer_type,
+        direction=direction,
+        bus_num=bus_num,
+        dev_num=dev_num,
+        endpoint=endpoint,
+        status=status,
+        length=len(data),
+        captured_length=len(data),
+        data=data,
+        setup=setup,
+        timestamp=timestamp,
+    )
+
+
+def _out_transaction(
+    urb_id: int,
+    at: float,
+    *,
+    data: bytes = b"\xd0\x01",
+    endpoint: int = 1,
+    bus_num: int = 1,
+    dev_num: int = 5,
+    completion_status: int = 0,
+    completed: bool = True,
+) -> UrbTransaction:
+    """Build an OUT transaction: submission carries the payload."""
+    submission = _record(
+        urb_id=urb_id,
+        event_type="submission",
+        direction="out",
+        timestamp=at,
+        data=data,
+        endpoint=endpoint,
+        bus_num=bus_num,
+        dev_num=dev_num,
+        status=-115,
+    )
+    completion = None
+    if completed:
+        completion = _record(
+            urb_id=urb_id,
+            event_type="completion",
+            direction="out",
+            timestamp=at + 0.001,
+            endpoint=endpoint,
+            bus_num=bus_num,
+            dev_num=dev_num,
+            status=completion_status,
+        )
+    return UrbTransaction(urb_id=urb_id, submission=submission, completion=completion)
+
+
+def _in_transaction(
+    urb_id: int,
+    at: float,
+    *,
+    data: bytes = b"\xd0\x99",
+    endpoint: int = 1,
+    bus_num: int = 1,
+    dev_num: int = 5,
+    status: int = 0,
+    with_submission: bool = True,
+) -> UrbTransaction:
+    """Build an IN transaction: completion carries the payload."""
+    submission = None
+    if with_submission:
+        submission = _record(
+            urb_id=urb_id,
+            event_type="submission",
+            direction="in",
+            timestamp=at - 0.001,
+            endpoint=endpoint,
+            bus_num=bus_num,
+            dev_num=dev_num,
+            status=-115,
+        )
+    completion = _record(
+        urb_id=urb_id,
+        event_type="completion",
+        direction="in",
+        timestamp=at,
+        data=data,
+        endpoint=endpoint,
+        bus_num=bus_num,
+        dev_num=dev_num,
+        status=status,
+    )
+    return UrbTransaction(urb_id=urb_id, submission=submission, completion=completion)
+
+
+def _control_transaction(urb_id: int, at: float, *, setup: bytes) -> UrbTransaction:
+    """Build a control transaction with the given setup packet."""
+    submission = _record(
+        urb_id=urb_id,
+        event_type="submission",
+        direction="out",
+        timestamp=at,
+        transfer_type="control",
+        endpoint=0,
+        setup=setup,
+        status=-115,
+    )
+    completion = _record(
+        urb_id=urb_id,
+        event_type="completion",
+        direction="out",
+        timestamp=at + 0.001,
+        transfer_type="control",
+        endpoint=0,
+        status=0,
+    )
+    return UrbTransaction(urb_id=urb_id, submission=submission, completion=completion)
+
+
+def _run(*transactions: UrbTransaction) -> PairingResult:
+    """Run the pairing pass over the given transactions."""
+    return pair_command_responses(tuple(transactions))
+
+
+def test_out_then_in_on_same_lane_pairs() -> None:
+    """An OUT followed by an IN on the same endpoint lane becomes one pair."""
+    result = _run(
+        _out_transaction(1, _BASE_TIME, data=b"\xd0\x01\x05"),
+        _in_transaction(2, _BASE_TIME + 0.050, data=b"\xd0\x00\x99"),
+    )
+    assert len(result.pairs) == 1
+    pair = result.pairs[0]
+    assert pair.endpoint_number == 1
+    assert pair.command.endpoint_address == "0x01"
+    assert pair.response.endpoint_address == "0x81"
+    assert 49.0 < pair.response_time_ms < 51.0
+    assert not result.unanswered_commands
+    assert not result.unsolicited_responses
+
+
+def test_single_out_and_in_of_one_urb_never_pair() -> None:
+    """A submission and completion sharing one URB id never pair with each other.
+
+    This is the hazard spec section 4.1 warns about: one URB id lifecycle is not
+    a command/response pair. Here an OUT and an IN carry the same urb_id, so if
+    the code paired within a transaction they would form a false pair. They must
+    not, because they arrive as two separate transactions and one is an OUT slot.
+    """
+    result = _run(
+        _out_transaction(7, _BASE_TIME, data=b"\x01"),
+        _in_transaction(7, _BASE_TIME + 10.0, data=b"\x99"),
+    )
+    # The IN is well past the timeout, so no pair. The OUT went a full window
+    # without an answer inside the capture, so it is a real unanswered command.
+    assert not result.pairs
+    assert len(result.unanswered_commands) == 1
+
+
+def test_pair_reports_byte_relationship() -> None:
+    """A pair reports the echoed prefix and the differing byte positions."""
+    result = _run(
+        _out_transaction(1, _BASE_TIME, data=b"\xd0\x01\x05\x0a"),
+        _in_transaction(2, _BASE_TIME + 0.010, data=b"\xd0\x01\x07\x0a"),
+    )
+    pair = result.pairs[0]
+    assert pair.echoed_prefix_length == 2
+    assert pair.differing_byte_indices == (2,)
+
+
+def test_multiple_outstanding_commands_pair_in_order() -> None:
+    """Two outstanding OUTs pair with the next INs in time order, not by URB id."""
+    result = _run(
+        _out_transaction(1, _BASE_TIME, data=b"\x01"),
+        _out_transaction(9, _BASE_TIME + 0.010, data=b"\x02"),
+        _in_transaction(3, _BASE_TIME + 0.020, data=b"\x01"),
+        _in_transaction(2, _BASE_TIME + 0.030, data=b"\x02"),
+    )
+    assert len(result.pairs) == 2
+    assert result.pairs[0].command.data == b"\x01"
+    assert result.pairs[1].command.data == b"\x02"
+
+
+def test_in_without_preceding_out_is_unsolicited() -> None:
+    """An IN with no preceding OUT on its lane is an unsolicited response."""
+    result = _run(_in_transaction(1, _BASE_TIME))
+    assert not result.pairs
+    assert len(result.unsolicited_responses) == 1
+    assert result.unsolicited_responses[0].endpoint_address == "0x81"
+
+
+def test_out_beyond_timeout_is_unanswered() -> None:
+    """An IN arriving after the timeout leaves the OUT unanswered."""
+    late = _BASE_TIME + COMMAND_RESPONSE_TIMEOUT_SECONDS + 1.0
+    result = _run(
+        _out_transaction(1, _BASE_TIME),
+        _in_transaction(2, late),
+    )
+    assert not result.pairs
+    assert len(result.unanswered_commands) == 1
+    assert len(result.unsolicited_responses) == 1
+
+
+def test_out_near_capture_end_is_not_falsely_unanswered() -> None:
+    """An OUT with no answer only because the capture ended is not unanswered.
+
+    The capture stops shortly after the OUT, inside the timeout window, so
+    whether an answer would have come is unknowable and must not be reported as
+    a real unanswered command.
+    """
+    result = _run(_out_transaction(1, _BASE_TIME))
+    assert not result.unanswered_commands
+    assert not result.pairs
+
+
+def test_cross_endpoint_events_do_not_pair() -> None:
+    """An OUT on endpoint 1 and an IN on endpoint 2 stay unpaired and both land.
+
+    The IN is well after the timeout so the OUT is a genuine unanswered command,
+    not a capture-boundary artifact, and both events are accounted for.
+    """
+    result = _run(
+        _out_transaction(1, _BASE_TIME, endpoint=1),
+        _in_transaction(2, _BASE_TIME + 6.0, endpoint=2),
+    )
+    assert not result.pairs
+    assert len(result.unanswered_commands) == 1
+    assert len(result.unsolicited_responses) == 1
+
+
+def test_cross_device_events_do_not_pair() -> None:
+    """Events from two devices on the same endpoint number stay unpaired."""
+    result = _run(
+        _out_transaction(1, _BASE_TIME, dev_num=5),
+        _in_transaction(2, _BASE_TIME + 6.0, dev_num=6),
+    )
+    assert not result.pairs
+    assert len(result.unanswered_commands) == 1
+    assert len(result.unsolicited_responses) == 1
+
+
+def test_failed_out_does_not_produce_a_false_unsolicited_response() -> None:
+    """A good IN after a failed OUT is explained by the failure, not unsolicited.
+
+    Spec section 4.1 step 4: an IN is only unsolicited when nothing explains it.
+    The failed OUT on the same lane explains this IN, so it must not be reported
+    as an unsolicited response. The failure is counted.
+    """
+    result = _run(
+        _out_transaction(1, _BASE_TIME, completion_status=-71),
+        _in_transaction(2, _BASE_TIME + 0.010),
+    )
+    assert not result.pairs
+    assert result.failed_event_count == 1
+    assert not result.unsolicited_responses
+    assert any("failed" in note for note in result.analysis_notes)
+
+
+def test_failed_in_after_good_out_does_not_produce_false_unanswered() -> None:
+    """A failed IN after a good OUT is explained by the failure, not unanswered.
+
+    Spec section 4.1 step 5: an OUT is only unanswered when nothing explains the
+    missing answer. The failed IN on the same lane consumes the OUT's slot, so
+    the OUT must not be reported as unanswered.
+    """
+    result = _run(
+        _out_transaction(1, _BASE_TIME),
+        _in_transaction(2, _BASE_TIME + 0.010, status=-71),
+    )
+    assert not result.pairs
+    assert not result.unanswered_commands
+    assert result.failed_event_count == 1
+
+
+def test_pairing_works_on_interrupt_transfers() -> None:
+    """Pairing is not limited to bulk. Interrupt OUT and IN pair the same way."""
+    out = UrbTransaction(
+        urb_id=1,
+        submission=_record(
+            urb_id=1,
+            event_type="submission",
+            direction="out",
+            timestamp=_BASE_TIME,
+            transfer_type="interrupt",
+            data=b"\x10",
+            status=-115,
+        ),
+        completion=_record(
+            urb_id=1,
+            event_type="completion",
+            direction="out",
+            timestamp=_BASE_TIME + 0.001,
+            transfer_type="interrupt",
+            status=0,
+        ),
+    )
+    in_txn = UrbTransaction(
+        urb_id=2,
+        submission=_record(
+            urb_id=2,
+            event_type="submission",
+            direction="in",
+            timestamp=_BASE_TIME + 0.004,
+            transfer_type="interrupt",
+            status=-115,
+        ),
+        completion=_record(
+            urb_id=2,
+            event_type="completion",
+            direction="in",
+            timestamp=_BASE_TIME + 0.005,
+            transfer_type="interrupt",
+            data=b"\x10\x01",
+            status=0,
+        ),
+    )
+    result = _run(out, in_txn)
+    assert len(result.pairs) == 1
+    assert result.pairs[0].command.transfer_type == "interrupt"
+
+
+def test_timeout_boundary_is_inclusive() -> None:
+    """An IN exactly at the timeout still pairs, the edge is inclusive."""
+    at_edge = _BASE_TIME + COMMAND_RESPONSE_TIMEOUT_SECONDS
+    result = _run(
+        _out_transaction(1, _BASE_TIME),
+        _in_transaction(2, at_edge),
+        _out_transaction(3, at_edge + 100.0),  # push capture_end well past the pair
+    )
+    assert len(result.pairs) == 1
+
+
+def test_class_specific_control_is_not_counted_as_vendor() -> None:
+    """A class request (type bits 0b01) is not a vendor control transfer."""
+    result = _run(_control_transaction(1, _BASE_TIME, setup=b"\x21\x0a\x00\x00\x00\x00\x00\x00"))
+    assert result.vendor_control_count == 0
+
+
+def test_standard_control_is_excluded_entirely() -> None:
+    """Standard control transfers produce no events, no pairs, no counts."""
+    result = _run(_control_transaction(1, _BASE_TIME, setup=b"\x80\x06\x00\x01\x00\x00\x12\x00"))
+    assert not result.pairs
+    assert result.vendor_control_count == 0
+    assert not result.analysis_notes
+
+
+def test_vendor_control_is_counted_with_request_codes() -> None:
+    """Vendor control transfers are counted and reported, never paired."""
+    result = _run(
+        _control_transaction(1, _BASE_TIME, setup=b"\x40\x9a\x00\x00\x00\x00\x00\x00"),
+        _control_transaction(2, _BASE_TIME + 0.010, setup=b"\xc0\xa1\x00\x00\x00\x00\x02\x00"),
+    )
+    assert result.vendor_control_count == 2
+    assert result.vendor_control_requests == (0x9A, 0xA1)
+    assert any("vendor-specific control" in note for note in result.analysis_notes)
+    assert not result.pairs
+
+
+def test_in_flight_out_at_capture_end_is_incomplete_not_unanswered() -> None:
+    """An OUT still in flight when the capture ended is a boundary artifact."""
+    result = _run(_out_transaction(1, _BASE_TIME, completed=False))
+    assert not result.unanswered_commands
+    assert len(result.incomplete_transfers) == 1
+    assert result.incomplete_transfers[0].reason == "orphan_submission"
+
+
+def test_orphan_in_at_capture_start_is_incomplete_not_unsolicited() -> None:
+    """An IN whose submission fell before the capture is a boundary artifact."""
+    result = _run(_in_transaction(1, _BASE_TIME, with_submission=False))
+    assert not result.unsolicited_responses
+    assert len(result.incomplete_transfers) == 1
+    assert result.incomplete_transfers[0].reason == "orphan_completion"
+
+
+def test_response_timing_stats_cover_all_pairs() -> None:
+    """Timing statistics aggregate every pair's response time in milliseconds."""
+    result = _run(
+        _out_transaction(1, _BASE_TIME),
+        _in_transaction(2, _BASE_TIME + 0.010),
+        _out_transaction(3, _BASE_TIME + 1.0),
+        _in_transaction(4, _BASE_TIME + 1.030),
+    )
+    timing = result.response_timing
+    assert timing is not None
+    assert 9.0 < timing.min_ms < 11.0
+    assert 29.0 < timing.max_ms < 31.0
+    assert 19.0 < timing.mean_ms < 21.0
+    assert 19.0 < timing.median_ms < 21.0
+
+
+def test_incomplete_reason_reflects_which_half_survived() -> None:
+    """A completion-only OUT is an orphan completion, submission-only an orphan submission."""
+    completion_only_out = UrbTransaction(
+        urb_id=1,
+        submission=None,
+        completion=_record(urb_id=1, event_type="completion", direction="out", timestamp=_BASE_TIME, status=0),
+    )
+    submission_only_in = UrbTransaction(
+        urb_id=2,
+        submission=_record(urb_id=2, event_type="submission", direction="in", timestamp=_BASE_TIME, status=-115),
+        completion=None,
+    )
+    result = _run(completion_only_out, submission_only_in)
+    reasons = {item.reason for item in result.incomplete_transfers}
+    assert reasons == {"orphan_completion", "orphan_submission"}
+
+
+def test_no_pairs_means_no_timing_stats() -> None:
+    """With zero pairs the timing statistics are absent, not zeroed."""
+    result = _run(_out_transaction(1, _BASE_TIME))
+    assert result.response_timing is None

--- a/tests/unit/test_pairing.py
+++ b/tests/unit/test_pairing.py
@@ -435,3 +435,59 @@ def test_no_pairs_means_no_timing_stats() -> None:
     """With zero pairs the timing statistics are absent, not zeroed."""
     result = _run(_out_transaction(1, _BASE_TIME))
     assert result.response_timing is None
+
+
+def test_failed_out_does_not_consume_the_in_that_answers_a_later_good_out() -> None:
+    """A STALLed OUT then a retry OUT then one IN pairs the retry, not the failure.
+
+    Spec section 4.1 step 3 pairs a successful OUT with a successful IN. A failed
+    OUT can never be the command half, so the IN must answer the retry. Consuming
+    the failed OUT first would drop the real pair and report the retry as a false
+    unanswered command, the exact false positive this module exists to prevent.
+    """
+    result = _run(
+        _out_transaction(1, _BASE_TIME, data=b"\xaa\x01", completion_status=-32),
+        _out_transaction(2, _BASE_TIME + 0.100, data=b"\xaa\x01"),
+        _in_transaction(3, _BASE_TIME + 0.200, data=b"\xbb\x01"),
+    )
+    assert len(result.pairs) == 1
+    assert result.pairs[0].command.timestamp == _BASE_TIME + 0.100
+    assert not result.unanswered_commands
+    assert not result.unsolicited_responses
+    assert result.failed_event_count == 1
+
+
+def test_unanswered_command_survives_trailing_control_traffic() -> None:
+    """An unanswered OUT is still reported when the capture tail is control traffic.
+
+    The end of the capture is the last timestamp across all traffic, including
+    vendor control transfers that never enter a lane. Deriving it from the lane
+    events alone would place the capture end at the OUT itself and suppress this
+    genuine unanswered command.
+    """
+    late = _BASE_TIME + COMMAND_RESPONSE_TIMEOUT_SECONDS + 100.0
+    result = _run(
+        _out_transaction(1, _BASE_TIME),
+        _control_transaction(2, late, setup=b"\x40\x9a\x00\x00\x00\x00\x00\x00"),
+    )
+    assert len(result.unanswered_commands) == 1
+    assert result.vendor_control_count == 1
+
+
+def test_failed_out_explains_one_in_and_a_second_in_is_unsolicited() -> None:
+    """A failed OUT explains only one IN. A second IN with nothing pending stands.
+
+    Spec section 4.1 step 4: an IN is unsolicited only when nothing explains it.
+    The failed OUT explains the first IN and is then spent, so the second IN has
+    no pending command and is a real unsolicited response.
+    """
+    result = _run(
+        _out_transaction(1, _BASE_TIME, completion_status=-71),
+        _in_transaction(2, _BASE_TIME + 0.100),
+        _in_transaction(3, _BASE_TIME + 0.200),
+    )
+    assert not result.pairs
+    assert len(result.unsolicited_responses) == 1
+    assert result.unsolicited_responses[0].timestamp == _BASE_TIME + 0.200
+    assert not result.unanswered_commands
+    assert result.failed_event_count == 1


### PR DESCRIPTION
## What does this PR do?

Adds command/response pairing across endpoint lanes, implementing m3 engine spec
section 4. `bsu_tool/analysis/pairing.py` takes the `UrbTransaction` objects a
capture already holds and links an OUT command to the IN that answers it, on the
same device and endpoint number, within a timeout window.

Closes #64.

### What it produces

`pair_command_responses(transactions)` returns a `PairingResult` with:

- `pairs`, each OUT matched to its IN, with the response time and the byte
  relationship between the two payloads (echoed prefix length, differing byte
  positions)
- `unanswered_commands`, successful OUTs with no answer inside the window
- `unsolicited_responses`, successful INs with no preceding OUT
- `incomplete_transfers`, URBs whose other half fell outside the capture
- `response_timing`, `vendor_control_count`, `failed_event_count`, and notes

### How it follows the spec

- Pairing starts from `pair_urbs()` output. It never rebuilds submit/complete
  pairs with a FIFO queue, because USB allows multiple outstanding URBs and
  completions can arrive out of submit order (section 4.1).
- A single transaction is never a pair. One transaction is one URB id lifecycle,
  while a pair is a protocol relationship between two directional events.
- Scope is device and endpoint number, so an OUT on `0x01` can pair with an IN
  on `0x81` (section 4.1).
- Standard control transfers are excluded. Vendor specific control transfers
  (bmRequestType type field is vendor) are counted and reported in the notes,
  never paired (section 4.2).

### Layering

This module produces per-event evidence. The aggregated public output types in
`bsu_tool.analysis.models` (`UnansweredCommand`, `UnsolicitedResponse`,
`IncompleteTransfer`) carry occurrence counts and payload signatures that come
from the section 2 normalization layer, which lives with the detection engine
(#63) and the description assembly (#66). The per-event types here are named
`UnpairedCommand`, `UnpairedResponse`, and `IncompleteTransferEvent` to keep
them distinct from those aggregated forms. `ResponseTimingStats` has the same
shape at both layers, so it is imported from `models` rather than redefined.

### Design decisions worth calling out

- **Failed events stay in the lane.** A failed OUT or IN consumes its slot
  without producing a pair, an unanswered command, or an unsolicited response,
  because the failure explains the missing counterpart (section 4.1 steps 4 and
  5). Dropping them would manufacture false unanswered and unsolicited results.
- **Capture boundary suppression.** A successful OUT whose timeout window would
  extend past the end of the capture is not reported as unanswered, because
  whether it was answered is unknowable. Without this, every capture ends with a
  false unanswered command per active lane.
- **Tie-break on equal timestamps.** usbmon has microsecond resolution, so an
  OUT and its IN can share a timestamp. Ties put OUT before IN so a command and
  its same-microsecond response are not inverted.

## How was it tested?

`tests/unit/test_pairing.py`, 21 tests: the pairing happy path, a single URB id
never pairing with itself, multiple outstanding commands pairing in time order,
cross-endpoint and cross-device events staying unpaired, the failed-traffic
suppression in both directions, the inclusive timeout edge, the capture-boundary
suppression, incomplete-transfer reasons, interrupt transfers, vendor and class
control handling, and the timing statistics.

`ruff`, `ruff format`, `pyright --strict`, `pytest` all clean.

## Review notes

- **Packet indices are the integration point.** The spec's section 5.8 and 5.9
  output carries indices into `Capture.records`, which a `UrbTransaction` alone
  cannot provide. Events here are located by timestamp, which markers also use.
  When the assembly step consumes both this module's pairs and the detection
  engine's tokens, the indices come from there.
- **`AnalysisEvent` is defined here and in #63.** Both are section 2.2 internal
  types, correctly not in `models.py` (which holds section 5 output only). Worth
  a team decision on whether it gets a shared home.
