### PR TITLE
feat: wait_for_human tool for guided sessions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,5 @@ repos:
     hooks:
       - id: pyright
         additional_dependencies:
-          - "mcp>=1.0"
+          - "mcp>=1.0,<2"   # 2.0 moved mcp.server.fastmcp; see pyproject
           - "pytest>=8.0"

--- a/bsu_tool/guided/__init__.py
+++ b/bsu_tool/guided/__init__.py
@@ -1,0 +1,7 @@
+"""Guided capture session support (issues #109 and #112).
+
+Modules here belong to the guided-capture command, which runs in the process
+that owns the real terminal. Nothing in this package may be registered on
+:mod:`bsu_tool.mcp.server`: that server speaks MCP over stdio, so its stdin is
+the transport and reading from it would corrupt the protocol.
+"""

--- a/bsu_tool/guided/human.py
+++ b/bsu_tool/guided/human.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from anyio import Lock
 from anyio.to_thread import run_sync
 from mcp.server.fastmcp import FastMCP
 
@@ -76,12 +77,18 @@ def ask_human(
 
 
 class _HumanChannel:
-    """The analyst input/output channel, with a latch so an ended session stays ended.
+    """The analyst input/output channel: one question at a time, and an ended session stays ended.
 
-    Once the channel aborts (end of input, terminal gone), every later call
-    returns the same aborted result instead of blocking on a reader that will
-    only fail again. Without the latch a model that keeps calling the tool after
-    an abort spins tightly on instant failures.
+    There is one analyst and one terminal, so questions are serialized. The MCP
+    server dispatches tool calls concurrently, and without the turn lock a model
+    that emits two ``wait_for_human`` calls in one turn prints both prompts over
+    each other and puts two worker threads on the same stdin, where whichever
+    thread wins takes the analyst's line.
+
+    The channel also latches its abort. Once it aborts (end of input, terminal
+    gone), every later call returns the same aborted result instead of blocking
+    on a reader that will only fail again. Without the latch a model that keeps
+    calling the tool after an abort spins tightly on instant failures.
     """
 
     def __init__(self, write: Callable[[str], None], read: Callable[[], str]) -> None:
@@ -89,15 +96,23 @@ class _HumanChannel:
         self._write = write
         self._read = read
         self._aborted_reason: str | None = None
+        self._turn = Lock()
 
     async def ask(self, question: str) -> WaitForHumanResult:
-        """Ask one question, offloading the blocking read off the event loop."""
-        if self._aborted_reason is not None:
-            return WaitForHumanResult(answer=None, aborted=True, reason=self._aborted_reason)
-        result: WaitForHumanResult = await run_sync(lambda: ask_human(question, write=self._write, read=self._read))
-        if result.aborted:
-            self._aborted_reason = result.reason
-        return result
+        """Ask one question, offloading the blocking read off the event loop.
+
+        The latch is checked inside the turn lock, not outside it. Checked
+        outside, a caller queued behind another passes the check before its
+        predecessor aborts and then reads anyway; inside, it sees the abort and
+        returns without ever touching the reader.
+        """
+        async with self._turn:
+            if self._aborted_reason is not None:
+                return WaitForHumanResult(answer=None, aborted=True, reason=self._aborted_reason)
+            result: WaitForHumanResult = await run_sync(lambda: ask_human(question, write=self._write, read=self._read))
+            if result.aborted:
+                self._aborted_reason = result.reason
+            return result
 
 
 def build_human_server(

--- a/bsu_tool/guided/human.py
+++ b/bsu_tool/guided/human.py
@@ -1,0 +1,149 @@
+"""The wait_for_human MCP tool for guided capture sessions (issue #109).
+
+The guided flow stops repeatedly to ask the analyst a question and wait for a
+typed answer: "what do you see on the board?", "plug it in now", "did anything
+happen?". This module exposes that as an MCP tool a model can call.
+
+Placement constraint, load bearing: this tool MUST NOT live in
+:mod:`bsu_tool.mcp.server`. That server runs as a subprocess speaking MCP over
+stdio, so its stdin is the transport, and a tool reading from it would corrupt
+the protocol. The tool belongs in an in-process MCP server owned by the
+guided-capture command, which holds the real terminal. :func:`build_human_server`
+builds that server.
+
+When input ends (the analyst pressed ctrl-d, or the terminal closed) the tool
+reports the session as aborted instead of hanging. A keyboard interrupt is left
+to propagate, so ctrl-c stays the analyst's way out of the guided command.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from anyio.to_thread import run_sync
+from mcp.server.fastmcp import FastMCP
+
+_ABORTING_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    EOFError,  # ctrl-d, or stdin at end of file
+    OSError,  # terminal hangup, device gone, closed fd at the OS layer
+    RuntimeError,  # input() lost sys.stdin (detached console, some launchers)
+    ValueError,  # read from a file object closed underneath us
+    UnicodeDecodeError,  # non-UTF-8 bytes arriving on a UTF-8 stream
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WaitForHumanResult:
+    """What came back from asking the analyst a question."""
+
+    answer: str | None
+    aborted: bool
+    reason: str | None
+    """Why the exchange aborted, ``None`` when it did not."""
+
+
+def ask_human(
+    question: str,
+    *,
+    write: Callable[[str], None],
+    read: Callable[[], str],
+) -> WaitForHumanResult:
+    """Print a question to the analyst and block until they answer.
+
+    Args:
+        question: The question to show the analyst, verbatim.
+        write: Where the question is printed. The guided command passes a
+            writer for the real terminal.
+        read: Blocking reader that returns one line of analyst input. The
+            guided command passes a reader for the real terminal. Tests pass
+            fakes.
+
+    Returns:
+        The analyst's answer, or an aborted result when input ended or the
+        terminal went away. An aborted result means the session should stop
+        cleanly, not retry the question. This function does not swallow
+        ``KeyboardInterrupt``, so ctrl-c still reaches the guided command as
+        the analyst's escape hatch.
+    """
+    write(f"\n[bsu-tool] {question}\n> ")
+    try:
+        answer = read()
+    except _ABORTING_EXCEPTIONS as exc:
+        write("\n")
+        return WaitForHumanResult(answer=None, aborted=True, reason=f"input ended ({exc.__class__.__name__})")
+    return WaitForHumanResult(answer=answer.strip(), aborted=False, reason=None)
+
+
+class _HumanChannel:
+    """The analyst input/output channel, with a latch so an ended session stays ended.
+
+    Once the channel aborts (end of input, terminal gone), every later call
+    returns the same aborted result instead of blocking on a reader that will
+    only fail again. Without the latch a model that keeps calling the tool after
+    an abort spins tightly on instant failures.
+    """
+
+    def __init__(self, write: Callable[[str], None], read: Callable[[], str]) -> None:
+        """Store the terminal writer and blocking reader for this channel."""
+        self._write = write
+        self._read = read
+        self._aborted_reason: str | None = None
+
+    async def ask(self, question: str) -> WaitForHumanResult:
+        """Ask one question, offloading the blocking read off the event loop."""
+        if self._aborted_reason is not None:
+            return WaitForHumanResult(answer=None, aborted=True, reason=self._aborted_reason)
+        result: WaitForHumanResult = await run_sync(lambda: ask_human(question, write=self._write, read=self._read))
+        if result.aborted:
+            self._aborted_reason = result.reason
+        return result
+
+
+def build_human_server(
+    *,
+    write: Callable[[str], None] | None = None,
+    read: Callable[[], str] | None = None,
+) -> FastMCP:
+    """Build the in-process MCP server that carries the human channel.
+
+    This server is meant to run inside the guided-capture command (#112), the
+    process that owns the real terminal. That command is responsible for wiring
+    this server's ``wait_for_human`` tool into its agent session. This function
+    does not run any transport itself, and it MUST NOT be registered on the
+    stdio ``bsu_tool`` server, whose stdin is the MCP transport.
+
+    Args:
+        write: Writer for the terminal the analyst is watching. Defaults to
+            printing to standard output.
+        read: Blocking reader for the analyst's terminal. Defaults to reading
+            one line from standard input. This default is only safe in the
+            process that owns the terminal.
+
+    Returns:
+        A :class:`FastMCP` instance exposing the ``wait_for_human`` tool.
+    """
+    channel = _HumanChannel(
+        write if write is not None else _write_stdout,
+        read if read is not None else input,
+    )
+
+    server = FastMCP("bsu-tool-human")
+
+    @server.tool()
+    async def wait_for_human(question: str) -> WaitForHumanResult:  # pyright: ignore[reportUnusedFunction]
+        """Ask the analyst a question and wait for their typed answer.
+
+        Use this for every step that needs a person: physical descriptions,
+        plugging and unplugging, confirming what happened after a stimulus.
+        When the result says ``aborted``, stop the session cleanly. Do not
+        ask again, because the input channel has closed and will keep aborting.
+        """
+        return await channel.ask(question)
+
+    return server
+
+
+def _write_stdout(text: str) -> None:
+    """Write text to standard output without buffering surprises."""
+    print(text, end="", flush=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 description = "Behavioral Sleuth for USB — CLI tool and MCP server for USB protocol analysis"
 requires-python = ">=3.11"
 license = "MIT OR Apache-2.0"
-dependencies = ["mcp>=1.0"]
+# mcp is capped below 2.0: that release moved mcp.server.fastmcp, which every
+# server module here imports, so an unbounded ">=1.0" now resolves to a version
+# the tool cannot import at all.
+dependencies = ["mcp>=1.0,<2", "anyio>=4.0"]
 
 [tool.setuptools.packages.find]
 include = ["bsu_tool*"]

--- a/tests/unit/test_wait_for_human.py
+++ b/tests/unit/test_wait_for_human.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import builtins
-import importlib
 import json
-import pkgutil
+import subprocess
+import sys
+import textwrap
+import threading
 from collections.abc import Callable
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
-import bsu_tool.mcp
 from bsu_tool.guided.human import WaitForHumanResult, ask_human, build_human_server
 
 
@@ -132,11 +133,117 @@ def test_mcp_package_never_imports_guided() -> None:
 
     This is the load-bearing safety property: if any bsu_tool.mcp module pulled
     in bsu_tool.guided, the stdin-reading tool could end up on the transport.
+
+    Asserted on module objects rather than on source text. A text search for
+    "bsu_tool.guided" misses a relative import (``from ...guided.human import
+    ask_human``), which is the likelier way this gets reintroduced, and walking
+    submodules never scans the package root. Importing the whole package in a
+    clean subprocess and inspecting ``sys.modules`` catches relative, absolute,
+    and transitive imports, in any file including ``__init__.py``.
     """
-    for module in pkgutil.walk_packages(bsu_tool.mcp.__path__, prefix="bsu_tool.mcp."):
-        loaded = importlib.import_module(module.name)
-        source = getattr(loaded, "__file__", None)
-        if source is None:
-            continue
-        with open(source, encoding="utf-8") as handle:
-            assert "bsu_tool.guided" not in handle.read(), f"{module.name} imports bsu_tool.guided"
+    probe = textwrap.dedent(
+        """
+        import importlib
+        import pkgutil
+        import sys
+
+        import bsu_tool.mcp
+
+        for module in pkgutil.walk_packages(bsu_tool.mcp.__path__, prefix="bsu_tool.mcp."):
+            importlib.import_module(module.name)
+
+        leaked = sorted(
+            name
+            for name in sys.modules
+            if name == "bsu_tool.guided" or name.startswith("bsu_tool.guided.")
+        )
+        print(",".join(leaked))
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    leaked = completed.stdout.strip()
+    assert leaked == "", f"bsu_tool.mcp pulled in guided modules: {leaked}"
+
+
+def test_concurrent_calls_are_serialized_on_one_analyst() -> None:
+    """Two overlapping calls take turns: one prompt, one read, then the next.
+
+    There is one analyst and one stdin. Without the turn lock both prompts print
+    over each other and two threads race on the reader.
+    """
+    events: list[str] = []
+    in_reader = threading.Semaphore(0)
+    release = threading.Semaphore(0)
+
+    def read() -> str:
+        events.append("read-start")
+        in_reader.release()
+        # Bounded, so a regression fails this test instead of hanging it: on the
+        # unlocked code both reader threads park here and never come back.
+        release.acquire(timeout=10)
+        events.append("read-end")
+        return "answer"
+
+    def write(text: str) -> None:
+        if text.strip():
+            events.append(f"write:{text.strip()}")
+
+    server = build_human_server(write=write, read=read)
+
+    async def drive() -> None:
+        async def unblock() -> None:
+            # Let the first call reach the reader, prove the second has not
+            # started, then release both in turn.
+            assert await asyncio.to_thread(in_reader.acquire, True, 10)
+            concurrent = events.count("read-start")
+            release.release()
+            assert await asyncio.to_thread(in_reader.acquire, True, 10)
+            release.release()
+            assert concurrent == 1, f"the second call read while the first held the terminal: {events}"
+
+        await asyncio.gather(
+            server.call_tool("wait_for_human", {"question": "one?"}),
+            server.call_tool("wait_for_human", {"question": "two?"}),
+            unblock(),
+        )
+
+    asyncio.run(drive())
+    # Each read is fully bracketed by its own turn: no interleaving.
+    assert events.count("read-start") == 2
+    for first, second in zip(events, events[1:]):
+        assert not (first == "read-start" and second == "read-start"), events
+
+
+def test_abort_latch_holds_against_a_queued_concurrent_call() -> None:
+    """A call queued behind an aborting call must not read: it sees the latch.
+
+    This is the concurrent form of test_abort_is_latched_so_repeated_calls_do_not_spin.
+    With the latch checked outside the turn lock the queued caller passes the
+    check before its predecessor aborts and reads anyway (reader called twice).
+    """
+    reads = 0
+    lock = threading.Lock()
+
+    def read() -> str:
+        nonlocal reads
+        with lock:
+            reads += 1
+        raise EOFError
+
+    server = build_human_server(write=lambda text: None, read=read)
+
+    async def drive() -> list[object]:
+        return list(
+            await asyncio.gather(
+                server.call_tool("wait_for_human", {"question": "one?"}),
+                server.call_tool("wait_for_human", {"question": "two?"}),
+            )
+        )
+
+    asyncio.run(drive())
+    assert reads == 1, f"the queued call read past the abort latch (reads={reads})"

--- a/tests/unit/test_wait_for_human.py
+++ b/tests/unit/test_wait_for_human.py
@@ -1,0 +1,142 @@
+"""Tests for the wait_for_human tool (issue #109)."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import importlib
+import json
+import pkgutil
+from collections.abc import Callable
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import TextContent
+
+import bsu_tool.mcp
+from bsu_tool.guided.human import WaitForHumanResult, ask_human, build_human_server
+
+
+def _collector() -> tuple[list[str], Callable[[str], None]]:
+    """Build a writer that records everything written."""
+    written: list[str] = []
+
+    def write(text: str) -> None:
+        written.append(text)
+
+    return written, write
+
+
+def test_answer_is_returned_stripped() -> None:
+    """A typed answer comes back stripped, with the question shown first."""
+    written, write = _collector()
+    result = ask_human("what do you see?", write=write, read=lambda: "  two relays, one LED  ")
+    assert result == WaitForHumanResult(answer="two relays, one LED", aborted=False, reason=None)
+    assert any("what do you see?" in text for text in written)
+
+
+def test_eof_aborts_cleanly() -> None:
+    """Closed input aborts the exchange instead of raising or hanging."""
+
+    def read() -> str:
+        raise EOFError
+
+    _, write = _collector()
+    result = ask_human("plug it in now", write=write, read=read)
+    assert result.aborted
+    assert result.answer is None
+    assert result.reason is not None and "EOFError" in result.reason
+
+
+def test_terminal_hangup_aborts_cleanly() -> None:
+    """An OSError from a dead terminal aborts cleanly rather than crashing."""
+
+    def read() -> str:
+        raise OSError("device gone")
+
+    _, write = _collector()
+    result = ask_human("did anything happen?", write=write, read=read)
+    assert result.aborted
+    assert result.reason is not None and "OSError" in result.reason
+
+
+def test_keyboard_interrupt_is_not_swallowed() -> None:
+    """Ctrl-c must reach the guided command, not turn into a normal result."""
+
+    def read() -> str:
+        raise KeyboardInterrupt
+
+    _, write = _collector()
+    try:
+        ask_human("plug it in", write=write, read=read)
+    except KeyboardInterrupt:
+        return
+    raise AssertionError("KeyboardInterrupt should propagate, not be swallowed")
+
+
+def test_server_exposes_only_wait_for_human_tool() -> None:
+    """The in-process server registers exactly the wait_for_human tool."""
+    server = build_human_server(write=lambda text: None, read=lambda: "yes")
+    tools = asyncio.run(server.list_tools())
+    assert [tool.name for tool in tools] == ["wait_for_human"]
+
+
+def _call(server: FastMCP, question: str) -> dict[str, object]:
+    """Call wait_for_human through the server and parse its JSON payload."""
+    content = asyncio.run(server.call_tool("wait_for_human", {"question": question}))
+    assert isinstance(content, list)
+    block = content[0]
+    assert isinstance(block, TextContent)
+    result: dict[str, object] = json.loads(block.text)
+    return result
+
+
+def test_server_tool_round_trip_returns_answer() -> None:
+    """Calling the tool through the server returns the analyst's typed answer."""
+    server = build_human_server(write=lambda text: None, read=lambda: "audible click")
+    payload = _call(server, "did it click?")
+    assert payload == {"answer": "audible click", "aborted": False, "reason": None}
+
+
+def test_abort_is_latched_so_repeated_calls_do_not_spin() -> None:
+    """After an abort, later calls return aborted without touching the reader again."""
+    reads = 0
+
+    def read() -> str:
+        nonlocal reads
+        reads += 1
+        raise EOFError
+
+    server = build_human_server(write=lambda text: None, read=read)
+    first = _call(server, "one?")
+    second = _call(server, "two?")
+    assert first["aborted"] is True
+    assert second["aborted"] is True
+    assert reads == 1  # the reader was not called again after the latch
+
+
+def test_default_reader_is_input() -> None:
+    """The default reader reads from stdin, the terminal-owning path."""
+    captured: list[str] = []
+    original = builtins.input
+    builtins.input = lambda: "typed answer"  # type: ignore[assignment]
+    try:
+        server = build_human_server(write=captured.append)
+        payload = _call(server, "q?")
+    finally:
+        builtins.input = original
+    assert payload["answer"] == "typed answer"
+
+
+def test_mcp_package_never_imports_guided() -> None:
+    """The stdio MCP server package must not import the terminal-reading guided code.
+
+    This is the load-bearing safety property: if any bsu_tool.mcp module pulled
+    in bsu_tool.guided, the stdin-reading tool could end up on the transport.
+    """
+    for module in pkgutil.walk_packages(bsu_tool.mcp.__path__, prefix="bsu_tool.mcp."):
+        loaded = importlib.import_module(module.name)
+        source = getattr(loaded, "__file__", None)
+        if source is None:
+            continue
+        with open(source, encoding="utf-8") as handle:
+            assert "bsu_tool.guided" not in handle.read(), f"{module.name} imports bsu_tool.guided"


### PR DESCRIPTION
## What does this PR do?

Adds the `wait_for_human` MCP tool for guided capture sessions. The guided flow
stops repeatedly to ask the analyst a question and wait for a typed answer (what
do you see on the board, plug it in now, did anything happen). This exposes that
as a tool a model can call.

Closes #109.

### The placement constraint, which is the whole design

This tool MUST NOT live in `bsu_tool.mcp.server`. That server speaks MCP over
stdio, so its stdin is the transport, and a tool that reads stdin there would
corrupt the protocol. It lives in `bsu_tool/guided/`, an in-process server owned
by the guided-capture command (#112), which holds the real terminal. Nothing in
`bsu_tool.mcp` imports `bsu_tool.guided`, and a test enforces that.

### How it works

- `ask_human(question, write, read)` prints the question and blocks for one line
  of input. The reader and writer are injected, so the guided command passes the
  real terminal and tests pass fakes.
- The MCP tool is async and offloads the blocking read to a worker thread, so a
  slow analyst never blocks the event loop the agent session runs on.
- `_HumanChannel` latches the abort. Once input ends, every later call returns
  the same aborted result without touching the reader again, so a model that
  keeps calling after an abort does not spin on instant failures.
- End of input and a dead terminal (`EOFError`, `OSError`, `RuntimeError`,
  `ValueError`, `UnicodeDecodeError`) all abort cleanly. `KeyboardInterrupt` is
  left to propagate, so ctrl-c stays the analyst's way out of the command.

## How was it tested?

`tests/unit/test_wait_for_human.py`, 9 tests: the answer round trip, EOF and
terminal-hangup aborts, ctrl-c propagating rather than being swallowed, the
server exposing exactly one tool, the abort latch not re-reading, the default
reader being `input`, and the safety property that no `bsu_tool.mcp` module
imports `bsu_tool.guided`.

`ruff`, `ruff format`, `pyright --strict`, `pytest` all clean.

## Review notes

- **The command that wires this in is #112.** This PR ships the tool and its
  contract. How the guided-capture command registers it into an agent session,
  including whether the agent SDK wants a `FastMCP` or its own server config, is
  #112's job and is not settled here.
- **The output model has no MCP schema.** `WaitForHumanResult` uses `slots=True`,
  which stops pydantic building an output schema, so the tool returns JSON text
  with no advertised schema. This matches the existing repo tools `list_markers`
  and `packets_between_markers`, so it is house convention rather than a new gap.
