### PR TITLE
103/device identity vid pid

### DIFF
--- a/bsu_tool/__main__.py
+++ b/bsu_tool/__main__.py
@@ -208,19 +208,13 @@ def main(argv: list[str] | None = None) -> None:
 
     sniff_cmd = subparsers.add_parser(
         "sniff",
-        help="Capture USB traffic from one device to a pcap-ng file (Linux only)",
+        help="Capture all USB traffic on one bus to a pcap-ng file (Linux only)",
     )
     sniff_cmd.add_argument(
         "--bus",
         type=int,
         required=True,
-        help="usbmon bus number (the N in /dev/usbmonN), as shown by lsusb",
-    )
-    sniff_cmd.add_argument(
-        "--device",
-        type=int,
-        default=None,
-        help="USB device number on that bus, as shown by lsusb; omit to capture all devices on the bus (bus-only)",
+        help="usbmon bus number (the N in /dev/usbmonN), as shown by lsusb; 0 captures every bus",
     )
     sniff_cmd.add_argument(
         "output",
@@ -257,7 +251,7 @@ def main(argv: list[str] | None = None) -> None:
         # machines, where fcntl is absent.
         from bsu_tool.sniff_command import run_sniff
 
-        run_sniff(args.bus, args.device, Path(args.output))
+        run_sniff(args.bus, Path(args.output))
         return
 
     if args.command == "detect-device":

--- a/bsu_tool/analysis/pairing.py
+++ b/bsu_tool/analysis/pairing.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import statistics
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Final
 
 from bsu_tool.analysis.models import IncompleteTransferReason, ResponseTimingStats
@@ -148,8 +148,17 @@ class IncompleteTransferEvent:
 
 @dataclass(frozen=True, slots=True)
 class PairingResult:
-    """Everything the pairing pass produced from one set of transactions."""
+    """Everything the pairing pass produced for **one device**.
 
+    One result per device, mirroring
+    :func:`~bsu_tool.analyzer.detect_repeated_sequences`. Captures are bus-wide,
+    so a single capture routinely holds a target device alongside root hubs and
+    unrelated peripherals. A capture-wide result would let ``response_timing``
+    average a fingerprint reader together with a hub's interrupt polling, with
+    nothing in the value to say it had done so.
+    """
+
+    device_id: str
     pairs: tuple[CommandResponsePair, ...]
     unanswered_commands: tuple[UnpairedCommand, ...]
     unsolicited_responses: tuple[UnpairedResponse, ...]
@@ -161,13 +170,25 @@ class PairingResult:
     analysis_notes: tuple[str, ...]
 
 
+@dataclass
+class _DeviceAccumulator:
+    """Per-device working state for one pairing pass."""
+
+    events: list[AnalysisEvent] = field(default_factory=lambda: list[AnalysisEvent]())
+    incomplete: list[IncompleteTransferEvent] = field(default_factory=lambda: list[IncompleteTransferEvent]())
+    vendor_requests: list[int] = field(default_factory=lambda: list[int]())
+    vendor_endpoints: set[int] = field(default_factory=lambda: set[int]())
+    failed_count: int = 0
+
+
 def pair_command_responses(
     transactions: tuple[UrbTransaction, ...],
     *,
     device_ids: DeviceIdMap,
+    device_id: str | None = None,
     timeout_seconds: float = COMMAND_RESPONSE_TIMEOUT_SECONDS,
-) -> PairingResult:
-    """Run the section 4.1 pairing pass over decoded transactions.
+) -> tuple[PairingResult, ...]:
+    """Run the section 4.1 pairing pass over decoded transactions, one result per device.
 
     Args:
         transactions: The ``UrbTransaction`` objects from a loaded capture,
@@ -175,19 +196,20 @@ def pair_command_responses(
         device_ids: ``Capture.device_ids``, mapping each observed address to the
             device that owns it. Lanes are keyed on the resolved id so a device
             that re-addresses mid-capture stays one lane.
+        device_id: Restrict the pass to one device. ``None`` analyzes each
+            device seen in the capture.
         timeout_seconds: Maximum capture-time gap for an IN to answer an OUT.
 
     Returns:
-        A :class:`PairingResult`. Failed events and standard Control traffic
-        are counted, never promoted. Events whose missing half fell outside
-        the capture are reported as incomplete transfers instead of unanswered
-        or unsolicited, because a capture boundary explains them.
+        One :class:`PairingResult` per device, sorted by ``device_id``. A device
+        whose traffic is entirely Control still gets a result, so it reports
+        itself rather than vanishing. An unknown ``device_id`` yields an empty
+        tuple. Failed events and standard Control traffic are counted, never
+        promoted. Events whose missing half fell outside the capture are
+        reported as incomplete transfers instead of unanswered or unsolicited,
+        because a capture boundary explains them.
     """
-    events: list[AnalysisEvent] = []
-    incomplete: list[IncompleteTransferEvent] = []
-    vendor_requests: list[int] = []
-    vendor_endpoints: set[int] = set()
-    failed_count = 0
+    devices: dict[str, _DeviceAccumulator] = {}
     capture_end = 0.0
 
     for transaction in transactions:
@@ -203,30 +225,57 @@ def pair_command_responses(
         record = transaction.submission or transaction.completion
         if record is None:
             continue
+
+        owner = resolve_device_id(device_ids, record)
+        # Filter here rather than after accumulating: a device excluded by the
+        # caller should not appear in the results at all.
+        if device_id is not None and owner != device_id:
+            continue
+        accumulator = devices.setdefault(owner, _DeviceAccumulator())
+
         if record.transfer_type == "control":
             request = _vendor_control_request(transaction)
             if request is not None:
-                vendor_requests.append(request)
-                vendor_endpoints.add(record.endpoint)
+                accumulator.vendor_requests.append(request)
+                accumulator.vendor_endpoints.add(record.endpoint)
             continue
 
         event = _to_event(transaction, device_ids)
         if event is None:
-            incomplete.append(_incomplete_from(transaction, device_ids))
+            accumulator.incomplete.append(_incomplete_from(transaction, device_ids))
             continue
         if event.boundary_orphan:
             # A URB in flight at a capture edge is a lifecycle orphan, not a
             # protocol-level unanswered or unsolicited event.
             reason: IncompleteTransferReason = "orphan_submission" if event.direction == "out" else "orphan_completion"
-            incomplete.append(_incomplete_from_event(event, reason))
+            accumulator.incomplete.append(_incomplete_from_event(event, reason))
             continue
         if not event.successful:
-            failed_count += 1
+            accumulator.failed_count += 1
         # Failed events stay in the lane. Spec section 4.1 step 2 keeps them
         # visible so a failed OUT or IN does not turn a nearby event into a
         # false unanswered command or unsolicited response.
-        events.append(event)
+        accumulator.events.append(event)
 
+    return tuple(
+        _result_for(device, accumulator, capture_end, timeout_seconds)
+        for device, accumulator in sorted(devices.items())
+    )
+
+
+def _result_for(
+    device_id: str,
+    accumulator: _DeviceAccumulator,
+    capture_end: float,
+    timeout_seconds: float,
+) -> PairingResult:
+    """Pair one device's lanes and assemble its result.
+
+    ``capture_end`` stays capture-wide rather than per-device: it marks when the
+    recording stopped, which is the same instant for every device, and is what
+    the section 4.1 step 5 boundary suppression measures against.
+    """
+    events = accumulator.events
     # Sort by timestamp, and on an exact tie put OUT before IN so a command and
     # its same-microsecond response are not inverted into unsolicited/unanswered.
     events.sort(key=lambda event: (event.timestamp, 0 if event.direction == "out" else 1))
@@ -235,43 +284,42 @@ def pair_command_responses(
     unanswered: list[UnpairedCommand] = []
     unsolicited: list[UnpairedResponse] = []
 
-    # Scope is device and endpoint number only, per spec section 4.1. Transfer
-    # type is determined by (device, endpoint number, direction) in USB, so it
-    # is not part of the key.
-    #
-    # The device half is the resolved device_id, not the bus/address pair. A
-    # device answers at address 0 while enumerating and takes a new address on
-    # every replug, so keying on the address would split one device into a lane
-    # per address and leave a command before a replug unable to pair with the
-    # response after it.
-    lanes: dict[tuple[str, int], list[AnalysisEvent]] = {}
+    # Scope within a device is the endpoint number, per spec section 4.1.
+    # Transfer type is determined by (device, endpoint number, direction) in
+    # USB, so it is not part of the key. The device half of the scope is already
+    # settled: events reached here bucketed by their resolved device_id, which
+    # is what keeps a device that re-addresses mid-capture in one lane instead
+    # of one lane per address.
+    lanes: dict[int, list[AnalysisEvent]] = {}
     for event in events:
-        key = (event.device_id, event.endpoint_number)
-        lanes.setdefault(key, []).append(event)
+        lanes.setdefault(event.endpoint_number, []).append(event)
 
     for lane_events in lanes.values():
         _pair_lane(lane_events, timeout_seconds, capture_end, pairs, unanswered, unsolicited)
 
     notes: list[str] = []
-    if vendor_requests:
-        codes = ", ".join(f"0x{code:02X}" for code in sorted(set(vendor_requests)))
-        endpoints = ", ".join(f"ep{number}" for number in sorted(vendor_endpoints))
+    if accumulator.vendor_requests:
+        codes = ", ".join(f"0x{code:02X}" for code in sorted(set(accumulator.vendor_requests)))
+        endpoints = ", ".join(f"ep{number}" for number in sorted(accumulator.vendor_endpoints))
         notes.append(
-            f"{len(vendor_requests)} vendor-specific control transfers seen on {endpoints} "
+            f"{len(accumulator.vendor_requests)} vendor-specific control transfers seen on {endpoints} "
             f"(requests {codes}), not included in pattern detection"
         )
-    if failed_count:
-        notes.append(f"{failed_count} failed bulk/interrupt events kept visible, not promoted into pairs")
+    if accumulator.failed_count:
+        notes.append(f"{accumulator.failed_count} failed bulk/interrupt events kept visible, not promoted into pairs")
+    if not events and not accumulator.incomplete:
+        notes.append("no bulk or interrupt traffic for this device, nothing to pair")
 
     return PairingResult(
+        device_id=device_id,
         pairs=tuple(pairs),
         unanswered_commands=tuple(unanswered),
         unsolicited_responses=tuple(unsolicited),
-        incomplete_transfers=tuple(incomplete),
+        incomplete_transfers=tuple(accumulator.incomplete),
         response_timing=_timing_stats(pairs),
-        vendor_control_count=len(vendor_requests),
-        vendor_control_requests=tuple(sorted(set(vendor_requests))),
-        failed_event_count=failed_count,
+        vendor_control_count=len(accumulator.vendor_requests),
+        vendor_control_requests=tuple(sorted(set(accumulator.vendor_requests))),
+        failed_event_count=accumulator.failed_count,
         analysis_notes=tuple(notes),
     )
 

--- a/bsu_tool/analysis/pairing.py
+++ b/bsu_tool/analysis/pairing.py
@@ -10,6 +10,12 @@ A single transaction is never a pair. One transaction is one URB id lifecycle,
 while a command/response pair is a protocol level relationship between two
 directional events.
 
+"Same device" means the same resolved ``device_id``, not the same bus/address
+pair. A device answers at address 0 while the kernel reads its descriptors and
+takes a fresh address on every replug, so an address-keyed lane would split one
+device several ways and lose any exchange that straddles a replug. Callers pass
+``Capture.device_ids`` for that resolution.
+
 Scope, per spec section 4.2: standard Control transfers are excluded entirely.
 Vendor specific Control transfers are counted and reported in the result notes,
 and are not fed into pairing.
@@ -36,6 +42,7 @@ from dataclasses import dataclass
 from typing import Final
 
 from bsu_tool.analysis.models import IncompleteTransferReason, ResponseTimingStats
+from bsu_tool.device_identity import DeviceIdMap, resolve_device_id
 from bsu_tool.urb_decoder import Direction, TransferType, UrbTransaction
 
 COMMAND_RESPONSE_TIMEOUT_SECONDS: Final[float] = 5.0
@@ -61,8 +68,7 @@ _REQUEST_TYPE_MASK: Final[int] = 0x03
 class AnalysisEvent:
     """One directional, payload-bearing event derived from a transaction."""
 
-    bus_num: int
-    dev_num: int
+    device_id: str
     endpoint_number: int
     endpoint_address: str
     direction: Direction
@@ -79,8 +85,7 @@ class AnalysisEvent:
 class CommandResponsePair:
     """A likely command and its response on one endpoint lane."""
 
-    bus_num: int
-    dev_num: int
+    device_id: str
     endpoint_number: int
     command: AnalysisEvent
     response: AnalysisEvent
@@ -101,8 +106,7 @@ class UnpairedCommand:
     the aggregated :class:`bsu_tool.analysis.models.UnansweredCommand`.
     """
 
-    bus_num: int
-    dev_num: int
+    device_id: str
     endpoint_number: int
     endpoint_address: str
     transfer_type: TransferType
@@ -118,8 +122,7 @@ class UnpairedResponse:
     the aggregated :class:`bsu_tool.analysis.models.UnsolicitedResponse`.
     """
 
-    bus_num: int
-    dev_num: int
+    device_id: str
     endpoint_number: int
     endpoint_address: str
     transfer_type: TransferType
@@ -135,8 +138,7 @@ class IncompleteTransferEvent:
     :class:`bsu_tool.analysis.models.IncompleteTransfer`.
     """
 
-    bus_num: int
-    dev_num: int
+    device_id: str
     endpoint_number: int
     endpoint_address: str
     direction: Direction
@@ -162,6 +164,7 @@ class PairingResult:
 def pair_command_responses(
     transactions: tuple[UrbTransaction, ...],
     *,
+    device_ids: DeviceIdMap,
     timeout_seconds: float = COMMAND_RESPONSE_TIMEOUT_SECONDS,
 ) -> PairingResult:
     """Run the section 4.1 pairing pass over decoded transactions.
@@ -169,6 +172,9 @@ def pair_command_responses(
     Args:
         transactions: The ``UrbTransaction`` objects from a loaded capture,
             exactly as ``Capture.transactions`` holds them.
+        device_ids: ``Capture.device_ids``, mapping each observed address to the
+            device that owns it. Lanes are keyed on the resolved id so a device
+            that re-addresses mid-capture stays one lane.
         timeout_seconds: Maximum capture-time gap for an IN to answer an OUT.
 
     Returns:
@@ -204,9 +210,9 @@ def pair_command_responses(
                 vendor_endpoints.add(record.endpoint)
             continue
 
-        event = _to_event(transaction)
+        event = _to_event(transaction, device_ids)
         if event is None:
-            incomplete.append(_incomplete_from(transaction))
+            incomplete.append(_incomplete_from(transaction, device_ids))
             continue
         if event.boundary_orphan:
             # A URB in flight at a capture edge is a lifecycle orphan, not a
@@ -232,9 +238,15 @@ def pair_command_responses(
     # Scope is device and endpoint number only, per spec section 4.1. Transfer
     # type is determined by (device, endpoint number, direction) in USB, so it
     # is not part of the key.
-    lanes: dict[tuple[int, int, int], list[AnalysisEvent]] = {}
+    #
+    # The device half is the resolved device_id, not the bus/address pair. A
+    # device answers at address 0 while enumerating and takes a new address on
+    # every replug, so keying on the address would split one device into a lane
+    # per address and leave a command before a replug unable to pair with the
+    # response after it.
+    lanes: dict[tuple[str, int], list[AnalysisEvent]] = {}
     for event in events:
-        key = (event.bus_num, event.dev_num, event.endpoint_number)
+        key = (event.device_id, event.endpoint_number)
         lanes.setdefault(key, []).append(event)
 
     for lane_events in lanes.values():
@@ -344,8 +356,7 @@ def _record_unanswered(
     """File an unpaired OUT as an unanswered command."""
     unanswered.append(
         UnpairedCommand(
-            bus_num=event.bus_num,
-            dev_num=event.dev_num,
+            device_id=event.device_id,
             endpoint_number=event.endpoint_number,
             endpoint_address=event.endpoint_address,
             transfer_type=event.transfer_type,
@@ -362,8 +373,7 @@ def _record_unsolicited(
     """File an unpaired IN as an unsolicited response."""
     unsolicited.append(
         UnpairedResponse(
-            bus_num=event.bus_num,
-            dev_num=event.dev_num,
+            device_id=event.device_id,
             endpoint_number=event.endpoint_number,
             endpoint_address=event.endpoint_address,
             transfer_type=event.transfer_type,
@@ -381,8 +391,7 @@ def _build_pair(command: AnalysisEvent, response: AnalysisEvent) -> CommandRespo
         echoed += 1
     differing = tuple(index for index in range(compare) if command.data[index] != response.data[index])
     return CommandResponsePair(
-        bus_num=command.bus_num,
-        dev_num=command.dev_num,
+        device_id=command.device_id,
         endpoint_number=command.endpoint_number,
         command=command,
         response=response,
@@ -393,7 +402,7 @@ def _build_pair(command: AnalysisEvent, response: AnalysisEvent) -> CommandRespo
     )
 
 
-def _to_event(transaction: UrbTransaction) -> AnalysisEvent | None:
+def _to_event(transaction: UrbTransaction, device_ids: DeviceIdMap) -> AnalysisEvent | None:
     """Build the payload-bearing analysis event for one transaction.
 
     OUT commands take their payload from the submission record. IN responses
@@ -416,8 +425,7 @@ def _to_event(transaction: UrbTransaction) -> AnalysisEvent | None:
     status = transaction.completion.status if transaction.completion is not None else None
     successful = status == 0
     return AnalysisEvent(
-        bus_num=payload.bus_num,
-        dev_num=payload.dev_num,
+        device_id=resolve_device_id(device_ids, payload),
         endpoint_number=payload.endpoint,
         endpoint_address=_endpoint_address(payload.endpoint, payload.direction),
         direction=payload.direction,
@@ -430,7 +438,7 @@ def _to_event(transaction: UrbTransaction) -> AnalysisEvent | None:
     )
 
 
-def _incomplete_from(transaction: UrbTransaction) -> IncompleteTransferEvent:
+def _incomplete_from(transaction: UrbTransaction, device_ids: DeviceIdMap) -> IncompleteTransferEvent:
     """Build an incomplete-transfer record for a transaction with no payload side.
 
     The reason follows which half survived. A submission with no completion is
@@ -446,8 +454,7 @@ def _incomplete_from(transaction: UrbTransaction) -> IncompleteTransferEvent:
         record = transaction.completion
         reason = "orphan_completion"
     return IncompleteTransferEvent(
-        bus_num=record.bus_num,
-        dev_num=record.dev_num,
+        device_id=resolve_device_id(device_ids, record),
         endpoint_number=record.endpoint,
         endpoint_address=_endpoint_address(record.endpoint, record.direction),
         direction=record.direction,
@@ -459,8 +466,7 @@ def _incomplete_from(transaction: UrbTransaction) -> IncompleteTransferEvent:
 def _incomplete_from_event(event: AnalysisEvent, reason: IncompleteTransferReason) -> IncompleteTransferEvent:
     """Build an incomplete-transfer record from an event at a capture boundary."""
     return IncompleteTransferEvent(
-        bus_num=event.bus_num,
-        dev_num=event.dev_num,
+        device_id=event.device_id,
         endpoint_number=event.endpoint_number,
         endpoint_address=event.endpoint_address,
         direction=event.direction,

--- a/bsu_tool/analyzer.py
+++ b/bsu_tool/analyzer.py
@@ -37,6 +37,7 @@ from bsu_tool.analysis.models import (
     TransferType,
     VariableByteRange,
 )
+from bsu_tool.device_identity import DeviceIdMap, resolve_device_id
 from bsu_tool.urb_decoder import UrbRecord, UrbTransaction
 
 
@@ -49,6 +50,7 @@ class CaptureLike(Protocol):
 
     records: tuple[UrbRecord, ...]
     transactions: tuple[UrbTransaction, ...]
+    device_ids: DeviceIdMap
 
 
 # --- Configuration constants (spec §7) ------------------------------------
@@ -264,7 +266,7 @@ def build_analysis_events(capture: CaptureLike, *, device_id: str | None = None)
 
     Args:
         capture: The loaded capture to read.
-        device_id: Restrict to one ``dev_bbb_ddd`` device; ``None`` keeps all.
+        device_id: Restrict to one device by its ``device_id``; ``None`` keeps all.
 
     Returns:
         Events in capture order, plus notes on what was excluded.
@@ -277,7 +279,7 @@ def build_analysis_events(capture: CaptureLike, *, device_id: str | None = None)
         reference = transaction.submission or transaction.completion
         if reference is None:  # pair_urbs guarantees at least one side
             continue
-        device = _device_id(reference)
+        device = resolve_device_id(capture.device_ids, reference)
         if device_id is not None and device != device_id:
             continue
         # Tallies are per device: a capture-wide count reported on one device's
@@ -306,7 +308,7 @@ def build_analysis_events(capture: CaptureLike, *, device_id: str | None = None)
         events.append(
             AnalysisEvent(
                 packet_index=index_of[id(payload_record)],
-                device_id=_device_id(payload_record),
+                device_id=resolve_device_id(capture.device_ids, payload_record),
                 endpoint_number=payload_record.endpoint,
                 endpoint_address=f"0x{_endpoint_address(payload_record):02x}",
                 direction=payload_record.direction,
@@ -337,14 +339,6 @@ def _setup_of(transaction: UrbTransaction) -> bytes | None:
 def _is_vendor_request(setup: bytes) -> bool:
     """Whether a setup packet's bmRequestType marks a vendor-specific request."""
     return (setup[0] >> _REQUEST_TYPE_SHIFT) & _REQUEST_TYPE_MASK == _VENDOR_REQUEST_TYPE
-
-
-def _device_id(record: UrbRecord) -> str:
-    """Format a bus/device pair as ``dev_bbb_ddd``.
-
-    Must match ``bsu_tool.session._device_id``; the ids are compared across tools.
-    """
-    return f"dev_{record.bus_num:03d}_{record.dev_num:03d}"
 
 
 def _endpoint_address(record: UrbRecord) -> int:
@@ -661,7 +655,7 @@ def detect_repeated_sequences(
 
     Args:
         capture: The loaded capture to analyze.
-        device_id: Restrict to one ``dev_bbb_ddd`` device; ``None`` analyzes each
+        device_id: Restrict to one device by its ``device_id``; ``None`` analyzes each
             device independently.
         scope: ``"device"`` counts over a device's whole stream, needed to see
             command/response cycles crossing endpoint numbers.

--- a/bsu_tool/device_identity.py
+++ b/bsu_tool/device_identity.py
@@ -1,0 +1,91 @@
+"""How a USB device is identified across a capture.
+
+A URB header carries only ``(bus, dev)``, and that pair does not name a physical
+device for the length of a capture. A device answers at address 0 while the
+kernel reads its descriptors, moves to the address ``SET_ADDRESS`` assigns, and
+takes a fresh one on every replug — so one device routinely occupies several
+addresses in a single file.
+
+Identity therefore keys on **vid:pid**, read from the device descriptor, with
+the address pair demoted to an observation. Where a capture holds no device
+descriptor for an address, vid:pid is unknowable and the address id is the
+honest fallback.
+
+This module is deliberately dependency-free so both :mod:`bsu_tool.session`
+(which builds the map) and :mod:`bsu_tool.analyzer` (which reads it) can share
+one definition. Session imports analyzer, so the reverse import would be
+circular — that is what previously forced a second, hand-synchronised copy.
+
+Serial numbers are **not** part of an id. An id propagates into every packet
+record and every serialized session, and a serial is a per-unit fingerprint;
+read it from ``get_enumeration`` when it is genuinely needed.
+"""
+
+from __future__ import annotations
+
+from bsu_tool.urb_decoder import UrbRecord
+
+#: Map from an observed ``(bus_num, dev_num)`` address to its resolved device id.
+DeviceIdMap = dict[tuple[int, int], str]
+
+
+def identity_device_id(vendor_id: int, product_id: int) -> str:
+    """Return the ``vid_pid`` id for a device whose descriptor was captured.
+
+    Lowercase hex with no ``0x`` prefix (e.g. ``27c6_63ac``), matching the
+    device-record and capture-filename conventions so ids line up across the
+    tool and the record repository.
+
+    Args:
+        vendor_id: ``idVendor`` from the device descriptor.
+        product_id: ``idProduct`` from the device descriptor.
+
+    Returns:
+        The stable identity id for this device.
+    """
+    return f"{vendor_id:04x}_{product_id:04x}"
+
+
+def address_device_id(bus_num: int, dev_num: int) -> str:
+    """Return the ``dev_bbb_ddd`` fallback id for an unidentifiable device.
+
+    Used when a capture contains no device descriptor for the address, leaving
+    vid:pid unknown. This id is **not** stable across a replug — that is the
+    property it lacks and :func:`identity_device_id` provides.
+
+    Args:
+        bus_num: USB bus number.
+        dev_num: Device address on that bus.
+
+    Returns:
+        The address-derived fallback id.
+    """
+    return f"dev_{bus_num:03d}_{dev_num:03d}"
+
+
+def resolve_device_id(device_ids: DeviceIdMap, record: UrbRecord) -> str:
+    """Return the device id owning ``record``'s address.
+
+    Falls back to the address id when the address is absent from the map, so the
+    lookup is total even for a record from outside the capture the map was built
+    from.
+
+    Args:
+        device_ids: Address-to-id map for the capture being read.
+        record: The decoded URB record to attribute.
+
+    Returns:
+        The resolved device id.
+    """
+    resolved = device_ids.get((record.bus_num, record.dev_num))
+    if resolved is not None:
+        return resolved
+    return address_device_id(record.bus_num, record.dev_num)
+
+
+__all__ = [
+    "DeviceIdMap",
+    "address_device_id",
+    "identity_device_id",
+    "resolve_device_id",
+]

--- a/bsu_tool/mcp/interfaces.py
+++ b/bsu_tool/mcp/interfaces.py
@@ -3,8 +3,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal, TypeAlias
 
 from bsu_tool.urb_decoder import Direction, EventType, TransferType
+
+IdentitySource: TypeAlias = Literal["descriptors", "host", "address"]
+"""Where a :class:`DeviceSummary`'s identity came from.
+
+``"descriptors"`` — vid:pid was read from a device descriptor inside the
+capture. Portable: it holds for any reader of the file.
+
+``"host"`` — vid:pid came from a sysfs snapshot taken on the capturing host.
+Reserved; no code path produces it yet.
+
+``"address"`` — no descriptor was captured, so the device is known only by the
+bus/address it occupied. Not stable across a replug.
+"""
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,8 +64,28 @@ class EndpointSummary:
 
 
 @dataclass(frozen=True, slots=True)
+class DeviceAddress:
+    """One bus/address a device occupied during a capture.
+
+    A device answers at address 0 while the kernel reads its descriptors, then
+    moves to the address ``SET_ADDRESS`` assigns, and takes a fresh one on every
+    replug. So one physical device routinely occupies several of these within a
+    single capture.
+    """
+
+    bus_num: int
+    dev_num: int
+
+
+@dataclass(frozen=True, slots=True)
 class DeviceSummary:
-    """A USB device observed in a loaded capture."""
+    """A USB device observed in a loaded capture.
+
+    Identity is keyed on vid:pid when the capture contains a device descriptor,
+    so a device that re-addresses mid-capture is reported once rather than once
+    per address. ``bus_num``/``dev_num`` are the *last* address observed — the
+    operational one — and ``addresses`` lists every address the device held.
+    """
 
     device_id: str
     bus_num: int
@@ -66,6 +100,13 @@ class DeviceSummary:
     descriptor_summary: str | None = None
     device_class: int | None = None  # bDeviceClass; often 0x00/0xef for composite devices
     interface_class: int | None = None  # first interface's bInterfaceClass; 0xff marks vendor-specific
+    addresses: tuple[DeviceAddress, ...] = ()
+    identity_source: IdentitySource = "address"
+    # Whether the device *reports* a serial number (iSerialNumber != 0). The value
+    # is deliberately not carried here: device_id propagates into every packet
+    # record and every serialized session, and a serial is a unit fingerprint.
+    # Read it from get_enumeration when it is genuinely needed.
+    has_serial: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/bsu_tool/mcp/tools/devices.py
+++ b/bsu_tool/mcp/tools/devices.py
@@ -56,7 +56,7 @@ def register(mcp: FastMCP, session: Session) -> None:
         enumeration, and reports the packet-index range of the enumeration
         phase — the standard endpoint-0 control transfers that precede the
         device's runtime traffic. Use this to learn what a device is before
-        interpreting its vendor protocol. ``device_id`` is a ``dev_bbb_ddd``
+        interpreting its vendor protocol. ``device_id`` is an id
         id from list_devices.
         """
         return session.get_enumeration(device_id)

--- a/bsu_tool/mcp/tools/live_capture.py
+++ b/bsu_tool/mcp/tools/live_capture.py
@@ -15,7 +15,6 @@ class StartCaptureResult:
     """Confirmation that a live capture is running."""
 
     bus: int
-    device: int | None
     output_path: str
 
 
@@ -25,8 +24,7 @@ class StopCaptureResult:
 
     output_path: str
     output_bytes: int
-    events_seen: int
-    events_matched: int
+    events_captured: int
     elapsed_seconds: float
     packet_count: int
     device_ids: tuple[str, ...]
@@ -39,17 +37,19 @@ def register(mcp: FastMCP, session: Session) -> None:
     def start_capture(  # pyright: ignore[reportUnusedFunction]
         bus: int,
         output_path: str,
-        device: int | None = None,
     ) -> StartCaptureResult:
         """Start a live usbmon capture and return once it is verifiably running.
 
         After this returns, instruct the analyst to operate the device, then
         call stop_capture to end the capture and load the result for analysis.
 
-        - bus: usbmon bus number (the N in /dev/usbmonN).
-        - device: USB device number on that bus, or omit for bus-only capture.
-          Bus-only is the right default when the capture should include
-          enumeration, since device addresses shift while a device enumerates.
+        Capture is bus-wide — every device on the bus is recorded. There is no
+        device filter, because a device's address changes as it enumerates and
+        on every replug, so no single address covers one physical device for a
+        whole capture. Select the device after loading, via the device_id
+        filters on get_packets and packets_between_markers.
+
+        - bus: usbmon bus number (the N in /dev/usbmonN). 0 captures every bus.
         - output_path: destination pcap-ng file; must end with .pcapng and not
           already exist.
 
@@ -74,7 +74,7 @@ def register(mcp: FastMCP, session: Session) -> None:
         capture_started = False
         retry_stop = False
         try:
-            controller.start(bus=bus, device=device, output_path=destination)
+            controller.start(bus=bus, output_path=destination)
             if not controller.is_running:
                 raise CaptureStateError("capture controller returned before the capture was live")
             if not session.mark_live_capture_running(live_capture):
@@ -107,7 +107,7 @@ def register(mcp: FastMCP, session: Session) -> None:
                     session.mark_live_capture_running(live_capture)
                 else:
                     session.release_live_capture(live_capture)
-        return StartCaptureResult(bus=bus, device=device, output_path=str(destination))
+        return StartCaptureResult(bus=bus, output_path=str(destination))
 
     @mcp.tool()
     def stop_capture() -> StopCaptureResult:  # pyright: ignore[reportUnusedFunction]
@@ -140,8 +140,7 @@ def register(mcp: FastMCP, session: Session) -> None:
             return StopCaptureResult(
                 output_path=str(output_path),
                 output_bytes=stats.output_bytes,
-                events_seen=stats.seen,
-                events_matched=stats.matched,
+                events_captured=stats.seen,
                 elapsed_seconds=stats.elapsed_seconds,
                 packet_count=capture.metadata.packet_count,
                 device_ids=tuple(device.device_id for device in session.list_devices()),

--- a/bsu_tool/mcp/tools/markers.py
+++ b/bsu_tool/mcp/tools/markers.py
@@ -86,7 +86,7 @@ def register(mcp: FastMCP, session: Session) -> None:
         the markers themselves are the boundaries and are excluded. Raises if
         either name is unknown or the start marker is anchored after the end marker.
 
-        Pass ``device_id`` (a ``dev_bbb_ddd`` id from list_devices) to keep only
+        Pass ``device_id`` (an id from list_devices) to keep only
         that device's packets within the span, mirroring get_packets; an unknown id
         yields an empty span. When a ``device_id`` is given, ``span_count`` is the
         post-filter total, so pagination stays coherent.

--- a/bsu_tool/mcp/tools/packets.py
+++ b/bsu_tool/mcp/tools/packets.py
@@ -43,7 +43,8 @@ def register(mcp: FastMCP, session: Session) -> None:
         Filters compose — a packet must satisfy all that are given. Two need
         explaining beyond their schema:
 
-        - device_id: a ``dev_bbb_ddd`` id from list_devices.
+        - device_id: an id from list_devices (``vid_pid`` when the capture holds the
+          device's descriptors, otherwise ``dev_bbb_ddd``).
         - endpoint: a decimal endpoint number such as ``"3"`` or ``"15"``. A
           ``0x``-prefixed address like ``"0x83"`` is also accepted (its endpoint
           number is used; direction bit ignored). Direction is orthogonal — use

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -29,15 +29,23 @@ from bsu_tool.descriptors import (
     parse_setup_packet,
     parse_string_descriptor,
 )
+from bsu_tool.device_identity import (
+    DeviceIdMap,
+    address_device_id,
+    identity_device_id,
+    resolve_device_id,
+)
 from bsu_tool.mcp.interfaces import (
     CaptureInterface,
     CaptureMetadata,
     CapturePacket,
+    DeviceAddress,
     DeviceEnumeration,
     DeviceSummary,
     EndpointSummary,
     EnumeratedEndpoint,
     EnumeratedInterface,
+    IdentitySource,
     PacketRecord,
     PacketSelection,
 )
@@ -185,6 +193,18 @@ def _empty_transfer_types() -> set[TransferType]:
     return set()
 
 
+def _empty_addresses() -> list[tuple[int, int]]:
+    return []
+
+
+def _empty_identities() -> set[tuple[int, int]]:
+    return set()
+
+
+def _empty_device_ids() -> DeviceIdMap:
+    return {}
+
+
 def _empty_string_descriptors() -> dict[int, str]:
     return {}
 
@@ -199,6 +219,20 @@ class Capture:
     records: tuple[UrbRecord, ...]
     transactions: tuple[UrbTransaction, ...]
     markers: list[Marker] = field(default_factory=_empty_markers)
+    #: Every ``(bus, dev)`` address in this capture mapped to its resolved device
+    #: id. Derived from the records, so it is never passed in — see __post_init__.
+    device_ids: DeviceIdMap = field(default_factory=_empty_device_ids)
+
+    def __post_init__(self) -> None:
+        """Resolve the address→device-id map so every consumer agrees on ids.
+
+        Computed here rather than at each call site because ``device_id`` reaches
+        packet records, filters and summaries alike; deriving it in one place is
+        what keeps a merged device from being reported under one id and filtered
+        under another.
+        """
+        if not self.device_ids:
+            self.device_ids = _device_ids_by_address(self.records, self.transactions)
 
     def to_dict(self) -> JsonDict:
         """Return a JSON-safe representation of this loaded capture."""
@@ -208,7 +242,9 @@ class Capture:
             "source": str(self.source),
             "metadata": _capture_metadata_to_dict(self.metadata),
             "devices": [_device_summary_to_dict(device) for device in devices],
-            "packets": [_urb_record_to_dict(index, record) for index, record in enumerate(self.records)],
+            "packets": [
+                _urb_record_to_dict(index, record, self.device_ids) for index, record in enumerate(self.records)
+            ],
             "markers": [marker.to_dict() for marker in self.markers],
             "summary": summary.to_dict(),
         }
@@ -241,6 +277,14 @@ _LiveCapturePhase = Literal["starting", "running", "stopping"]
 
 @dataclass
 class _DeviceAccumulator:
+    """Per-device tallies built while walking a capture's records.
+
+    Accumulated per *address* first, because ``(bus, dev)`` is the only identity
+    a URB header carries, then merged by vid:pid in :func:`_merge_by_identity`
+    once descriptors have been parsed. ``addresses`` holds every address folded
+    into this accumulator; ``bus_num``/``dev_num`` track the last one observed.
+    """
+
     bus_num: int
     dev_num: int
     packet_count: int = 0
@@ -250,6 +294,13 @@ class _DeviceAccumulator:
     device_descriptor: DeviceDescriptor | None = None
     configuration: ConfigurationDescriptor | None = None
     string_descriptors: dict[int, str] = field(default_factory=_empty_string_descriptors)
+    addresses: list[tuple[int, int]] = field(default_factory=_empty_addresses)
+    #: Every distinct (vid, pid) a device descriptor reported at this address.
+    #: More than one means two physical devices shared the address — see validate().
+    observed_identities: set[tuple[int, int]] = field(default_factory=_empty_identities)
+    first_index: int = 0
+    last_index: int = 0
+    identity_source: IdentitySource = "address"
 
 
 @dataclass
@@ -410,7 +461,7 @@ class Session:
         Args:
             start_name: Name of the marker anchoring the start of the span.
             end_name: Name of the marker anchoring the end of the span.
-            device_id: Restrict the span to one device by its ``dev_bbb_ddd`` id,
+            device_id: Restrict the span to one device by its ``device_id``,
                 mirroring ``get_packets``. ``None`` keeps every device in range. An
                 unknown id matches nothing and yields an empty span (no error). The
                 returned span's ``count`` is the post-filter total.
@@ -442,9 +493,9 @@ class Session:
         # two anchors; keep each record's original index and drop any that a
         # device_id filter excludes so count reflects the post-filter total.
         packets = tuple(
-            _packet_record(index, records[index])
+            _packet_record(index, records[index], self.capture.device_ids)
             for index in range(start.packet_index + 1, end.packet_index)
-            if device_id is None or _device_id(records[index].bus_num, records[index].dev_num) == device_id
+            if device_id is None or resolve_device_id(self.capture.device_ids, records[index]) == device_id
         )
         return MarkerSpan(start_marker=start, end_marker=end, packets=packets, count=len(packets))
 
@@ -470,7 +521,7 @@ class Session:
         stream — only Isochronous records are dropped at load time.
 
         Args:
-            device_id: Restrict to one device by its ``dev_bbb_ddd`` id.
+            device_id: Restrict to one device by its ``device_id``.
             endpoint: Restrict to one endpoint number in decimal, e.g. ``"3"`` or
                 ``"15"``. A ``0x``-prefixed full address such as ``"0x83"`` is also
                 accepted — only its endpoint number (low nibble) is used, the
@@ -492,10 +543,11 @@ class Session:
         endpoint_number = _normalize_endpoint(endpoint)
         records = self.capture.records
         matches = tuple(
-            _packet_record(index, record)
+            _packet_record(index, record, self.capture.device_ids)
             for index, record in enumerate(records)
             if _record_matches(
                 record,
+                device_ids=self.capture.device_ids,
                 device_id=device_id,
                 endpoint_number=endpoint_number,
                 direction=direction,
@@ -528,7 +580,7 @@ class Session:
         records = self.capture.records
         if not 0 <= index < len(records):
             return None
-        return _packet_record(index, records[index])
+        return _packet_record(index, records[index], self.capture.device_ids)
 
     def detect_repeated_sequences(
         self,
@@ -546,7 +598,7 @@ class Session:
         that function for the normalization and detection rules.
 
         Args:
-            device_id: Restrict analysis to one ``dev_bbb_ddd`` device. ``None``
+            device_id: Restrict analysis to one device by its ``device_id``. ``None``
                 analyzes every device independently.
             scope: ``"device"`` counts sequences across one device's endpoints,
                 which is required to see command/response cycles that cross
@@ -587,7 +639,7 @@ class Session:
         is before interpreting its vendor protocol.
 
         Args:
-            device_id: The ``dev_bbb_ddd`` id of the device, as reported by
+            device_id: The ``device_id`` of the device, as reported by
                 :meth:`list_devices`.
 
         Returns:
@@ -626,6 +678,11 @@ class Session:
         1. The capture decoded no supported URB records (an empty analysis).
         2. A marker anchored outside the decoded record range (a dangling
            reference that ``get_packet`` would resolve to nothing).
+        3. One address reported two different vid:pid identities. Every device
+           enumerates at address 0, so two devices enumerating in one capture
+           share it, and their traffic cannot be told apart by address alone.
+           Whichever identity won absorbed the other's address-0 packets, so the
+           merge is unsafe and the affected device's counts are overstated.
 
         In-flight submissions (no matching completion) and orphan completions
         (submission not captured) are NOT faults: usbmon captures routinely begin
@@ -648,6 +705,7 @@ class Session:
                     f"marker {marker.name!r} references packet index {marker.packet_index} "
                     f"outside the decoded range 0..{len(records) - 1}"
                 )
+        problems.extend(_identity_conflicts(records, self.capture.transactions))
         return problems
 
     def to_dict(self) -> JsonDict:
@@ -825,8 +883,8 @@ def _device_summary_to_dict(device: DeviceSummary) -> JsonDict:
     }
 
 
-def _urb_record_to_dict(index: int, record: UrbRecord) -> JsonDict:
-    packet = _packet_record(index, record)
+def _urb_record_to_dict(index: int, record: UrbRecord, device_ids: DeviceIdMap) -> JsonDict:
+    packet = _packet_record(index, record, device_ids)
     return {
         "index": index,
         "urb_id": record.urb_id,
@@ -980,14 +1038,14 @@ def _decode_supported_packets(packets: list[CapturePacket]) -> tuple[UrbRecord, 
     return tuple(records)
 
 
-def _packet_record(index: int, record: UrbRecord) -> PacketRecord:
+def _packet_record(index: int, record: UrbRecord, device_ids: DeviceIdMap) -> PacketRecord:
     return PacketRecord(
         index=index,
         urb_id=record.urb_id,
         event_type=record.event_type,
         transfer_type=record.transfer_type,
         direction=record.direction,
-        device_id=_device_id(record.bus_num, record.dev_num),
+        device_id=resolve_device_id(device_ids, record),
         bus_num=record.bus_num,
         dev_num=record.dev_num,
         endpoint_address=f"0x{_endpoint_address(record):02x}",
@@ -1033,13 +1091,14 @@ def _normalize_endpoint(endpoint: str | None) -> int | None:
 def _record_matches(
     record: UrbRecord,
     *,
+    device_ids: DeviceIdMap,
     device_id: str | None,
     endpoint_number: int | None,
     direction: Direction | None,
     transfer_type: TransferType | None,
     event_type: EventType | None,
 ) -> bool:
-    if device_id is not None and _device_id(record.bus_num, record.dev_num) != device_id:
+    if device_id is not None and resolve_device_id(device_ids, record) != device_id:
         return False
     if endpoint_number is not None and record.endpoint != endpoint_number:
         return False
@@ -1057,8 +1116,11 @@ def _accumulate_devices(
     transactions: tuple[UrbTransaction, ...],
 ) -> dict[tuple[int, int], _DeviceAccumulator]:
     devices: dict[tuple[int, int], _DeviceAccumulator] = {}
-    for record in records:
+    for index, record in enumerate(records):
         accumulator = _device_accumulator(devices, record.bus_num, record.dev_num)
+        if accumulator.packet_count == 0:
+            accumulator.first_index = index
+        accumulator.last_index = index
         accumulator.packet_count += 1
         addr = _endpoint_address(record)
         accumulator.endpoint_packet_counts[addr] = accumulator.endpoint_packet_counts.get(addr, 0) + 1
@@ -1080,11 +1142,75 @@ def _summarize_devices(
     records: tuple[UrbRecord, ...],
     transactions: tuple[UrbTransaction, ...],
 ) -> tuple[DeviceSummary, ...]:
-    devices = _accumulate_devices(records, transactions)
-    return tuple(
-        _device_summary(accumulator)
-        for _, accumulator in sorted(devices.items(), key=lambda item: (item[0][0], item[0][1]))
-    )
+    merged = _merge_by_identity(_accumulate_devices(records, transactions))
+    # Sorted by first appearance so output order tracks the capture, and so a
+    # merged device sorts where its earliest address did.
+    ordered = sorted(merged.items(), key=lambda item: (item[1].first_index, item[0]))
+    return tuple(_device_summary(device_id, accumulator) for device_id, accumulator in ordered)
+
+
+def _merge_by_identity(
+    devices: dict[tuple[int, int], _DeviceAccumulator],
+) -> dict[str, _DeviceAccumulator]:
+    """Fold address-keyed accumulators into one entry per physical device.
+
+    Accumulators whose captured device descriptor reports the same vid:pid are
+    the same device seen at different addresses — during enumeration, or across
+    a replug — and are merged under a ``vid_pid`` id. An accumulator with no
+    device descriptor cannot be identified that way and is kept on its own,
+    under its ``dev_bbb_ddd`` address id.
+
+    Args:
+        devices: Address-keyed accumulators from :func:`_accumulate_devices`.
+
+    Returns:
+        Accumulators keyed by resolved device id. Each carries every address it
+        absorbed in ``addresses``, with ``bus_num``/``dev_num`` set to the last
+        address observed.
+    """
+    merged: dict[str, _DeviceAccumulator] = {}
+    for (bus_num, dev_num), accumulator in sorted(devices.items()):
+        descriptor = accumulator.device_descriptor
+        if descriptor is None:
+            device_id = address_device_id(bus_num, dev_num)
+            accumulator.identity_source = "address"
+        else:
+            device_id = identity_device_id(descriptor.vendor_id, descriptor.product_id)
+            accumulator.identity_source = "descriptors"
+        accumulator.addresses = [(bus_num, dev_num)]
+
+        existing = merged.get(device_id)
+        if existing is None:
+            merged[device_id] = accumulator
+            continue
+        _absorb(existing, accumulator)
+    return merged
+
+
+def _absorb(target: _DeviceAccumulator, other: _DeviceAccumulator) -> None:
+    """Fold ``other``'s tallies into ``target`` (same physical device)."""
+    target.packet_count += other.packet_count
+    for address, count in other.endpoint_packet_counts.items():
+        target.endpoint_packet_counts[address] = target.endpoint_packet_counts.get(address, 0) + count
+    for address, count in other.endpoint_byte_counts.items():
+        target.endpoint_byte_counts[address] = target.endpoint_byte_counts.get(address, 0) + count
+    target.transfer_types |= other.transfer_types
+    # String descriptors are keyed by index and identical across addresses for one
+    # device; keep any the target has not seen rather than overwriting.
+    for index, text in other.string_descriptors.items():
+        target.string_descriptors.setdefault(index, text)
+    if target.device_descriptor is None:
+        target.device_descriptor = other.device_descriptor
+    if other.configuration is not None and _prefer_configuration(target.configuration, other.configuration):
+        target.configuration = other.configuration
+    target.addresses.extend(other.addresses)
+    target.observed_identities |= other.observed_identities
+    target.first_index = min(target.first_index, other.first_index)
+    if other.last_index > target.last_index:
+        # The most recent address is the operational one, so report that pair.
+        target.last_index = other.last_index
+        target.bus_num = other.bus_num
+        target.dev_num = other.dev_num
 
 
 def _device_accumulator(
@@ -1098,6 +1224,44 @@ def _device_accumulator(
         accumulator = _DeviceAccumulator(bus_num=bus_num, dev_num=dev_num)
         devices[key] = accumulator
     return accumulator
+
+
+def _identity_conflicts(
+    records: tuple[UrbRecord, ...],
+    transactions: tuple[UrbTransaction, ...],
+) -> list[str]:
+    """Report addresses where more than one vid:pid identity was seen.
+
+    Devices all enumerate at address 0, so two of them enumerating within one
+    capture leave descriptors for both under the same address. Merging then
+    attributes every address-0 packet to whichever identity won.
+    """
+    problems: list[str] = []
+    for (bus_num, dev_num), accumulator in sorted(_accumulate_devices(records, transactions).items()):
+        if len(accumulator.observed_identities) <= 1:
+            continue
+        identities = ", ".join(
+            identity_device_id(vendor_id, product_id)
+            for vendor_id, product_id in sorted(accumulator.observed_identities)
+        )
+        problems.append(
+            f"address {bus_num}:{dev_num} reported more than one device identity ({identities}); "
+            f"its packets cannot be attributed by address alone and the merge overstates one device"
+        )
+    return problems
+
+
+def _device_ids_by_address(
+    records: tuple[UrbRecord, ...],
+    transactions: tuple[UrbTransaction, ...],
+) -> DeviceIdMap:
+    """Map every ``(bus, dev)`` address in a capture to its resolved device id.
+
+    Built once at load so per-packet lookups, filters and summaries all agree.
+    Addresses belonging to one physical device map to the same id.
+    """
+    merged = _merge_by_identity(_accumulate_devices(records, transactions))
+    return {address: device_id for device_id, accumulator in merged.items() for address in accumulator.addresses}
 
 
 def _endpoint_address(record: UrbRecord) -> int:
@@ -1127,6 +1291,7 @@ def _apply_descriptor_info(
         descriptor = parse_device_descriptor(completion.data)
         if descriptor is not None:
             accumulator.device_descriptor = descriptor
+            accumulator.observed_identities.add((descriptor.vendor_id, descriptor.product_id))
     elif setup.descriptor_type == CONFIGURATION_DESCRIPTOR:
         configuration = parse_configuration(completion.data)
         if configuration is not None and _prefer_configuration(accumulator.configuration, configuration):
@@ -1149,7 +1314,7 @@ def _prefer_configuration(existing: ConfigurationDescriptor | None, candidate: C
     return len(candidate.interfaces) > len(existing.interfaces)
 
 
-def _device_summary(accumulator: _DeviceAccumulator) -> DeviceSummary:
+def _device_summary(device_id: str, accumulator: _DeviceAccumulator) -> DeviceSummary:
     device = accumulator.device_descriptor
     config = accumulator.configuration
     manufacturer = _descriptor_string(accumulator, device.manufacturer_index) if device else None
@@ -1158,7 +1323,7 @@ def _device_summary(accumulator: _DeviceAccumulator) -> DeviceSummary:
     product_id = _format_usb_id(device.product_id) if device else None
     interface_class = config.interfaces[0].interface_class if config and config.interfaces else None
     return DeviceSummary(
-        device_id=_device_id(accumulator.bus_num, accumulator.dev_num),
+        device_id=device_id,
         bus_num=accumulator.bus_num,
         dev_num=accumulator.dev_num,
         packet_count=accumulator.packet_count,
@@ -1178,6 +1343,11 @@ def _device_summary(accumulator: _DeviceAccumulator) -> DeviceSummary:
         descriptor_summary=_descriptor_summary(vendor_id, product_id, manufacturer, product),
         device_class=device.device_class if device else None,
         interface_class=interface_class,
+        addresses=tuple(DeviceAddress(bus_num=bus, dev_num=dev) for bus, dev in sorted(set(accumulator.addresses))),
+        identity_source=accumulator.identity_source,
+        # Presence only: iSerialNumber is non-zero. The value stays out of every
+        # summary, packet record and session dump — see DeviceSummary.has_serial.
+        has_serial=device is not None and device.serial_number_index is not None,
     )
 
 
@@ -1193,10 +1363,6 @@ def _format_usb_id(value: int) -> str:
 
 def _sorted_transfer_types(transfer_types: set[TransferType]) -> tuple[TransferType, ...]:
     return tuple(transfer_type for transfer_type in _TRANSFER_TYPE_ORDER if transfer_type in transfer_types)
-
-
-def _device_id(bus_num: int, dev_num: int) -> str:
-    return f"dev_{bus_num:03d}_{dev_num:03d}"
 
 
 def _descriptor_summary(
@@ -1225,14 +1391,12 @@ def _build_enumeration(
     transactions: tuple[UrbTransaction, ...],
     device_id: str,
 ) -> DeviceEnumeration:
-    accumulators = _accumulate_devices(records, transactions)
-    accumulator = next(
-        (acc for acc in accumulators.values() if _device_id(acc.bus_num, acc.dev_num) == device_id),
-        None,
-    )
+    merged = _merge_by_identity(_accumulate_devices(records, transactions))
+    accumulator = merged.get(device_id)
+    device_ids = {address: found_id for found_id, acc in merged.items() for address in acc.addresses}
     device = accumulator.device_descriptor if accumulator else None
     config = accumulator.configuration if accumulator else None
-    enum_indices, runtime_start, is_complete = _enumeration_indices(records, device_id)
+    enum_indices, runtime_start, is_complete = _enumeration_indices(records, device_ids, device_id)
     return DeviceEnumeration(
         device_id=device_id,
         vendor_id=_format_usb_id(device.vendor_id) if device else None,
@@ -1284,6 +1448,7 @@ def _enumerated_interfaces(
 
 def _enumeration_indices(
     records: tuple[UrbRecord, ...],
+    device_ids: DeviceIdMap,
     device_id: str,
 ) -> tuple[list[int], int | None, bool]:
     """Classify a device's records into its enumeration phase.
@@ -1297,7 +1462,7 @@ def _enumeration_indices(
         (
             index
             for index, record in enumerate(records)
-            if _device_id(record.bus_num, record.dev_num) == device_id and not enum_flags[index]
+            if resolve_device_id(device_ids, record) == device_id and not enum_flags[index]
         ),
         None,
     )
@@ -1307,7 +1472,7 @@ def _enumeration_indices(
     for index, record in enumerate(records):
         if runtime_start is not None and index >= runtime_start:
             break
-        if _device_id(record.bus_num, record.dev_num) != device_id or not enum_flags[index]:
+        if resolve_device_id(device_ids, record) != device_id or not enum_flags[index]:
             continue
         enum_indices.append(index)
         if _is_set_configuration(record):

--- a/bsu_tool/sniff_command.py
+++ b/bsu_tool/sniff_command.py
@@ -30,13 +30,12 @@ from bsu_tool.usbmon_source import (
 )
 
 
-def run_sniff(bus: int, device: int | None, output: Path) -> None:
+def run_sniff(bus: int, output: Path) -> None:
     """Run a capture from the CLI. Prints progress and stats to stderr.
 
-    ``device`` is a USB device address to filter on, or ``None`` for
-    bus-only capture (every device on the bus). Translates the library's
-    structured exceptions into ``bsu-tool: ...`` error messages and clean
-    exit codes. Does not return on error.
+    Capture is bus-wide: every device on ``bus`` is recorded. Translates the
+    library's structured exceptions into ``bsu-tool: ...`` error messages and
+    clean exit codes. Does not return on error.
     """
     stop_event = threading.Event()
 
@@ -45,25 +44,21 @@ def run_sniff(bus: int, device: int | None, output: Path) -> None:
 
     signal.signal(signal.SIGINT, _handle_sigint)
 
-    target = "all devices" if device is None else f"device {device}"
     print(
-        f"Capturing bus {bus} {target} to {output}. Press Ctrl+C to stop.",
+        f"Capturing bus {bus} (all devices) to {output}. Press Ctrl+C to stop.",
         file=sys.stderr,
     )
 
-    if bus == 0 and device is None:
-        # /dev/usbmon0 spans every bus; with no device filter this records
-        # the entire host, and device addresses are not unique across buses.
+    if bus == 0:
+        # /dev/usbmon0 spans every bus, so this records the entire host.
         print(
-            "  Warning: bus 0 captures all buses. With no --device filter this "
-            "records the whole host, and device addresses collide across buses.",
+            "  Warning: bus 0 captures all buses, so this records the whole host.",
             file=sys.stderr,
         )
 
     try:
         stats = capture(
             bus=bus,
-            device=device,
             output_path=output,
             stop_event=stop_event,
             on_progress=_print_progress,
@@ -91,40 +86,31 @@ def _print_progress(stats: CaptureStats) -> None:
     a longer earlier line.
     """
     line = (
-        f"  seen={stats.seen:>7d}  matched={stats.matched:>7d}  "
-        f"elapsed={stats.elapsed_seconds:>6.1f}s  "
-        f"size={_format_bytes(stats.output_bytes)}"
+        f"  events={stats.seen:>7d}  elapsed={stats.elapsed_seconds:>6.1f}s  size={_format_bytes(stats.output_bytes)}"
     )
     print(f"\r{line:<78}", end="", file=sys.stderr, flush=True)
 
 
 def _print_final_stats(stats: CaptureStats) -> None:
     """Print the multi-line summary that follows the progress counter."""
-    rate = stats.matched / stats.elapsed_seconds if stats.elapsed_seconds > 0 else 0.0
+    rate = stats.seen / stats.elapsed_seconds if stats.elapsed_seconds > 0 else 0.0
     print("Capture stopped.", file=sys.stderr)
-    print(f"  Events seen:       {stats.seen}", file=sys.stderr)
-    print(f"  Events matched:    {stats.matched}", file=sys.stderr)
+    print(f"  Events captured:   {stats.seen}", file=sys.stderr)
     print(f"  Elapsed:           {stats.elapsed_seconds:.2f}s", file=sys.stderr)
-    print(f"  Average rate:      {rate:.1f} matched/sec", file=sys.stderr)
+    print(f"  Average rate:      {rate:.1f} events/sec", file=sys.stderr)
     print(f"  Output:            {stats.output_path}", file=sys.stderr)
     print(
         f"  Output size:       {_format_bytes(stats.output_bytes)} ({stats.output_bytes} bytes)",
         file=sys.stderr,
     )
 
-    if stats.matched == 0:
+    if stats.seen == 0:
         print(file=sys.stderr)
-        if stats.seen == 0:
-            print(
-                "  Note: no events were seen on this bus. Is the device generating traffic?",
-                file=sys.stderr,
-            )
-        else:
-            print(
-                f"  Note: {stats.seen} events were seen on the bus, but none "
-                f"matched device number. Check the device number with `lsusb`.",
-                file=sys.stderr,
-            )
+        print(
+            "  Note: no events were seen on this bus. Is the device attached to "
+            "this bus, and is it generating traffic?",
+            file=sys.stderr,
+        )
 
 
 def _format_bytes(n: int) -> str:

--- a/bsu_tool/sniffer.py
+++ b/bsu_tool/sniffer.py
@@ -2,7 +2,15 @@
 
 Wires :class:`~bsu_tool.usbmon_source.UsbmonSource` (raw events from one
 ``/dev/usbmonN``) to :class:`~bsu_tool.pcapng_writer.PcapNgWriter`
-(Enhanced Packet Blocks), filtering by device number and tracking stats.
+(Enhanced Packet Blocks), tracking stats as it goes.
+
+Capture is always *bus-wide*: every non-filler event on the bus is written.
+There is deliberately no device filter. A device's address changes while it
+enumerates (it answers at address 0 before ``SET_ADDRESS`` assigns its real
+one) and again on every replug, so no single address selects one physical
+device for a whole capture — the descriptors that identify it arrive at one
+address and its traffic at another. Selecting a device is an analysis-time
+concern, where :mod:`bsu_tool.session` keys on vid:pid and can span both.
 
 :func:`capture` takes everything by argument — no globals, signals, or
 printing — and blocks until its stop event is set. That fits a CLI bound
@@ -25,14 +33,6 @@ from bsu_tool.urb_decoder import LINKTYPE_USB_LINUX_MMAPPED
 from bsu_tool.usbmon_source import UsbmonSource
 
 # ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-#: Offset of the device-number byte in the 64-byte usbmon header
-#: (layout documented in urb_decoder.py).
-_DEVNUM_OFFSET: int = 11
-
-# ---------------------------------------------------------------------------
 # Stats
 # ---------------------------------------------------------------------------
 
@@ -46,9 +46,8 @@ class CaptureStats:
     so it sees live values, not snapshots (copy manually to compare two
     points in time).
 
-    * ``seen`` — non-filler events from the kernel, including devices the
-      user did not ask for.
-    * ``matched`` — events that passed the device filter and were written.
+    * ``seen`` — non-filler events read from the kernel. Capture is bus-wide,
+      so every one of them is written; there is no separate "matched" count.
     * ``elapsed_seconds`` — wall-clock since start; updated each tick.
     * ``output_path`` / ``output_bytes`` — the file and its size.
       ``output_bytes`` is the writer's running total (approximate mid-
@@ -57,7 +56,6 @@ class CaptureStats:
 
     output_path: Path
     seen: int = 0
-    matched: int = 0
     elapsed_seconds: float = 0.0
     output_bytes: int = 0
 
@@ -80,30 +78,23 @@ _PROGRESS_INTERVAL_SECONDS: float = 0.2
 
 def capture(
     bus: int,
-    device: int | None,
     output_path: Path,
     *,
     stop_event: Event,
     ready_event: Event | None = None,
     on_progress: ProgressCallback | None = None,
 ) -> CaptureStats:
-    """Capture USB traffic from one bus (optionally one device) to a pcap-ng file.
+    """Capture every USB event on one bus to a pcap-ng file.
 
-    Reads events from ``/dev/usbmon{bus}``, keeps those matching ``device``
-    (or all of them in bus-only mode), and writes them to ``output_path``
-    as Enhanced Packet Blocks. Runs until ``stop_event`` is set.
+    Reads events from ``/dev/usbmon{bus}`` and writes each non-filler event to
+    ``output_path`` as an Enhanced Packet Block. Runs until ``stop_event`` is
+    set. There is no device filter — see the module docstring for why.
 
     Parameters
     ----------
     bus:
-        usbmon bus number (the N in ``/dev/usbmonN``).
-    device:
-        USB device number on that bus (as shown by ``lsusb``), or ``None``
-        for *bus-only* capture (write every non-filler event regardless of
-        address). Use bus-only when the address is unknown or will change —
-        enumeration, replug/reset, or a switch into a bootloader. ``0`` is
-        a real address (the enumeration default), *not* a wildcard; only
-        ``None`` means "all devices". In bus-only mode ``matched == seen``.
+        usbmon bus number (the N in ``/dev/usbmonN``). ``0`` is the catch-all
+        node that captures every bus at once.
     output_path:
         Destination file, opened with ``"xb"`` — the open fails if it
         already exists. Resolved against the cwd at open time.
@@ -167,17 +158,6 @@ def capture(
                 for header, data in source:
                     stats.seen += 1
 
-                    if device is not None and header[_DEVNUM_OFFSET] != device:
-                        # Another device on the bus. Still tick progress so a wrong
-                        # --device shows climbing "seen" against stuck "matched".
-                        now = time.monotonic()
-                        if on_progress is not None and now - last_progress_time >= _PROGRESS_INTERVAL_SECONDS:
-                            stats.elapsed_seconds = now - start_time
-                            stats.output_bytes = out_fp.tell()
-                            on_progress(stats)
-                            last_progress_time = now
-                        continue
-
                     # Derive the EPB timestamp from the usbmon header rather than
                     # time.time(), so a reader sees consistent values whether it
                     # reads the EPB header or the URB header.
@@ -191,7 +171,6 @@ def capture(
                         timestamp_us=timestamp_us,
                         packet_data=packet_data,
                     )
-                    stats.matched += 1
 
                     now = time.monotonic()
                     if on_progress is not None and now - last_progress_time >= _PROGRESS_INTERVAL_SECONDS:
@@ -258,7 +237,7 @@ class CaptureController:
     A single controller manages one capture. Typical use::
 
         controller = CaptureController()
-        controller.start(bus=3, device=5, output_path=Path("out.pcapng"))
+        controller.start(bus=3, output_path=Path("out.pcapng"))
         # ... tell the user to operate the device, wait for them to finish ...
         stats = controller.stop()
 
@@ -299,7 +278,6 @@ class CaptureController:
     def start(
         self,
         bus: int,
-        device: int | None,
         output_path: Path,
         *,
         on_progress: ProgressCallback | None = None,
@@ -316,9 +294,6 @@ class CaptureController:
         ----------
         bus:
             usbmon bus number (the N in ``/dev/usbmonN``).
-        device:
-            USB device number on that bus (as shown by ``lsusb``), or ``None``
-            for bus-only capture. See :func:`capture`.
         output_path:
             Destination pcap-ng file. Must not already exist.
         on_progress:
@@ -347,7 +322,6 @@ class CaptureController:
             try:
                 self._stats = capture(
                     bus=bus,
-                    device=device,
                     output_path=output_path,
                     stop_event=self._stop,
                     ready_event=self._ready,

--- a/bsu_tool/usb_enum.py
+++ b/bsu_tool/usb_enum.py
@@ -19,6 +19,15 @@ usbmon mapping
 that captures traffic on *every* bus. Each :class:`LiveUsbDevice` carries the
 derived ``usbmon_path`` for its bus, and :data:`USBMON_ALL_BUSES_PATH` names the
 capture-everything device.
+
+Identity note
+-------------
+Live rows are keyed by *address* (``dev_bbb_ddd``), not by vid:pid. At one
+instant several attached devices can share a vid:pid — a host with multiple USB
+controllers reports one root hub per controller, all ``1d6b:0002`` — so an
+identity key would collide here. A capture has the opposite problem (one device,
+several addresses over time) and keys on vid:pid instead. Use
+:func:`identity_capture_id` to cross the two.
 """
 
 from __future__ import annotations
@@ -26,6 +35,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
+
+from bsu_tool.device_identity import address_device_id, identity_device_id
 
 DEFAULT_SYSFS_ROOT: Final[Path] = Path("/sys/bus/usb/devices")
 """Canonical Linux sysfs location that lists attached USB devices."""
@@ -52,13 +63,20 @@ class LiveUsbDevice:
 
     The ``bus_num`` and ``dev_num`` fields mirror what ``lsusb`` prints ("Bus 003
     Device 007") and match the capture-side
-    :class:`~bsu_tool.mcp.interfaces.DeviceSummary` field names. ``device_id`` is
-    the same stable ``dev_bbb_ddd`` identifier the capture side builds (e.g.
-    ``dev_001_004`` for bus 1 device 4), so a live-enumerated device can be
-    correlated to one seen in a capture. ``vendor_id`` and ``product_id`` are
-    ``0x``-prefixed 4-digit hex strings matching the capture-side convention.
-    ``usbmon_path`` is the ``/dev/usbmonN`` character device that captures this
-    device's bus.
+    :class:`~bsu_tool.mcp.interfaces.DeviceSummary` field names.
+
+    ``device_id`` is the ``dev_bbb_ddd`` **address** identifier (e.g.
+    ``dev_001_004`` for bus 1 device 4). It is stable for as long as the device
+    stays attached — which is what makes snapshot diffing work — but **not**
+    across a replug, because the kernel reassigns the address. Deliberately not
+    the capture side's vid:pid id: several attached devices can share one
+    vid:pid (root hubs routinely do), so an identity id would collide within a
+    single snapshot. Use :func:`identity_device_id` to correlate a live device
+    to one seen in a capture.
+
+    ``vendor_id`` and ``product_id`` are ``0x``-prefixed 4-digit hex strings
+    matching the capture-side convention. ``usbmon_path`` is the
+    ``/dev/usbmonN`` character device that captures this device's bus.
     """
 
     device_id: str
@@ -71,15 +89,36 @@ class LiveUsbDevice:
 
 
 def device_id_for(bus_num: int, dev_num: int) -> str:
-    """Return the stable ``dev_bbb_ddd`` id for a bus/device address.
+    """Return the ``dev_bbb_ddd`` address id for a bus/device address.
 
-    Mirrors the capture-side identifier built in :mod:`bsu_tool.session` (e.g.
-    ``dev_001_004`` for bus 1 device 4) so a live-enumerated device can be
-    matched to one observed in a capture. Each field is zero-padded to three
-    digits; addresses wider than three digits are not truncated and simply widen
-    the field, matching the capture side exactly.
+    Shares its format with the capture side's fallback id (see
+    :func:`bsu_tool.device_identity.address_device_id`). Stable while the device
+    remains attached, so two snapshots of one host agree on it — that is what
+    :func:`bsu_tool.detect_device.diff_snapshots` relies on. It is *not* stable
+    across a replug: the kernel assigns a new address, and the same physical
+    device then reports a different id.
+
+    Each field is zero-padded to three digits; wider addresses are not truncated
+    and simply widen the field.
     """
-    return f"dev_{bus_num:03d}_{dev_num:03d}"
+    return address_device_id(bus_num, dev_num)
+
+
+def identity_capture_id(device: LiveUsbDevice) -> str:
+    """Return the capture-side ``vid_pid`` id for a live-enumerated device.
+
+    Bridges live enumeration to a loaded capture, which keys devices on vid:pid
+    rather than address. Note this id is not unique among attached devices: two
+    units of the same model, or several root hubs, map to one id.
+
+    Args:
+        device: A device from :func:`enumerate_usb_devices`.
+
+    Returns:
+        The ``vid_pid`` id a capture would report for this device, e.g.
+        ``27c6_63ac``.
+    """
+    return identity_device_id(int(device.vendor_id, 16), int(device.product_id, 16))
 
 
 def usbmon_path_for_bus(bus: int) -> str:

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -430,7 +430,7 @@ issue.
 ```python
 @dataclass(frozen=True)
 class ProtocolHypothesis:
-    device_id: str  # e.g. "dev_001_003"
+    device_id: str  # e.g. "27c6_63ac" (vid_pid), or "dev_001_003" when undescribed
     command_patterns: tuple[CommandPattern, ...]
     observations: tuple[AnalysisObservation, ...]
     unsolicited_responses: tuple[UnsolicitedResponse, ...]

--- a/docs/architecture/protocol-description.md
+++ b/docs/architecture/protocol-description.md
@@ -212,7 +212,7 @@ marker hits. With the M3 spec's current model, each `CommandPattern` has at most
 The deterministic summary should be compact:
 
 ```text
-Device dev_001_011 has 3 repeated command patterns across endpoints 0x01 and 0x83.
+Device 27c6_63ac has 3 repeated command patterns across endpoints 0x01 and 0x83.
 pattern_01 occurs 12 times near marker enroll-start and contains 2 steps: OUT bulk 0x01,
 then IN bulk 0x83. Median response time is 4.2 ms. 1 incomplete transfer was observed at a
 capture boundary.

--- a/docs/demo/milestone-2-runbook.md
+++ b/docs/demo/milestone-2-runbook.md
@@ -54,10 +54,14 @@ time. Ask Claude to show each tool result before continuing.
 
 2. `Call the bsu-tool list_devices tool and show every device and endpoint.`
 
-   Confirm `dev_001_011` is the Goodix reader, with vendor ID `0x27c6`, product
-   ID `0x63ac`, and endpoints `0x00`, `0x01`, and `0x83`.
+   Confirm two devices are listed. `27c6_63ac` is the Goodix reader, with vendor
+   ID `0x27c6`, product ID `0x63ac`, endpoints `0x00`, `0x01`, and `0x83`, and
+   `packet_count` `175`. Its `addresses` field shows `1:0` and `1:11` — the
+   address it answered on while enumerating and the one it was assigned — folded
+   into one identity. The other device, `dev_001_001`, sent no descriptors, so it
+   keeps an address-derived id.
 
-3. `Call the bsu-tool get_packets tool with device_id dev_001_011 and limit 5. Show the decoded records and pagination fields.`
+3. `Call the bsu-tool get_packets tool with device_id 27c6_63ac and limit 5. Show the decoded records and pagination fields.`
 
    Confirm five decoded control/bulk records are returned and `has_more` is
    `true`.
@@ -70,7 +74,7 @@ time. Ask Claude to show each tool result before continuing.
 
    Confirm both markers are present with packet indexes `145` and `252`.
 
-7. `Call the bsu-tool packets_between_markers tool with start_name goodix-bulk-start, end_name goodix-bulk-end, device_id dev_001_011, and limit 5.`
+7. `Call the bsu-tool packets_between_markers tool with start_name goodix-bulk-start, end_name goodix-bulk-end, device_id 27c6_63ac, and limit 5.`
 
    Confirm `span_count` is `106`, five Goodix bulk packets are returned,
    endpoints `0x01` and/or `0x83` are shown, and `has_more` is `true`. This is

--- a/docs/demo/milestone-2-runbook.md
+++ b/docs/demo/milestone-2-runbook.md
@@ -36,6 +36,10 @@ bsu-tool parse test_data/captures/goodix_enum_and_enroll_sanitized.pcapng
 Confirm the output reports `Total packets: 253`, three devices, and device
 `001:011` with endpoints `0x00`, `0x01`, and `0x03`.
 
+> The CLI summary still keys devices by address and masks endpoint direction,
+> so it reports three devices where `list_devices` below reports two, and shows
+> endpoint `0x03` where the device answers on `0x83`. Tracked in #105.
+
 ## Claude Code demo
 
 Start Claude Code from the repository root:

--- a/docs/mcp-tool-design.md
+++ b/docs/mcp-tool-design.md
@@ -10,7 +10,7 @@ Suggested workflow:
 
 1. Call `load_capture` with a `.pcapng` path.
 2. Call `list_devices` to identify USB devices in the capture.
-3. Select the target device using `bus_num` / `dev_num`, endpoints seen, packet counts, and any visible descriptor data.
+3. Select the target device by its `device_id`, using endpoints seen, packet counts, and any visible descriptor data.
 4. Call `get_packets` with a narrow filter: target device, endpoint, direction, transfer type, URB event, and packet index range.
 5. Separate enumeration traffic from runtime communication when the evidence supports it.
 6. Summarize likely device behavior using packet-level evidence.
@@ -135,7 +135,9 @@ MCP protocol errors should be reserved for invalid MCP requests, unknown tools, 
 
 `device_id` is a tool/session-level stable identifier derived from the device record.
 
-Use `bus_num` and `dev_num` for USB topology because those names match the current session model.
+Use `bus_num` and `dev_num` for USB topology because those names match the current session model. They are
+*observations*, not identity: a device changes address while enumerating and on every replug, so `device_id`
+(vid:pid when descriptors were captured) is what identifies it, and `addresses` lists every address it held.
 
 ### Enums
 
@@ -197,7 +199,7 @@ For non-paginated tools, `pagination` may be omitted.
     "code": "INVALID_DEVICE_ID",
     "message": "The requested device_id was not found.",
     "details": {
-      "device_id": "dev_99"
+      "device_id": "1d50_60c6"
     }
   }
 }
@@ -435,7 +437,7 @@ Example `structuredContent.data`:
 {
   "devices": [
     {
-      "device_id": "dev_01",
+      "device_id": "27c6_63ac",
       "bus_num": 1,
       "dev_num": 4,
       "vendor_id": "0x1234",
@@ -557,7 +559,7 @@ Example usage:
 
 ```python
 get_packets(
-    device_id="dev_01",
+    device_id="27c6_63ac",
     endpoint_address="0x81",
     direction="in",
     transfer_type="bulk",
@@ -581,7 +583,7 @@ Example `structuredContent.data`:
       "interface_id": 0,
       "timestamp_us": 421231,
       "urb_id": "urb_7f2b0010",
-      "device_id": "dev_01",
+      "device_id": "27c6_63ac",
       "bus_num": 1,
       "dev_num": 4,
       "endpoint_address": "0x81",
@@ -709,7 +711,7 @@ Likely output:
 Example usage:
 
 ```python
-list_endpoints(device_id="dev_01", include_ep0=True)
+list_endpoints(device_id="27c6_63ac", include_ep0=True)
 ```
 
 ---
@@ -771,7 +773,7 @@ Likely output:
 Example usage:
 
 ```python
-infer_traffic_phase(device_id="dev_01", method="heuristic_v1", include_reasons=True)
+infer_traffic_phase(device_id="27c6_63ac", method="heuristic_v1", include_reasons=True)
 ```
 
 ---
@@ -805,7 +807,7 @@ Example usage:
 
 ```python
 summarize_device_activity(
-    device_id="dev_01", traffic_phase="any", include_repeated_payload_previews=False, top_n_previews=10
+    device_id="27c6_63ac", traffic_phase="any", include_repeated_payload_previews=False, top_n_previews=10
 )
 ```
 
@@ -891,10 +893,10 @@ load_capture(path="/captures/device_trace.pcapng")
 
 list_devices(include_descriptor_summary=True)
 
-get_packets(device_id="dev_01", limit=40, include_data_preview=True)
+get_packets(device_id="27c6_63ac", limit=40, include_data_preview=True)
 
 get_packets(
-    device_id="dev_01",
+    device_id="27c6_63ac",
     endpoint_address="0x81",
     direction="in",
     transfer_type="bulk",
@@ -908,12 +910,12 @@ get_packets(
 ## Extended workflow if supporting tools are available
 
 ```python
-list_endpoints(device_id="dev_01", include_ep0=True)
+list_endpoints(device_id="27c6_63ac", include_ep0=True)
 
-infer_traffic_phase(device_id="dev_01", method="heuristic_v1", include_reasons=True)
+infer_traffic_phase(device_id="27c6_63ac", method="heuristic_v1", include_reasons=True)
 
 get_packets(
-    device_id="dev_01", transfer_type="control", traffic_phase="enumeration", limit=40, include_setup_summary=True
+    device_id="27c6_63ac", transfer_type="control", traffic_phase="enumeration", limit=40, include_setup_summary=True
 )
 
 get_control_transfer_details(packet_index=12, include_descriptor_decode=True)
@@ -921,12 +923,12 @@ get_control_transfer_details(packet_index=12, include_descriptor_decode=True)
 mark_session_marker(
     name="suspected_runtime_loop",
     packet_index=421,
-    device_id="dev_01",
+    device_id="27c6_63ac",
     note="Possible start of repeated runtime communication.",
     tags=["hypothesis", "runtime"],
 )
 
-list_session_markers(device_id="dev_01", tag="runtime")
+list_session_markers(device_id="27c6_63ac", tag="runtime")
 
-summarize_device_activity(device_id="dev_01", traffic_phase="any", include_repeated_payload_previews=False)
+summarize_device_activity(device_id="27c6_63ac", traffic_phase="any", include_repeated_payload_previews=False)
 ```

--- a/test_data/captures/README.md
+++ b/test_data/captures/README.md
@@ -31,11 +31,13 @@ Three plug-in enumerations, a template delete, an eight-second idle baseline, a
 one continuous capture, because `get_enumeration` derives descriptors and the
 runtime boundary from a single record stream.
 
-The same physical reader appears as **three device ids** (`dev_001_019`,
-`dev_001_020`, `dev_001_021`) because usbmon addresses shift on every replug;
-`dev_001_000` is the address-0 phase shared by all three. `dev_001_021` carried
-the delete, enrollment and verifies. This capture is direct evidence for the
-device-identity problem tracked in #103.
+The reader occupies **four usbmon addresses** across this capture — `1:0`
+during each enumeration, then `1:19`, `1:20` and `1:21` as the kernel
+re-addresses it on every replug. Since #103 all four resolve to the single
+identity **`27c6_63ac`**, keyed on vid:pid, so the whole capture reads as one
+device and analysis no longer splits at a replug. `DeviceSummary.addresses`
+lists the four; `bus_num`/`dev_num` report `1:21`, the address that carried the
+delete, enrollment and verifies.
 
 ### Notes for anyone reading it
 

--- a/test_data/captures/goodix_enroll_verify_sanitized.markers.json
+++ b/test_data/captures/goodix_enroll_verify_sanitized.markers.json
@@ -1,6 +1,6 @@
 {
   "capture": "goodix_enroll_verify_sanitized.pcapng",
-  "device_id": "dev_001_021",
+  "device_id": "27c6_63ac",
   "provenance": {
     "recorded": "2026-08-06",
     "distro": "Ubuntu 24.04.4 LTS",

--- a/tests/int/test_analyzer_goodix.py
+++ b/tests/int/test_analyzer_goodix.py
@@ -20,7 +20,7 @@ _ENUM_AND_ENROLL = _CAPTURES / "goodix_enum_and_enroll_sanitized.pcapng"
 _ENROLL = _CAPTURES / "goodix_enroll_sanitized.pcapng"
 _CHAOSKEY = _CAPTURES / "chaoskey_enum.pcapng"
 
-_GOODIX_DEVICE = "dev_001_011"
+_GOODIX_DEVICE = "27c6_63ac"
 
 
 def _load(path: pathlib.Path) -> Session:
@@ -133,7 +133,7 @@ def test_second_goodix_capture_yields_patterns() -> None:
 def test_chaoskey_enumeration_only_capture_excludes_the_vendor_device() -> None:
     """ChaosKey (1d50:60c6) enumerates but sends no runtime traffic, so it is excluded.
 
-    ``dev_001_005`` is a vendor-specific device (interface class 0xFF) whose entire
+    ``1d50_60c6`` is a vendor-specific device (interface class 0xFF) whose entire
     contribution is control traffic, so §1.2 removes it from analysis. It must still
     report itself rather than vanish. The only bulk/interrupt events in this capture
     belong to the root hub, so nothing here validates detection.
@@ -142,10 +142,11 @@ def test_chaoskey_enumeration_only_capture_excludes_the_vendor_device() -> None:
     results = session.detect_repeated_sequences()
     assert all(not result.patterns for result in results)
 
-    chaoskey = _for_device(results, "dev_001_005")
+    chaoskey = _for_device(results, "1d50_60c6")
     assert chaoskey.event_count == 0
     assert any("nothing to analyze" in note for note in chaoskey.analysis_notes)
-    assert any("8 control transfers" in note for note in chaoskey.analysis_notes)
+    # 8 control transfers at address 5 plus the 1 at address 0 it enumerated on.
+    assert any("9 control transfers" in note for note in chaoskey.analysis_notes)
 
 
 def test_per_device_notes_do_not_report_capture_wide_counts() -> None:
@@ -157,7 +158,9 @@ def test_per_device_notes_do_not_report_capture_wide_counts() -> None:
         for note in result.analysis_notes
         if "control transfers excluded" in note
     }
-    assert counts == {"dev_001_000": 1, "dev_001_001": 17, "dev_001_005": 8}
+    # The ChaosKey's address-0 and address-5 phases are one device, so its
+    # control-transfer count is the sum of both (1 + 8).
+    assert counts == {"dev_001_001": 17, "1d50_60c6": 9}
 
 
 def test_detection_is_deterministic_across_loads() -> None:

--- a/tests/int/test_goodix_enroll_verify_capture.py
+++ b/tests/int/test_goodix_enroll_verify_capture.py
@@ -24,7 +24,7 @@ _CAPTURE = _CAPTURES / "goodix_enroll_verify_sanitized.pcapng"
 _SIDECAR = _CAPTURES / "goodix_enroll_verify_sanitized.markers.json"
 
 #: The reader's address during the third attach, when the session traffic ran.
-_DEVICE_ID = "dev_001_021"
+_DEVICE_ID = "27c6_63ac"
 
 #: Placeholder written over the real serial by tools/sanitize_capture.py.
 _SERIAL_PLACEHOLDER = "UID00000000_XXXX_MOC_B0"
@@ -55,18 +55,22 @@ def test_capture_loads_with_expected_devices() -> None:
     assert len(capture.records) == 1122
 
     devices = {device.device_id: device for device in session.list_devices()}
-    # Address 0 is the enumeration phase shared by all three attaches; 19, 20
-    # and 21 are the same physical reader re-addressed on each replug.
-    assert set(devices) == {"dev_001_000", "dev_001_019", "dev_001_020", _DEVICE_ID}
+    # Address 0 is the enumeration phase shared by all three attaches; 19, 20 and
+    # 21 are the same physical reader re-addressed on each replug. All four fold
+    # into one vid:pid identity, so this whole capture is a single device.
+    assert set(devices) == {_DEVICE_ID}
+    assert [(a.bus_num, a.dev_num) for a in devices[_DEVICE_ID].addresses] == [(1, 0), (1, 19), (1, 20), (1, 21)]
 
     session_device = devices[_DEVICE_ID]
     assert session_device.vendor_id == "0x27c6"
     assert session_device.product_id == "0x63ac"
+    # Endpoint tallies now cover all four addresses, so they sum to the whole capture.
     assert [(endpoint.address, endpoint.packet_count) for endpoint in session_device.endpoints_seen] == [
-        ("0x00", 114),
-        ("0x01", 182),
-        ("0x83", 720),
+        ("0x00", 196),
+        ("0x01", 190),
+        ("0x83", 736),
     ]
+    assert sum(endpoint.packet_count for endpoint in session_device.endpoints_seen) == 1122
 
 
 def test_enumeration_is_complete_and_serial_is_redacted() -> None:

--- a/tests/int/test_load_backend_goodix.py
+++ b/tests/int/test_load_backend_goodix.py
@@ -39,7 +39,7 @@ def test_load_populates_session_from_real_capture() -> None:
     )
     # derived devices: bind capture-specific identity, descriptor, and endpoints to one device
     devices_by_id = {device.device_id: device for device in session.list_devices()}
-    goodix = devices_by_id["dev_001_011"]
+    goodix = devices_by_id["27c6_63ac"]
     assert goodix.vendor_id == "0x27c6"
     assert goodix.endpoints_seen
     # packet store: valid indexes return a record, both out-of-range branches return None
@@ -78,7 +78,7 @@ def test_load_capture_tool_reports_real_metadata() -> None:
     assert session.capture.metadata.packet_count == 253
     assert len(session.capture.records) == 253
     devices_by_id = {device.device_id: device for device in session.list_devices()}
-    assert devices_by_id["dev_001_011"].vendor_id == "0x27c6"
+    assert devices_by_id["27c6_63ac"].vendor_id == "0x27c6"
 
 
 def test_load_enroll_only_capture_without_enumeration_traffic() -> None:

--- a/tests/int/test_mcp_enumeration_chaoskey.py
+++ b/tests/int/test_mcp_enumeration_chaoskey.py
@@ -20,7 +20,7 @@ import pathlib
 from bsu_tool.session import Session
 
 _CAPTURE = pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures" / "chaoskey_enum.pcapng"
-_CHAOSKEY_DEVICE_ID = "dev_001_005"
+_CHAOSKEY_DEVICE_ID = "1d50_60c6"
 
 
 def test_list_devices_reports_chaoskey_classes() -> None:
@@ -81,9 +81,12 @@ def test_get_enumeration_enumeration_only_capture_has_no_runtime() -> None:
 
     assert enumeration.is_complete is True
     assert enumeration.runtime_start_index is None
-    assert enumeration.enumeration_start_index == 36
+    # The address-0 phase belongs to the same device, so enumeration starts there.
+    assert enumeration.enumeration_start_index == 28
     assert enumeration.enumeration_end_index == 51
-    assert enumeration.enumeration_packet_indices == tuple(range(36, 52))
+    # Two address-0 packets precede the contiguous address-5 run; both phases
+    # belong to the same device now that identity keys on vid:pid.
+    assert enumeration.enumeration_packet_indices == (28, 29, *range(36, 52))
     # The phase carries only endpoint-0 control packets.
     for index in enumeration.enumeration_packet_indices:
         packet = session.get_packet(index)

--- a/tests/int/test_mcp_enumeration_goodix.py
+++ b/tests/int/test_mcp_enumeration_goodix.py
@@ -9,7 +9,7 @@ from bsu_tool.session import Session
 _CAPTURE = (
     pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures" / "goodix_enum_and_enroll_sanitized.pcapng"
 )
-_GOODIX_DEVICE_ID = "dev_001_011"
+_GOODIX_DEVICE_ID = "27c6_63ac"
 
 
 def test_list_devices_reports_descriptor_classes() -> None:
@@ -65,7 +65,9 @@ def test_get_enumeration_identifies_phase_boundary() -> None:
     enumeration = session.get_enumeration(_GOODIX_DEVICE_ID)
 
     assert enumeration.is_complete is True
-    assert enumeration.enumeration_start_index == 30
+    # Enumeration starts where the reader first answers at address 0, not where
+    # it later appears at address 11 — both addresses are now the same device.
+    assert enumeration.enumeration_start_index == 22
     assert enumeration.enumeration_end_index == 145
     assert enumeration.runtime_start_index == 146
     # Every enumeration packet precedes the first runtime packet.

--- a/tests/int/test_mcp_get_packets_goodix.py
+++ b/tests/int/test_mcp_get_packets_goodix.py
@@ -26,12 +26,12 @@ def test_get_packets_goodix_capture() -> None:
     assert len(everything.matches) == 253
     assert [packet.index for packet in everything.matches[:3]] == [0, 1, 2]
 
-    device = session.get_packets(device_id="dev_001_011")
+    device = session.get_packets(device_id="27c6_63ac")
     assert device.total_count == 253
     assert 0 < len(device.matches) < everything.total_count
-    assert {packet.device_id for packet in device.matches} == {"dev_001_011"}
+    assert {packet.device_id for packet in device.matches} == {"27c6_63ac"}
 
-    bulk_in = session.get_packets(device_id="dev_001_011", transfer_type="bulk", direction="in")
+    bulk_in = session.get_packets(device_id="27c6_63ac", transfer_type="bulk", direction="in")
     assert bulk_in.matches
     for packet in bulk_in.matches:
         assert packet.transfer_type == "bulk"
@@ -40,9 +40,9 @@ def test_get_packets_goodix_capture() -> None:
 
     # Endpoint filters by number: "3" and full address "0x83" both reach EP3 IN
     # once direction is pinned.
-    by_number = session.get_packets(device_id="dev_001_011", endpoint="3", direction="in")
+    by_number = session.get_packets(device_id="27c6_63ac", endpoint="3", direction="in")
     assert by_number.matches == bulk_in.matches
-    assert session.get_packets(device_id="dev_001_011", endpoint="0x83", direction="in").matches == bulk_in.matches
+    assert session.get_packets(device_id="27c6_63ac", endpoint="0x83", direction="in").matches == bulk_in.matches
 
 
 def test_get_packets_tool_assembles_paginated_result() -> None:

--- a/tests/int/test_mcp_list_devices_goodix.py
+++ b/tests/int/test_mcp_list_devices_goodix.py
@@ -20,12 +20,28 @@ def test_list_devices_goodix_capture() -> None:
 
     assert capture.metadata.packet_count == 253
     assert len(capture.records) == 253
-    assert [device.device_id for device in devices] == ["dev_001_000", "dev_001_001", "dev_001_011"]
-    assert [device.packet_count for device in devices] == [8, 78, 167]
-    assert devices[1].transfer_types_seen == ("control", "interrupt")
-    assert [ep.address for ep in devices[2].endpoints_seen] == ["0x00", "0x01", "0x83"]
-    assert devices[2].transfer_types_seen == ("control", "bulk")
-    assert devices[2].vendor_id == "0x27c6"
-    assert devices[2].product_id == "0x63ac"
-    assert devices[2].manufacturer == "Goodix Technology Co., Ltd."
-    assert devices[2].product == "Goodix Fingerprint USB Device"
+    # The reader occupied address 0 during enumeration and address 11 afterwards;
+    # both fold into one vid:pid identity. The unnamed root hub sent no
+    # descriptors, so it keeps its address id.
+    assert [device.device_id for device in devices] == ["dev_001_001", "27c6_63ac"]
+    assert [device.packet_count for device in devices] == [78, 175]
+    assert devices[0].transfer_types_seen == ("control", "interrupt")
+    assert [ep.address for ep in devices[1].endpoints_seen] == ["0x00", "0x01", "0x83"]
+    assert devices[1].transfer_types_seen == ("control", "bulk")
+    assert devices[1].vendor_id == "0x27c6"
+    assert devices[1].product_id == "0x63ac"
+    assert devices[1].manufacturer == "Goodix Technology Co., Ltd."
+    assert devices[1].product == "Goodix Fingerprint USB Device"
+
+
+def test_merged_device_reports_both_addresses() -> None:
+    """A device seen at two addresses reports both, with the operational one last."""
+    session = Session()
+    session.load(_CAPTURE)
+
+    goodix = next(device for device in session.list_devices() if device.device_id == "27c6_63ac")
+
+    assert [(a.bus_num, a.dev_num) for a in goodix.addresses] == [(1, 0), (1, 11)]
+    # bus_num/dev_num report the last address held, not the enumeration address.
+    assert (goodix.bus_num, goodix.dev_num) == (1, 11)
+    assert goodix.identity_source == "descriptors"

--- a/tests/int/test_sniffer_writer_roundtrip_goodix.py
+++ b/tests/int/test_sniffer_writer_roundtrip_goodix.py
@@ -142,10 +142,10 @@ def roundtrip(
             return _ReplaySource(events)
 
         mp.setattr(sniffer, "UsbmonSource", _factory)
-        stats = capture(bus=_GOODIX_BUS, device=None, output_path=out_path, stop_event=Event())
+        stats = capture(bus=_GOODIX_BUS, output_path=out_path, stop_event=Event())
 
     # Bus-only capture writes every event it sees.
-    assert stats.matched == stats.seen == len(original_epbs)
+    assert stats.seen == len(original_epbs)
 
     _, reemitted_epbs = _read_epbs(out_path)
     return original_epbs, reemitted_epbs, link_type

--- a/tests/unit/mcp/test_live_capture.py
+++ b/tests/unit/mcp/test_live_capture.py
@@ -293,12 +293,12 @@ def test_stop_capture_returns_stats_and_autoloads(tmp_path: Path) -> None:
     assert payload["output_bytes"] == 4242
     # the summary comes from a real decode of the captured file
     assert payload["packet_count"] == 253
-    assert "dev_001_011" in payload["device_ids"]
+    assert "27c6_63ac" in payload["device_ids"]
     # the SHARED session now holds that capture for the other tools
     assert session.capture is not None
     assert len(session.capture.records) == 253
     devices_payload = _call(server, "list_devices", {})
-    assert "dev_001_011" in {device["device_id"] for device in devices_payload["devices"]}
+    assert "27c6_63ac" in {device["device_id"] for device in devices_payload["devices"]}
     # the capture slot is free again
     _call(server, "start_capture", {"bus": 1, "output_path": str(tmp_path / "next.pcapng")})
 

--- a/tests/unit/mcp/test_live_capture.py
+++ b/tests/unit/mcp/test_live_capture.py
@@ -50,12 +50,12 @@ class _FakeController:
     active_results: ClassVar[list[bool]] = []
 
     def __init__(self) -> None:
-        self.start_args: tuple[int, int | None, Path] | None = None
+        self.start_args: tuple[int, Path] | None = None
         self.stop_calls = 0
         _FakeController.instances.append(self)
 
-    def start(self, bus: int, device: int | None, output_path: Path) -> None:
-        self.start_args = (bus, device, output_path)
+    def start(self, bus: int, output_path: Path) -> None:
+        self.start_args = (bus, output_path)
         if _FakeController.start_entered is not None:
             _FakeController.start_entered.set()
             assert _FakeController.start_release is not None
@@ -85,9 +85,8 @@ class _FakeController:
             raise _FakeController.stop_error
         assert self.start_args is not None
         return CaptureStats(
-            output_path=self.start_args[2],
+            output_path=self.start_args[1],
             seen=500,
-            matched=253,
             elapsed_seconds=2.5,
             output_bytes=4242,
         )
@@ -122,9 +121,9 @@ def test_start_capture_starts_controller_and_reports(tmp_path: Path) -> None:
 
     payload = _call(server, "start_capture", {"bus": 1, "output_path": str(out)})
 
-    assert payload == {"bus": 1, "device": None, "output_path": str(out)}
+    assert payload == {"bus": 1, "output_path": str(out)}
     (controller,) = _FakeController.instances
-    assert controller.start_args == (1, None, out)
+    assert controller.start_args == (1, out)
 
 
 def test_start_capture_normalizes_relative_output_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -136,7 +135,7 @@ def test_start_capture_normalizes_relative_output_path(monkeypatch: pytest.Monke
     payload = _call(server, "start_capture", {"bus": 1, "output_path": "live.pcapng"})
 
     assert payload["output_path"] == str(expected)
-    assert _FakeController.instances[0].start_args == (1, None, expected)
+    assert _FakeController.instances[0].start_args == (1, expected)
     _call(server, "stop_capture", {})
 
 
@@ -283,14 +282,13 @@ def test_stop_capture_returns_stats_and_autoloads(tmp_path: Path) -> None:
     session = Session()
     server = build_server(session=session)
     out = tmp_path / "live.pcapng"
-    _call(server, "start_capture", {"bus": 1, "device": 11, "output_path": str(out)})
-    assert _FakeController.instances[0].start_args == (1, 11, out)
+    _call(server, "start_capture", {"bus": 1, "output_path": str(out)})
+    assert _FakeController.instances[0].start_args == (1, out)
 
     payload = _call(server, "stop_capture", {})
 
     assert payload["output_path"] == str(out)
-    assert payload["events_seen"] == 500
-    assert payload["events_matched"] == 253
+    assert payload["events_captured"] == 500
     assert payload["elapsed_seconds"] == 2.5
     assert payload["output_bytes"] == 4242
     # the summary comes from a real decode of the captured file
@@ -407,14 +405,13 @@ def test_start_capture_waits_for_monkeypatched_capture_readiness(
 
     def fake_capture(
         bus: int,
-        device: int | None,
         output_path: Path,
         *,
         stop_event: Event,
         ready_event: Event | None = None,
         on_progress: ProgressCallback | None = None,
     ) -> CaptureStats:
-        del bus, device, on_progress
+        del bus, on_progress
         shutil.copyfile(_GOODIX, output_path)
         assert ready_event is not None
         ready_event.set()
@@ -422,7 +419,6 @@ def test_start_capture_waits_for_monkeypatched_capture_readiness(
         return CaptureStats(
             output_path=output_path,
             seen=253,
-            matched=253,
             elapsed_seconds=0.1,
             output_bytes=output_path.stat().st_size,
         )

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -328,7 +328,9 @@ def test_list_devices_summarizes_multiple_devices(tmp_path: Path) -> None:
 
     assert len(capture.records) == 9
     assert capture.metadata.packet_count == 9
-    assert [device.device_id for device in device_summaries] == ["dev_001_004", "dev_001_007"]
+    # Device 4 sends no descriptors, so it keeps its address id; device 7's
+    # descriptor exchange gives it a vid:pid identity.
+    assert [device.device_id for device in device_summaries] == ["dev_001_004", "27c6_533c"]
     assert device_summaries[0].packet_count == 2
     assert device_summaries[0].endpoints_seen == (
         EndpointSummary(address="0x01", packet_count=1, byte_count=0),
@@ -1004,3 +1006,193 @@ def test_session_round_trips_json_safe_dict(tmp_path: Path) -> None:
     assert packet["data_hex"] == "61"
     assert packet["data_preview"] == "61"
     assert packet["setup_hex"] is None
+
+
+# ---------------------------------------------------------------------------
+# Device identity: merging across addresses, and keeping distinct devices apart
+# ---------------------------------------------------------------------------
+
+
+def _enumerating_device(
+    *,
+    dev_num: int,
+    bus_num: int = 1,
+    vendor_id: int,
+    product_id: int,
+    urb_id: int,
+    serial_number_index: int = 0,
+) -> tuple[bytes, ...]:
+    """A GET_DESCRIPTOR(DEVICE) exchange identifying one device at one address."""
+    setup = _get_descriptor_setup(descriptor_type=1, descriptor_index=0, length=18)
+    descriptor = bytearray(
+        _device_descriptor(vendor_id=vendor_id, product_id=product_id, manufacturer_index=0, product_index=0)
+    )
+    descriptor[16] = serial_number_index  # iSerialNumber
+    return (
+        _usbmon_packet(
+            urb_id=urb_id, transfer_type=_CONTROL, endpoint=0x80, dev_num=dev_num, bus_num=bus_num, setup=setup
+        ),
+        _usbmon_packet(
+            urb_id=urb_id,
+            event=_COMPLETION,
+            transfer_type=_CONTROL,
+            endpoint=0x80,
+            dev_num=dev_num,
+            bus_num=bus_num,
+            flag_setup=0x3E,
+            data=bytes(descriptor),
+        ),
+    )
+
+
+def _write_packets(tmp_path: Path, packets: tuple[bytes, ...], name: str = "identity.pcapng") -> Path:
+    path = tmp_path / name
+    path.write_bytes(_capture_bytes(packets))
+    return path
+
+
+def test_one_device_across_two_addresses_is_reported_once(tmp_path: Path) -> None:
+    """A device that re-addresses (enumeration, or a replug) is a single device.
+
+    This is the shape every real enumeration capture has: the device answers at
+    address 0 while its descriptors are read, then moves to its assigned address.
+    """
+    path = _write_packets(
+        tmp_path,
+        (
+            *_enumerating_device(dev_num=0, vendor_id=0x1A86, product_id=0x7523, urb_id=1),
+            *_enumerating_device(dev_num=9, vendor_id=0x1A86, product_id=0x7523, urb_id=2),
+        ),
+    )
+    session = Session()
+    session.load(path)
+
+    (device,) = session.list_devices()
+    assert device.device_id == "1a86_7523"
+    assert device.packet_count == 4
+    assert [(a.bus_num, a.dev_num) for a in device.addresses] == [(1, 0), (1, 9)]
+    assert (device.bus_num, device.dev_num) == (1, 9)  # the operational address, not address 0
+    assert device.identity_source == "descriptors"
+
+
+def test_same_address_on_two_buses_does_not_cross_match(tmp_path: Path) -> None:
+    """Device 5 on bus 1 and device 5 on bus 2 are distinct devices.
+
+    The address alone is ambiguous across buses, so identity must not collapse
+    them, and a device_id filter must return only its own device's packets.
+    """
+    path = _write_packets(
+        tmp_path,
+        (
+            *_enumerating_device(bus_num=1, dev_num=5, vendor_id=0x1A86, product_id=0x7523, urb_id=1),
+            *_enumerating_device(bus_num=2, dev_num=5, vendor_id=0x0403, product_id=0x6001, urb_id=2),
+        ),
+    )
+    session = Session()
+    session.load(path)
+
+    assert [device.device_id for device in session.list_devices()] == ["1a86_7523", "0403_6001"]
+
+    selection = session.get_packets(device_id="1a86_7523")
+    assert len(selection.matches) == 2
+    assert {packet.bus_num for packet in selection.matches} == {1}
+
+
+def test_devices_without_descriptors_keep_separate_address_ids(tmp_path: Path) -> None:
+    """Unidentifiable devices are never merged with each other.
+
+    Two descriptor-less devices share no vid:pid to key on, so folding them
+    together would invent an identity the capture does not support.
+    """
+    path = _write_packets(
+        tmp_path,
+        (
+            _usbmon_packet(urb_id=1, dev_num=4, endpoint=0x01, data=b"a"),
+            _usbmon_packet(urb_id=2, dev_num=8, endpoint=0x01, data=b"b"),
+        ),
+    )
+    session = Session()
+    session.load(path)
+
+    devices = session.list_devices()
+    assert [device.device_id for device in devices] == ["dev_001_004", "dev_001_008"]
+    assert all(device.identity_source == "address" for device in devices)
+    assert all(device.has_serial is False for device in devices)
+
+
+def test_has_serial_reports_presence_without_exposing_the_value(tmp_path: Path) -> None:
+    """has_serial reflects iSerialNumber != 0; no serial value reaches the summary."""
+    path = _write_packets(
+        tmp_path,
+        (
+            *_enumerating_device(dev_num=5, vendor_id=0x1A86, product_id=0x7523, urb_id=1, serial_number_index=3),
+            *_enumerating_device(bus_num=2, dev_num=6, vendor_id=0x0403, product_id=0x6001, urb_id=2),
+        ),
+    )
+    session = Session()
+    session.load(path)
+
+    with_serial, without_serial = session.list_devices()
+    assert with_serial.has_serial is True
+    assert without_serial.has_serial is False
+    # The id is built from vid:pid alone, so no unit fingerprint can leak through it.
+    assert with_serial.device_id == "1a86_7523"
+
+
+def test_packet_records_carry_the_merged_device_id(tmp_path: Path) -> None:
+    """Packets report the same id list_devices does, so filters cannot silently miss.
+
+    A packet at the enumeration address must resolve to the merged id; if it
+    reported its raw address instead, a device_id filter would drop it.
+    """
+    path = _write_packets(
+        tmp_path,
+        (
+            *_enumerating_device(dev_num=0, vendor_id=0x1A86, product_id=0x7523, urb_id=1),
+            *_enumerating_device(dev_num=9, vendor_id=0x1A86, product_id=0x7523, urb_id=2),
+        ),
+    )
+    session = Session()
+    session.load(path)
+
+    assert {packet.device_id for packet in session.get_packets().matches} == {"1a86_7523"}
+    # Every packet in the capture belongs to the one device, address 0 included.
+    assert len(session.get_packets(device_id="1a86_7523").matches) == 4
+
+
+def test_validate_flags_one_address_reporting_two_identities(tmp_path: Path) -> None:
+    """Two devices enumerating in one capture both use address 0, and that is a fault.
+
+    Their address-0 traffic is indistinguishable by address, so the merge folds
+    one device's packets into the other. Reporting it beats silently overstating
+    a device's counts.
+    """
+    path = _write_packets(
+        tmp_path,
+        (
+            *_enumerating_device(dev_num=0, vendor_id=0x1A86, product_id=0x7523, urb_id=1),
+            *_enumerating_device(dev_num=0, vendor_id=0x0403, product_id=0x6001, urb_id=2),
+        ),
+    )
+    session = Session()
+    session.load(path)
+
+    (problem,) = session.validate()
+    assert "address 1:0" in problem
+    assert "0403_6001" in problem
+    assert "1a86_7523" in problem
+
+
+def test_validate_accepts_one_device_enumerating_at_address_zero(tmp_path: Path) -> None:
+    """The ordinary case — a single device using address 0 — is not a fault."""
+    path = _write_packets(
+        tmp_path,
+        (
+            *_enumerating_device(dev_num=0, vendor_id=0x1A86, product_id=0x7523, urb_id=1),
+            *_enumerating_device(dev_num=9, vendor_id=0x1A86, product_id=0x7523, urb_id=2),
+        ),
+    )
+    session = Session()
+    session.load(path)
+
+    assert session.validate() == []

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pytest
 
@@ -15,6 +15,7 @@ from bsu_tool.analyzer import (
     build_analysis_events,
     detect_repeated_sequences,
 )
+from bsu_tool.device_identity import DeviceIdMap, address_device_id
 from bsu_tool.urb_decoder import Direction, TransferType, UrbRecord, UrbTransaction, pair_urbs
 
 _BUS = 1
@@ -28,6 +29,20 @@ class _FakeCapture:
 
     records: tuple[UrbRecord, ...]
     transactions: tuple[UrbTransaction, ...]
+    device_ids: DeviceIdMap = field(default_factory=lambda: DeviceIdMap())
+
+    def __post_init__(self) -> None:
+        """Derive the address→id map the way ``Capture`` does, if not supplied.
+
+        These fixtures carry no descriptors, so every address resolves to its
+        ``dev_bbb_ddd`` fallback id — which is what the analyzer sees for a
+        capture that never recorded an enumeration.
+        """
+        if not self.device_ids:
+            self.device_ids = {
+                (record.bus_num, record.dev_num): address_device_id(record.bus_num, record.dev_num)
+                for record in self.records
+            }
 
 
 def _transfer(

--- a/tests/unit/test_device_identity.py
+++ b/tests/unit/test_device_identity.py
@@ -1,0 +1,86 @@
+"""Unit tests for device identity id construction and resolution.
+
+These cover the id *formats* and the map lookup in isolation. The behaviour that
+matters — one physical device reported once across the addresses it occupied —
+is exercised against real captures in ``tests/int`` and against synthetic
+multi-device captures in ``tests/unit/mcp/test_session.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bsu_tool.device_identity import address_device_id, identity_device_id, resolve_device_id
+from bsu_tool.urb_decoder import UrbRecord
+
+
+def _record(*, bus_num: int, dev_num: int) -> UrbRecord:
+    """A minimal decoded record carrying only the address fields under test."""
+    return UrbRecord(
+        urb_id=1,
+        event_type="submission",
+        transfer_type="bulk",
+        direction="out",
+        bus_num=bus_num,
+        dev_num=dev_num,
+        endpoint=1,
+        status=0,
+        length=0,
+        captured_length=0,
+        data=b"",
+        setup=None,
+        timestamp=0.0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("vendor_id", "product_id", "expected"),
+    [
+        (0x27C6, 0x63AC, "27c6_63ac"),
+        (0x1D50, 0x60C6, "1d50_60c6"),
+        (0x0765, 0x5020, "0765_5020"),  # leading zero preserved
+        (0x0000, 0x0000, "0000_0000"),
+    ],
+)
+def test_identity_id_is_zero_padded_lowercase_hex(vendor_id: int, product_id: int, expected: str) -> None:
+    """vid:pid ids are 4 lowercase hex digits each, no 0x prefix, underscore-joined."""
+    assert identity_device_id(vendor_id, product_id) == expected
+
+
+@pytest.mark.parametrize(
+    ("bus_num", "dev_num", "expected"),
+    [
+        (1, 11, "dev_001_011"),
+        (3, 7, "dev_003_007"),
+        (1, 0, "dev_001_000"),
+        (1, 1234, "dev_001_1234"),  # wider addresses widen the field, never truncate
+    ],
+)
+def test_address_id_is_zero_padded_decimal(bus_num: int, dev_num: int, expected: str) -> None:
+    """Address ids zero-pad to three digits and never truncate a wider value."""
+    assert address_device_id(bus_num, dev_num) == expected
+
+
+def test_identity_and_address_ids_cannot_collide() -> None:
+    """The two id spaces are distinguishable, so a mixed listing stays unambiguous."""
+    assert identity_device_id(0x27C6, 0x63AC) != address_device_id(27, 63)
+    assert not identity_device_id(0x0001, 0x0011).startswith("dev_")
+
+
+def test_resolve_returns_the_mapped_id() -> None:
+    """A mapped address resolves to its device's id, not to its own address id."""
+    device_ids = {(1, 0): "27c6_63ac", (1, 11): "27c6_63ac"}
+    assert resolve_device_id(device_ids, _record(bus_num=1, dev_num=0)) == "27c6_63ac"
+    assert resolve_device_id(device_ids, _record(bus_num=1, dev_num=11)) == "27c6_63ac"
+
+
+def test_resolve_falls_back_to_the_address_id() -> None:
+    """An unmapped address still resolves, so the lookup is total."""
+    assert resolve_device_id({}, _record(bus_num=1, dev_num=4)) == "dev_001_004"
+
+
+def test_resolve_distinguishes_same_address_on_different_buses() -> None:
+    """Device 5 on bus 1 and on bus 2 are different devices and must not cross-match."""
+    device_ids = {(1, 5): "1a86_7523", (2, 5): "0403_6001"}
+    assert resolve_device_id(device_ids, _record(bus_num=1, dev_num=5)) == "1a86_7523"
+    assert resolve_device_id(device_ids, _record(bus_num=2, dev_num=5)) == "0403_6001"

--- a/tests/unit/test_pairing.py
+++ b/tests/unit/test_pairing.py
@@ -7,6 +7,7 @@ from bsu_tool.analysis.pairing import (
     PairingResult,
     pair_command_responses,
 )
+from bsu_tool.device_identity import DeviceIdMap, address_device_id
 from bsu_tool.urb_decoder import Direction, EventType, TransferType, UrbRecord, UrbTransaction
 
 _BASE_TIME = 1_000_000.0
@@ -144,9 +145,21 @@ def _control_transaction(urb_id: int, at: float, *, setup: bytes) -> UrbTransact
     return UrbTransaction(urb_id=urb_id, submission=submission, completion=completion)
 
 
-def _run(*transactions: UrbTransaction) -> PairingResult:
-    """Run the pairing pass over the given transactions."""
-    return pair_command_responses(tuple(transactions))
+def _run(*transactions: UrbTransaction, device_ids: DeviceIdMap | None = None) -> PairingResult:
+    """Run the pairing pass over the given transactions.
+
+    Defaults to one address-derived id per address, the resolution a capture
+    with no descriptors gets, so each address is its own device. Pass
+    ``device_ids`` to model a device seen at more than one address.
+    """
+    if device_ids is None:
+        device_ids = {
+            (record.bus_num, record.dev_num): address_device_id(record.bus_num, record.dev_num)
+            for transaction in transactions
+            for record in (transaction.submission, transaction.completion)
+            if record is not None
+        }
+    return pair_command_responses(tuple(transactions), device_ids=device_ids)
 
 
 def test_out_then_in_on_same_lane_pairs() -> None:
@@ -491,3 +504,30 @@ def test_failed_out_explains_one_in_and_a_second_in_is_unsolicited() -> None:
     assert result.unsolicited_responses[0].timestamp == _BASE_TIME + 0.200
     assert not result.unanswered_commands
     assert result.failed_event_count == 1
+
+
+def test_a_device_that_re_addresses_stays_one_lane() -> None:
+    """A command sent before a replug pairs with the response that follows it.
+
+    The kernel assigns a new address on every replug, so the same device speaks
+    from two addresses within one capture. Lanes key on the resolved device_id
+    for exactly this reason: keying on the address splits the exchange in two
+    and invents an unsolicited response out of the real answer.
+    """
+    transactions = (
+        _out_transaction(1, _BASE_TIME, dev_num=5, data=b"\xd0\x01"),
+        _in_transaction(2, _BASE_TIME + 0.1, dev_num=9, data=b"\xd0\x99"),
+    )
+    one_device = {(1, 5): "1a86_7523", (1, 9): "1a86_7523"}
+
+    result = _run(*transactions, device_ids=one_device)
+
+    assert len(result.pairs) == 1
+    assert result.pairs[0].device_id == "1a86_7523"
+    assert not result.unsolicited_responses
+
+    # The same traffic under address-derived ids is what the old keying saw: two
+    # lanes, no pair, and the answer misreported as unsolicited.
+    split = _run(*transactions)
+    assert not split.pairs
+    assert len(split.unsolicited_responses) == 1

--- a/tests/unit/test_pairing.py
+++ b/tests/unit/test_pairing.py
@@ -145,8 +145,8 @@ def _control_transaction(urb_id: int, at: float, *, setup: bytes) -> UrbTransact
     return UrbTransaction(urb_id=urb_id, submission=submission, completion=completion)
 
 
-def _run(*transactions: UrbTransaction, device_ids: DeviceIdMap | None = None) -> PairingResult:
-    """Run the pairing pass over the given transactions.
+def _run_all(*transactions: UrbTransaction, device_ids: DeviceIdMap | None = None) -> tuple[PairingResult, ...]:
+    """Run the pairing pass and return every device's result.
 
     Defaults to one address-derived id per address, the resolution a capture
     with no descriptors gets, so each address is its own device. Pass
@@ -160,6 +160,31 @@ def _run(*transactions: UrbTransaction, device_ids: DeviceIdMap | None = None) -
             if record is not None
         }
     return pair_command_responses(tuple(transactions), device_ids=device_ids)
+
+
+def _run(*transactions: UrbTransaction, device_ids: DeviceIdMap | None = None) -> PairingResult:
+    """Run the pairing pass over transactions from a single device.
+
+    Most tests exercise one device, so this collapses the per-device tuple to
+    the one result and asserts that assumption rather than letting a second
+    device slip past unnoticed.
+    """
+    results = _run_all(*transactions, device_ids=device_ids)
+    if not results:
+        return PairingResult(
+            device_id="",
+            pairs=(),
+            unanswered_commands=(),
+            unsolicited_responses=(),
+            incomplete_transfers=(),
+            response_timing=None,
+            vendor_control_count=0,
+            vendor_control_requests=(),
+            analysis_notes=(),
+            failed_event_count=0,
+        )
+    assert len(results) == 1, f"expected one device, got {[r.device_id for r in results]}"
+    return results[0]
 
 
 def test_out_then_in_on_same_lane_pairs() -> None:
@@ -268,14 +293,21 @@ def test_cross_endpoint_events_do_not_pair() -> None:
 
 
 def test_cross_device_events_do_not_pair() -> None:
-    """Events from two devices on the same endpoint number stay unpaired."""
-    result = _run(
+    """Events from two devices on the same endpoint number stay unpaired.
+
+    They also land in separate results, so neither device's counts are inflated
+    by the other's traffic.
+    """
+    commander, responder = _run_all(
         _out_transaction(1, _BASE_TIME, dev_num=5),
         _in_transaction(2, _BASE_TIME + 6.0, dev_num=6),
     )
-    assert not result.pairs
-    assert len(result.unanswered_commands) == 1
-    assert len(result.unsolicited_responses) == 1
+    assert (commander.device_id, responder.device_id) == ("dev_001_005", "dev_001_006")
+    assert not commander.pairs and not responder.pairs
+    assert len(commander.unanswered_commands) == 1
+    assert not commander.unsolicited_responses
+    assert len(responder.unsolicited_responses) == 1
+    assert not responder.unanswered_commands
 
 
 def test_failed_out_does_not_produce_a_false_unsolicited_response() -> None:
@@ -380,7 +412,9 @@ def test_standard_control_is_excluded_entirely() -> None:
     result = _run(_control_transaction(1, _BASE_TIME, setup=b"\x80\x06\x00\x01\x00\x00\x12\x00"))
     assert not result.pairs
     assert result.vendor_control_count == 0
-    assert not result.analysis_notes
+    # The device still reports itself, so a reader can tell "nothing to pair"
+    # apart from "device absent from the capture".
+    assert result.analysis_notes == ("no bulk or interrupt traffic for this device, nothing to pair",)
 
 
 def test_vendor_control_is_counted_with_request_codes() -> None:
@@ -527,7 +561,90 @@ def test_a_device_that_re_addresses_stays_one_lane() -> None:
     assert not result.unsolicited_responses
 
     # The same traffic under address-derived ids is what the old keying saw: two
-    # lanes, no pair, and the answer misreported as unsolicited.
-    split = _run(*transactions)
-    assert not split.pairs
-    assert len(split.unsolicited_responses) == 1
+    # separate devices, no pair, and the answer misreported as unsolicited.
+    split = _run_all(*transactions)
+    assert [r.device_id for r in split] == ["dev_001_005", "dev_001_009"]
+    assert not any(r.pairs for r in split)
+    assert len(split[1].unsolicited_responses) == 1
+
+
+def test_results_are_scoped_per_device() -> None:
+    """One device's traffic never inflates another's counts or timing.
+
+    Captures are bus-wide since the capture-time device filter was removed, so
+    a target device always shares a capture with root hubs and unrelated
+    peripherals. A capture-wide result would average their response times
+    together with nothing in the value to say so.
+    """
+    results = _run_all(
+        # Device 5: a real exchange.
+        _out_transaction(1, _BASE_TIME, dev_num=5),
+        _in_transaction(2, _BASE_TIME + 0.1, dev_num=5),
+        # Device 6: unrelated inbound polling, the shape a root hub produces.
+        _in_transaction(3, _BASE_TIME + 0.2, dev_num=6),
+        _in_transaction(4, _BASE_TIME + 0.3, dev_num=6),
+    )
+
+    by_id = {result.device_id: result for result in results}
+    assert set(by_id) == {"dev_001_005", "dev_001_006"}
+
+    assert len(by_id["dev_001_005"].pairs) == 1
+    assert not by_id["dev_001_005"].unsolicited_responses
+    # Timing covers this device's one pair only.
+    timing = by_id["dev_001_005"].response_timing
+    assert timing is not None
+    assert 99.0 < timing.mean_ms < 101.0
+
+    assert not by_id["dev_001_006"].pairs
+    assert len(by_id["dev_001_006"].unsolicited_responses) == 2
+    # No pairs means no timing to report, rather than the other device's.
+    assert by_id["dev_001_006"].response_timing is None
+
+
+def test_results_are_sorted_by_device_id() -> None:
+    """Result order is deterministic regardless of which device spoke first."""
+    results = _run_all(
+        _in_transaction(1, _BASE_TIME, dev_num=9),
+        _in_transaction(2, _BASE_TIME + 0.1, dev_num=4),
+    )
+    assert [result.device_id for result in results] == ["dev_001_004", "dev_001_009"]
+
+
+def test_device_id_filter_returns_only_that_device() -> None:
+    """The filter narrows to one device, mirroring detect_repeated_sequences."""
+    transactions = (
+        _out_transaction(1, _BASE_TIME, dev_num=5),
+        _in_transaction(2, _BASE_TIME + 0.1, dev_num=5),
+        _in_transaction(3, _BASE_TIME + 0.2, dev_num=6),
+    )
+    device_ids = {(1, 5): "dev_001_005", (1, 6): "dev_001_006"}
+
+    (only,) = pair_command_responses(transactions, device_ids=device_ids, device_id="dev_001_005")
+
+    assert only.device_id == "dev_001_005"
+    assert len(only.pairs) == 1
+
+
+def test_unknown_device_id_filter_yields_no_results() -> None:
+    """An id absent from the capture returns nothing rather than an empty shell."""
+    results = pair_command_responses(
+        (_out_transaction(1, _BASE_TIME, dev_num=5),),
+        device_ids={(1, 5): "dev_001_005"},
+        device_id="1a86_7523",
+    )
+    assert results == ()
+
+
+def test_capture_boundary_is_shared_across_devices() -> None:
+    """Boundary suppression measures against the capture end, not per device.
+
+    Device 5 goes quiet early while device 6 keeps the capture running. Its
+    unanswered command is real and must still be reported, which would not
+    happen if each device carried its own private notion of the capture end.
+    """
+    results = _run_all(
+        _out_transaction(1, _BASE_TIME, dev_num=5),
+        _in_transaction(2, _BASE_TIME + 30.0, dev_num=6),
+    )
+    by_id = {result.device_id: result for result in results}
+    assert len(by_id["dev_001_005"].unanswered_commands) == 1

--- a/tests/unit/test_sniff_command.py
+++ b/tests/unit/test_sniff_command.py
@@ -10,8 +10,8 @@
 SIGINT wiring, stderr progress/summary printing, and translation of the
 library's structured exceptions into ``bsu-tool: ...`` messages with a
 clean exit code. These tests target the parts that carry real logic —
-byte formatting, the exception→exit-code mapping, and the "nothing
-matched" hint branches — and skip asserting exact cosmetic layout.
+byte formatting, the exception→exit-code mapping, and the "no events"
+hint branch — and skip asserting exact cosmetic layout.
 
 ``capture`` is replaced with a spy so nothing touches ``/dev/usbmon`` or
 blocks on real traffic, and ``signal.signal`` is stubbed so the tests do
@@ -65,7 +65,6 @@ class _CaptureSpy:
         self,
         *,
         bus: int,
-        device: int | None,
         output_path: Path,
         stop_event: Event,
         on_progress: ProgressCallback | None = None,
@@ -75,7 +74,7 @@ class _CaptureSpy:
             raise self._error
         if self._result is not None:
             return self._result
-        return CaptureStats(output_path=output_path, seen=1, matched=1, elapsed_seconds=1.0, output_bytes=42)
+        return CaptureStats(output_path=output_path, seen=1, elapsed_seconds=1.0, output_bytes=42)
 
 
 def _install(monkeypatch: pytest.MonkeyPatch, spy: _CaptureSpy) -> list[_SigintHandler]:
@@ -90,11 +89,10 @@ def _install(monkeypatch: pytest.MonkeyPatch, spy: _CaptureSpy) -> list[_SigintH
     return handlers
 
 
-def _stats(*, seen: int, matched: int, output: str = "out.pcapng") -> CaptureStats:
+def _stats(*, seen: int, output: str = "out.pcapng") -> CaptureStats:
     return CaptureStats(
         output_path=Path(output),
         seen=seen,
-        matched=matched,
         elapsed_seconds=2.0,
         output_bytes=1024,
     )
@@ -152,7 +150,7 @@ def test_capture_errors_exit_cleanly(
 ) -> None:
     _install(monkeypatch, _CaptureSpy(error=error))
     with pytest.raises(SystemExit) as exc_info:
-        run_sniff(bus=3, device=5, output=Path("out.pcapng"))
+        run_sniff(bus=3, output=Path("out.pcapng"))
     assert exc_info.value.code == 1
     assert "bsu-tool:" in capsys.readouterr().err
 
@@ -160,7 +158,7 @@ def test_capture_errors_exit_cleanly(
 def test_file_exists_error_names_the_path(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     _install(monkeypatch, _CaptureSpy(error=FileExistsError()))
     with pytest.raises(SystemExit):
-        run_sniff(bus=3, device=5, output=Path("existing.pcapng"))
+        run_sniff(bus=3, output=Path("existing.pcapng"))
     assert "existing.pcapng" in capsys.readouterr().err
 
 
@@ -170,18 +168,18 @@ def test_file_exists_error_names_the_path(monkeypatch: pytest.MonkeyPatch, capsy
 
 
 def test_happy_path_prints_final_stats(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
-    spy = _CaptureSpy(result=_stats(seen=10, matched=10))
+    spy = _CaptureSpy(result=_stats(seen=10))
     _install(monkeypatch, spy)
-    run_sniff(bus=3, device=5, output=Path("out.pcapng"))  # returns normally
+    run_sniff(bus=3, output=Path("out.pcapng"))  # returns normally
     err = capsys.readouterr().err
     assert "Capture stopped." in err
     assert "out.pcapng" in err
 
 
 def test_sigint_handler_sets_the_capture_stop_event(monkeypatch: pytest.MonkeyPatch) -> None:
-    spy = _CaptureSpy(result=_stats(seen=1, matched=1))
+    spy = _CaptureSpy(result=_stats(seen=1))
     handlers = _install(monkeypatch, spy)
-    run_sniff(bus=3, device=5, output=Path("out.pcapng"))
+    run_sniff(bus=3, output=Path("out.pcapng"))
 
     assert spy.stop_event is not None
     assert not spy.stop_event.is_set()
@@ -191,46 +189,33 @@ def test_sigint_handler_sets_the_capture_stop_event(monkeypatch: pytest.MonkeyPa
     assert spy.stop_event.is_set()
 
 
-def test_bus_zero_all_devices_warns(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
-    _install(monkeypatch, _CaptureSpy(result=_stats(seen=1, matched=1)))
-    run_sniff(bus=0, device=None, output=Path("out.pcapng"))
+def test_bus_zero_warns_it_records_the_whole_host(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _install(monkeypatch, _CaptureSpy(result=_stats(seen=1)))
+    run_sniff(bus=0, output=Path("out.pcapng"))
     assert "Warning: bus 0" in capsys.readouterr().err
 
 
-def test_bus_zero_with_device_does_not_warn(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    # A device filter on bus 0 is fine — the whole-host warning must not fire.
-    _install(monkeypatch, _CaptureSpy(result=_stats(seen=1, matched=1)))
-    run_sniff(bus=0, device=5, output=Path("out.pcapng"))
+def test_specific_bus_does_not_warn(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _install(monkeypatch, _CaptureSpy(result=_stats(seen=1)))
+    run_sniff(bus=3, output=Path("out.pcapng"))
     assert "Warning: bus 0" not in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------
-# _print_final_stats — the "nothing matched" hint branches
+# _print_final_stats — the "no events" hint branch
 # ---------------------------------------------------------------------------
 
 
 def test_final_stats_note_when_no_events_seen(capsys: pytest.CaptureFixture[str]) -> None:
-    _print_final_stats(_stats(seen=0, matched=0))
+    _print_final_stats(_stats(seen=0))
     assert "no events were seen" in capsys.readouterr().err
 
 
-def test_final_stats_note_when_seen_but_none_matched(capsys: pytest.CaptureFixture[str]) -> None:
-    err_text = _emit_final_stats(seen=50, matched=0, capsys=capsys)
-    assert "none" in err_text
-    assert "device number" in err_text
-
-
-def test_final_stats_no_note_when_matched(capsys: pytest.CaptureFixture[str]) -> None:
-    err_text = _emit_final_stats(seen=50, matched=50, capsys=capsys)
-    assert "no events were seen" not in err_text
-    assert "none matched" not in err_text
-
-
-def _emit_final_stats(*, seen: int, matched: int, capsys: pytest.CaptureFixture[str]) -> str:
-    _print_final_stats(_stats(seen=seen, matched=matched))
-    return capsys.readouterr().err
+def test_final_stats_no_note_when_events_captured(capsys: pytest.CaptureFixture[str]) -> None:
+    _print_final_stats(_stats(seen=50))
+    assert "no events were seen" not in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sniffer.py
+++ b/tests/unit/test_sniffer.py
@@ -114,47 +114,26 @@ def _read_epbs(path: Path) -> list[EnhancedPacketBlock]:
 
 
 # ---------------------------------------------------------------------------
-# capture() — filtering and stats
+# capture() — bus-wide recording and stats
 # ---------------------------------------------------------------------------
 
 
-def test_device_filter_counts_seen_vs_matched(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_every_device_on_the_bus_is_written(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Capture is bus-wide: addresses are recorded regardless of which device
+    # they belong to, so a device that re-addresses mid-capture stays whole.
     events = [
         (_header(devnum=5), b"\x01"),
-        (_header(devnum=9), b"\x02"),  # different device
-        (_header(devnum=5), b"\x03"),
+        (_header(devnum=9), b"\x02"),  # a different device on the same bus
+        (_header(devnum=0), b"\x03"),  # the enumeration address
     ]
     _install_source(monkeypatch, _FakeSource(events))
     out = tmp_path / "cap.pcapng"
 
-    stats = capture(bus=3, device=5, output_path=out, stop_event=Event())
+    stats = capture(bus=3, output_path=out, stop_event=Event())
 
     assert stats.seen == 3
-    assert stats.matched == 2
     payloads = [epb.packet_data[64:] for epb in _read_epbs(out)]
-    assert payloads == [b"\x01", b"\x03"]
-
-
-def test_bus_only_mode_matches_everything(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    events = [(_header(devnum=d), bytes([d])) for d in (5, 9, 0)]
-    _install_source(monkeypatch, _FakeSource(events))
-    out = tmp_path / "cap.pcapng"
-
-    stats = capture(bus=3, device=None, output_path=out, stop_event=Event())
-
-    assert stats.matched == stats.seen == 3
-
-
-def test_device_zero_is_not_a_wildcard(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    # device=0 must match only address-0 events, not "everything".
-    events = [(_header(devnum=0), b"\xa0"), (_header(devnum=1), b"\xa1")]
-    _install_source(monkeypatch, _FakeSource(events))
-    out = tmp_path / "cap.pcapng"
-
-    stats = capture(bus=3, device=0, output_path=out, stop_event=Event())
-
-    assert stats.seen == 2
-    assert stats.matched == 1
+    assert payloads == [b"\x01", b"\x02", b"\x03"]
 
 
 def test_timestamp_is_derived_from_header(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -162,7 +141,7 @@ def test_timestamp_is_derived_from_header(monkeypatch: pytest.MonkeyPatch, tmp_p
     _install_source(monkeypatch, _FakeSource(events))
     out = tmp_path / "cap.pcapng"
 
-    capture(bus=3, device=None, output_path=out, stop_event=Event())
+    capture(bus=3, output_path=out, stop_event=Event())
 
     (epb,) = _read_epbs(out)
     expected = 1234 * 1_000_000 + 567
@@ -173,7 +152,7 @@ def test_output_bytes_matches_file_size(monkeypatch: pytest.MonkeyPatch, tmp_pat
     _install_source(monkeypatch, _FakeSource([(_header(), b"\x01\x02")]))
     out = tmp_path / "cap.pcapng"
 
-    stats = capture(bus=3, device=None, output_path=out, stop_event=Event())
+    stats = capture(bus=3, output_path=out, stop_event=Event())
 
     assert stats.output_bytes == out.stat().st_size
 
@@ -183,7 +162,7 @@ def test_existing_output_path_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     out = tmp_path / "cap.pcapng"
     out.write_bytes(b"existing")  # already exists -> "xb" open fails
     with pytest.raises(FileExistsError):
-        capture(bus=3, device=None, output_path=out, stop_event=Event())
+        capture(bus=3, output_path=out, stop_event=Event())
     assert out.read_bytes() == b"existing"
 
 
@@ -192,7 +171,7 @@ def test_startup_failure_does_not_create_output(monkeypatch: pytest.MonkeyPatch,
     out = tmp_path / "cap.pcapng"
 
     with pytest.raises(UsbmonPermissionError):
-        capture(bus=3, device=None, output_path=out, stop_event=Event())
+        capture(bus=3, output_path=out, stop_event=Event())
 
     assert not out.exists()
 
@@ -200,29 +179,27 @@ def test_startup_failure_does_not_create_output(monkeypatch: pytest.MonkeyPatch,
 def test_ready_event_is_set_once_live(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _install_source(monkeypatch, _FakeSource([]))
     ready = Event()
-    capture(bus=3, device=None, output_path=tmp_path / "c.pcapng", stop_event=Event(), ready_event=ready)
+    capture(bus=3, output_path=tmp_path / "c.pcapng", stop_event=Event(), ready_event=ready)
     assert ready.is_set()
 
 
-def test_progress_callback_fires_on_matched_and_filtered(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_progress_callback_ticks_per_event(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     # Force every event past the throttle by advancing a fake clock a full
     # second per tick.
     ticks = iter(range(0, 1000))
     monkeypatch.setattr(sniffer.time, "monotonic", lambda: float(next(ticks)))
 
-    events = [(_header(devnum=5), b"\x01"), (_header(devnum=9), b"\x02")]  # one matched, one filtered
+    events = [(_header(devnum=5), b"\x01"), (_header(devnum=9), b"\x02")]
     _install_source(monkeypatch, _FakeSource(events))
 
-    calls: list[tuple[int, int]] = []
+    calls: list[int] = []
     capture(
         bus=3,
-        device=5,
         output_path=tmp_path / "c.pcapng",
         stop_event=Event(),
-        on_progress=lambda s: calls.append((s.seen, s.matched)),
+        on_progress=lambda s: calls.append(s.seen),
     )
-    assert (1, 1) in calls  # matched branch
-    assert (2, 1) in calls  # filtered branch: seen climbs, matched stuck
+    assert calls == [1, 2]
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +210,7 @@ def test_progress_callback_fires_on_matched_and_filtered(monkeypatch: pytest.Mon
 def test_controller_start_then_stop_returns_stats(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _install_source(monkeypatch, _FakeSource([(_header(), b"\x01")]))
     controller = CaptureController()
-    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+    controller.start(bus=3, output_path=tmp_path / "c.pcapng")
     stats = controller.stop()
     assert isinstance(stats, CaptureStats)
 
@@ -241,9 +218,9 @@ def test_controller_start_then_stop_returns_stats(monkeypatch: pytest.MonkeyPatc
 def test_controller_double_start_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _install_source(monkeypatch, _FakeSource([]))
     controller = CaptureController()
-    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+    controller.start(bus=3, output_path=tmp_path / "c.pcapng")
     with pytest.raises(CaptureStateError):
-        controller.start(bus=3, device=None, output_path=tmp_path / "d.pcapng")
+        controller.start(bus=3, output_path=tmp_path / "d.pcapng")
     controller.stop()
 
 
@@ -257,7 +234,7 @@ def test_controller_startup_error_surfaces_from_start(monkeypatch: pytest.Monkey
     _install_source(monkeypatch, source)
     controller = CaptureController()
     with pytest.raises(UsbmonPermissionError):
-        controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+        controller.start(bus=3, output_path=tmp_path / "c.pcapng")
 
 
 def test_controller_post_live_error_surfaces_from_stop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -266,7 +243,7 @@ def test_controller_post_live_error_surfaces_from_stop(monkeypatch: pytest.Monke
     _install_source(monkeypatch, source)
     out = tmp_path / "c.pcapng"
     controller = CaptureController()
-    controller.start(bus=3, device=None, output_path=out)
+    controller.start(bus=3, output_path=out)
     with pytest.raises(RuntimeError, match="bus vanished"):
         controller.stop()
     assert out.exists()
@@ -279,7 +256,7 @@ def test_controller_start_times_out_when_never_live(monkeypatch: pytest.MonkeyPa
     controller = CaptureController()
     out = tmp_path / "c.pcapng"
     with pytest.raises(TimeoutError):
-        controller.start(bus=3, device=None, output_path=out, ready_timeout=0.15)
+        controller.start(bus=3, output_path=out, ready_timeout=0.15)
     assert not out.exists()
     with pytest.raises(TimeoutError):
         controller.stop(timeout=0.01)
@@ -296,7 +273,7 @@ def test_controller_thread_start_failure_is_not_active(monkeypatch: pytest.Monke
     controller = CaptureController()
 
     with pytest.raises(RuntimeError, match="cannot start thread"):
-        controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+        controller.start(bus=3, output_path=tmp_path / "c.pcapng")
 
     assert not controller.is_active
 
@@ -309,14 +286,13 @@ def test_controller_stop_times_out_without_losing_active_state(
 
     def blocked_capture(
         bus: int,
-        device: int | None,
         output_path: Path,
         *,
         stop_event: Event,
         ready_event: Event | None = None,
         on_progress: sniffer.ProgressCallback | None = None,
     ) -> CaptureStats:
-        del bus, device, stop_event, on_progress
+        del bus, stop_event, on_progress
         output_path.write_bytes(b"capture")
         assert ready_event is not None
         ready_event.set()
@@ -325,7 +301,7 @@ def test_controller_stop_times_out_without_losing_active_state(
 
     monkeypatch.setattr(sniffer, "capture", blocked_capture)
     controller = CaptureController()
-    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+    controller.start(bus=3, output_path=tmp_path / "c.pcapng")
 
     with pytest.raises(TimeoutError, match="did not stop"):
         controller.stop(timeout=0.01)
@@ -340,7 +316,7 @@ def test_is_running_reflects_lifecycle(monkeypatch: pytest.MonkeyPatch, tmp_path
     _install_source(monkeypatch, _FakeSource([(_header(), b"\x01")], hold_until_stop=True))
     controller = CaptureController()
     assert controller.is_running is False
-    controller.start(bus=3, device=None, output_path=tmp_path / "c.pcapng")
+    controller.start(bus=3, output_path=tmp_path / "c.pcapng")
     assert controller.is_running is True
     controller.stop()
     assert controller.is_running is False

--- a/tests/unit/test_usb_enum.py
+++ b/tests/unit/test_usb_enum.py
@@ -9,9 +9,11 @@ import pytest
 
 from bsu_tool.usb_enum import (
     USBMON_ALL_BUSES_PATH,
+    LiveUsbDevice,
     UsbEnumerationError,
     device_id_for,
     enumerate_usb_devices,
+    identity_capture_id,
     usbmon_path_for_bus,
 )
 
@@ -188,3 +190,21 @@ def test_usbmon_path_helpers() -> None:
     """Bus N maps to /dev/usbmonN and the all-buses device is usbmon0."""
     assert usbmon_path_for_bus(3) == "/dev/usbmon3"
     assert USBMON_ALL_BUSES_PATH == "/dev/usbmon0"
+
+
+def test_identity_capture_id_bridges_a_live_device_to_its_capture_id() -> None:
+    """A live row converts to the vid:pid id a capture would report for it."""
+    device = LiveUsbDevice(
+        device_id="dev_001_011",
+        bus_num=1,
+        dev_num=11,
+        vendor_id="0x27c6",
+        product_id="0x63ac",
+        description="Goodix Fingerprint USB Device",
+        usbmon_path="/dev/usbmon1",
+    )
+
+    assert identity_capture_id(device) == "27c6_63ac"
+    # The live id stays address-based: several attached devices can share a
+    # vid:pid, so identity would collide within one snapshot.
+    assert device.device_id == "dev_001_011"


### PR DESCRIPTION
## What this does

Device identity was derived from bus and device number, which the kernel reassigns on every replug and during enumeration. The same physical device therefore appeared as two or more devices in one capture, splitting analysis and breaking marker correlation.

Identity now keys on vid:pid from the device descriptor, with a `dev_bbb_ddd` fallback when a capture holds no descriptors. Bus and device number become observations, reported in a new `addresses` field, with `bus_num`/`dev_num` retained as the last address observed.

Closes #103

## Changes

- **New `bsu_tool/device_identity.py`.** One definition of both id forms plus the address resolver, shared by `session`, `analyzer` and `pairing`. Replaces the duplicated `_device_id` in `session.py` and `analyzer.py`, which carried a "must match" comment and no enforcement.
- **`Capture.device_ids`** maps every observed address to its resolved id, built once at load. Packet records, filters, summaries and enumeration all read it, so a merged device cannot be reported under one id and filtered under another.
- **`DeviceSummary`** gains `addresses`, `identity_source` and `has_serial`. Serial value is deliberately excluded from ids and summaries since ids reach every packet record and every serialized session. Read it from `get_enumeration` when needed.
- **Removed the capture-time `--device` filter.** No single address selects one device for a whole capture, so `sniff` is now bus-wide and selection happens at analysis time. This also deletes the cross-bus mismatch in `sniffer.py` rather than fixing it: the filter compared device number without bus, so `--bus 0 --device 5` matched device 5 on every bus.
- **Pairing lanes key on `device_id`.** An address-keyed lane split one device several ways and lost any command/response exchange straddling a replug.
- **`usb_enum` keeps its address-based id** on purpose. Several attached devices can share a vid:pid (root hubs routinely do), so an identity key would collide within one snapshot and break `detect_device.diff_snapshots`. Added `identity_capture_id()` as the explicit bridge to the capture side.
- **Pairing reports one result per device.** Bus-wide capture means a target device always shares a file with root hubs and other peripherals, so a capture-wide `response_timing` averaged unrelated devices. Now mirrors `detect_repeated_sequences`: `tuple[PairingResult, ...]` plus an optional `device_id` filter. Verified on a live capture, where the root hub's 7 unsolicited responses and 2 incomplete transfers moved off the fingerprint reader's numbers.

## Breaking changes

- `device_id` format is `vid_pid` (for example `27c6_63ac`) wherever descriptors were captured, `dev_bbb_ddd` otherwise.
- `start_capture` no longer takes `device`. `StopCaptureResult.events_matched` is  now `events_captured`.
- `bsu-tool sniff` no longer accepts `--device`.
- `pair_command_responses` now requires a `device_ids` keyword.
- `pair_command_responses` returns `tuple[PairingResult, ...]` instead of a single result, and `PairingResult` carries `device_id`.

## Results on existing pcapng files

| Capture | Before | After |
|---|---|---|
| `goodix_enroll_verify` | 4 devices | 1 (`27c6_63ac`, 1122 packets, the whole file) |
| `goodix_enum_and_enroll` | 3 | 2 |
| `chaoskey_enum` | 3 | 2 |
| `xrite` | 4 | 3 |
| `goodix_enroll` (no descriptors) | 1 | 1 (`dev_001_003` fallback) |

## Testing

445 passed, 4 skipped. `ruff check`, `ruff format`, `pyright` clean. Each commit was checked out and run in isolation, so the history bisects.

New coverage: merge across re-address on all three enumeration fixtures, cross-bus address collision, descriptor-less fallback, `has_serial` both ways, packet records carrying the merged id, and `validate()` flagging one address that reports two identities. On the pairing side: a lane spanning a replug, per-device result scoping, deterministic result ordering, the `device_id` filter, an unknown filter id, and the capture boundary staying shared across devices.

Demo numbers re-verified: `packet_count` 253 and `span_count` 106 both hold. Only the id strings in `milestone-2-runbook.md` changed. 

Live testing performed: bus-wide captures on real USB hardware, covering enumeration-only and enumeration plus a bulk fingerprint enrollment, each with the device replugged several times mid-capture. Confirmed one physical device
resolves to one identity across its addresses, that `get_packets` and `list_devices` agree on the merged id, and that per-endpoint counts reconcile against tshark. Also exercised the MCP server path/demo and the per-device pairing results.

## Follow-ups

Not in this PR, worth filing:

1. **Converge `AnalysisEvent`.** `analyzer.py` and `pairing.py` both define one. Both now carry `device_id`, but they still differ on `payload` vs `data`, `failed` vs `successful`, and `packet_index` / `urb_id`. The `analyzer` version is the better base.
2. **sysfs identity tier.** `identity_source` accepts `"host"` but nothing  produces it. That tier would give a live capture vid:pid without needing enumeration in the file, which matters when a device cannot be unplugged.
3. **Address-0 splitting.** Two devices enumerating in one capture share address  0. `validate()` now reports this rather than silently mis-merging, but correct per-transaction attribution is unimplemented. No real capture hits it; covered synthetically.