### PR TITLE
fix: flag identities merged from concurrently active addresses

### DIFF
--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -84,6 +84,9 @@ _ENDPOINT_NUMBER_MASK: Final[int] = 0x0F
 _TRANSFER_TYPE_ORDER: Final[tuple[TransferType, ...]] = ("control", "bulk", "interrupt")
 _DATA_PREVIEW_BYTES: Final[int] = 32
 _CONTROL_ENDPOINT: Final[int] = 0
+#: The address a device answers on before SET_ADDRESS assigns it one. Shared by
+#: every device that enumerates, so it identifies no single unit.
+_UNADDRESSED_DEV_NUM: Final[int] = 0
 
 
 @dataclass(frozen=True)
@@ -683,6 +686,10 @@ class Session:
            share it, and their traffic cannot be told apart by address alone.
            Whichever identity won absorbed the other's address-0 packets, so the
            merge is unsafe and the affected device's counts are overstated.
+        4. One identity merged from two addresses active at the same time — the
+           reverse fault. Identity keys on vid:pid, so two identical units
+           attached at once (two root hubs on a two-bus machine, say) report as
+           one device with their counts summed. See :func:`_over_merge_conflicts`.
 
         In-flight submissions (no matching completion) and orphan completions
         (submission not captured) are NOT faults: usbmon captures routinely begin
@@ -706,6 +713,7 @@ class Session:
                     f"outside the decoded range 0..{len(records) - 1}"
                 )
         problems.extend(_identity_conflicts(records, self.capture.transactions))
+        problems.extend(_over_merge_conflicts(records, self.capture.transactions))
         return problems
 
     def to_dict(self) -> JsonDict:
@@ -1170,13 +1178,8 @@ def _merge_by_identity(
     """
     merged: dict[str, _DeviceAccumulator] = {}
     for (bus_num, dev_num), accumulator in sorted(devices.items()):
-        descriptor = accumulator.device_descriptor
-        if descriptor is None:
-            device_id = address_device_id(bus_num, dev_num)
-            accumulator.identity_source = "address"
-        else:
-            device_id = identity_device_id(descriptor.vendor_id, descriptor.product_id)
-            accumulator.identity_source = "descriptors"
+        device_id = _accumulator_device_id(bus_num, dev_num, accumulator)
+        accumulator.identity_source = "address" if accumulator.device_descriptor is None else "descriptors"
         accumulator.addresses = [(bus_num, dev_num)]
 
         existing = merged.get(device_id)
@@ -1211,6 +1214,29 @@ def _absorb(target: _DeviceAccumulator, other: _DeviceAccumulator) -> None:
         target.last_index = other.last_index
         target.bus_num = other.bus_num
         target.dev_num = other.dev_num
+
+
+def _accumulator_device_id(bus_num: int, dev_num: int, accumulator: _DeviceAccumulator) -> str:
+    """Return the id one address resolves to, before any merging.
+
+    The single definition of how an accumulator picks between the identity id
+    and the address fallback, so the merge and the checks that audit the merge
+    cannot drift apart the way the two hand-synchronised ``_device_id`` copies
+    did before :mod:`bsu_tool.device_identity` existed.
+
+    Args:
+        bus_num: USB bus number of the observed address.
+        dev_num: Device address on that bus.
+        accumulator: Tallies for that address, carrying any captured descriptor.
+
+    Returns:
+        The ``vid_pid`` id when a device descriptor was captured, else the
+        ``dev_bbb_ddd`` address fallback.
+    """
+    descriptor = accumulator.device_descriptor
+    if descriptor is None:
+        return address_device_id(bus_num, dev_num)
+    return identity_device_id(descriptor.vendor_id, descriptor.product_id)
 
 
 def _device_accumulator(
@@ -1249,6 +1275,69 @@ def _identity_conflicts(
             f"its packets cannot be attributed by address alone and the merge overstates one device"
         )
     return problems
+
+
+def _over_merge_conflicts(
+    records: tuple[UrbRecord, ...],
+    transactions: tuple[UrbTransaction, ...],
+) -> list[str]:
+    """Report one identity merged from addresses that were active at the same time.
+
+    Identity keys on vid:pid alone, so two identical units attached at once fold
+    into one reported device with packet counts summed and endpoints unioned.
+    The common case is a machine with two USB buses: the generic Linux root hub
+    ``1d6b_0002`` sits on each of them.
+
+    One physical device cannot transmit at two addresses simultaneously, so
+    overlapping activity is positive evidence of two units. A replug produces
+    disjoint ranges instead, which is what keeps that case quiet.
+
+    Address 0 is excluded, and must be: it is the address every device answers
+    on before ``SET_ADDRESS`` assigns one, so a device that replugs returns to
+    it and its index range spans the whole capture by construction. Only an
+    assigned address carries the one-unit-at-a-time guarantee this rests on.
+
+    Args:
+        records: Decoded URB records for the capture.
+        transactions: Paired URBs, the source of the device descriptors.
+
+    Returns:
+        One message per over-merged identity, empty when none is detected.
+    """
+    spans_by_identity: dict[str, list[tuple[tuple[int, int], int, int]]] = {}
+    for (bus_num, dev_num), accumulator in sorted(_accumulate_devices(records, transactions).items()):
+        if dev_num == _UNADDRESSED_DEV_NUM:
+            continue
+        device_id = _accumulator_device_id(bus_num, dev_num, accumulator)
+        spans_by_identity.setdefault(device_id, []).append(
+            ((bus_num, dev_num), accumulator.first_index, accumulator.last_index)
+        )
+
+    problems: list[str] = []
+    for device_id, spans in sorted(spans_by_identity.items()):
+        overlapping = _concurrently_active_addresses(spans)
+        if not overlapping:
+            continue
+        addresses = ", ".join(f"{bus_num}:{dev_num}" for bus_num, dev_num in sorted(overlapping))
+        problems.append(
+            f"device {device_id} merges addresses active at the same time ({addresses}); "
+            f"one device cannot transmit at two addresses at once, so these are separate "
+            f"units of the same model reported as one, with their counts summed"
+        )
+    return problems
+
+
+def _concurrently_active_addresses(
+    spans: list[tuple[tuple[int, int], int, int]],
+) -> set[tuple[int, int]]:
+    """Return the addresses whose packet index ranges overlap another's."""
+    overlapping: set[tuple[int, int]] = set()
+    for position, (address, first_index, last_index) in enumerate(spans):
+        for other_address, other_first, other_last in spans[position + 1 :]:
+            if first_index <= other_last and other_first <= last_index:
+                overlapping.add(address)
+                overlapping.add(other_address)
+    return overlapping
 
 
 def _device_ids_by_address(

--- a/bsu_tool/session.py
+++ b/bsu_tool/session.py
@@ -712,8 +712,11 @@ class Session:
                     f"marker {marker.name!r} references packet index {marker.packet_index} "
                     f"outside the decoded range 0..{len(records) - 1}"
                 )
-        problems.extend(_identity_conflicts(records, self.capture.transactions))
-        problems.extend(_over_merge_conflicts(records, self.capture.transactions))
+        # Accumulated once and shared: both checks read the same per-address
+        # tallies, and walking the records twice to build them would be waste.
+        devices = _accumulate_devices(records, self.capture.transactions)
+        problems.extend(_identity_conflicts(devices))
+        problems.extend(_over_merge_conflicts(devices))
         return problems
 
     def to_dict(self) -> JsonDict:
@@ -1253,17 +1256,22 @@ def _device_accumulator(
 
 
 def _identity_conflicts(
-    records: tuple[UrbRecord, ...],
-    transactions: tuple[UrbTransaction, ...],
+    devices: dict[tuple[int, int], _DeviceAccumulator],
 ) -> list[str]:
     """Report addresses where more than one vid:pid identity was seen.
 
     Devices all enumerate at address 0, so two of them enumerating within one
     capture leave descriptors for both under the same address. Merging then
     attributes every address-0 packet to whichever identity won.
+
+    Args:
+        devices: Address-keyed accumulators from :func:`_accumulate_devices`.
+
+    Returns:
+        One message per address reporting several identities, empty when none does.
     """
     problems: list[str] = []
-    for (bus_num, dev_num), accumulator in sorted(_accumulate_devices(records, transactions).items()):
+    for (bus_num, dev_num), accumulator in sorted(devices.items()):
         if len(accumulator.observed_identities) <= 1:
             continue
         identities = ", ".join(
@@ -1278,8 +1286,7 @@ def _identity_conflicts(
 
 
 def _over_merge_conflicts(
-    records: tuple[UrbRecord, ...],
-    transactions: tuple[UrbTransaction, ...],
+    devices: dict[tuple[int, int], _DeviceAccumulator],
 ) -> list[str]:
     """Report one identity merged from addresses that were active at the same time.
 
@@ -1298,14 +1305,13 @@ def _over_merge_conflicts(
     assigned address carries the one-unit-at-a-time guarantee this rests on.
 
     Args:
-        records: Decoded URB records for the capture.
-        transactions: Paired URBs, the source of the device descriptors.
+        devices: Address-keyed accumulators from :func:`_accumulate_devices`.
 
     Returns:
         One message per over-merged identity, empty when none is detected.
     """
     spans_by_identity: dict[str, list[tuple[tuple[int, int], int, int]]] = {}
-    for (bus_num, dev_num), accumulator in sorted(_accumulate_devices(records, transactions).items()):
+    for (bus_num, dev_num), accumulator in sorted(devices.items()):
         if dev_num == _UNADDRESSED_DEV_NUM:
             continue
         device_id = _accumulator_device_id(bus_num, dev_num, accumulator)

--- a/tests/unit/mcp/test_session.py
+++ b/tests/unit/mcp/test_session.py
@@ -1196,3 +1196,59 @@ def test_validate_accepts_one_device_enumerating_at_address_zero(tmp_path: Path)
     session.load(path)
 
     assert session.validate() == []
+
+
+def test_validate_flags_two_identical_devices_active_at_once(tmp_path: Path) -> None:
+    """Two units of one model attached together merge into one device, and that is a fault.
+
+    The id is vid:pid, so identical hardware on two buses folds together with
+    counts summed. A device cannot transmit at two addresses simultaneously, so
+    the interleaved traffic here is proof of two units rather than one that
+    re-addressed.
+    """
+    path = _write_packets(
+        tmp_path,
+        (
+            *_enumerating_device(bus_num=1, dev_num=5, vendor_id=0x1D6B, product_id=0x0002, urb_id=1),
+            *_enumerating_device(bus_num=2, dev_num=5, vendor_id=0x1D6B, product_id=0x0002, urb_id=2),
+            # Bus 1 speaks again after bus 2 started, so the two ranges overlap.
+            _usbmon_packet(urb_id=3, bus_num=1, dev_num=5, endpoint=0x01, data=b"a"),
+        ),
+    )
+    session = Session()
+    session.load(path)
+
+    # The merge itself is unchanged — this is a report, not a resolution.
+    (device,) = session.list_devices()
+    assert device.device_id == "1d6b_0002"
+
+    (problem,) = session.validate()
+    assert "1d6b_0002" in problem
+    assert "1:5" in problem
+    assert "2:5" in problem
+
+
+def test_validate_accepts_a_replug_reusing_the_enumeration_address(tmp_path: Path) -> None:
+    """A replug is disjoint activity, not concurrent, so it is never flagged.
+
+    This is the case the whole PR exists to merge, and the reference captures
+    all have this shape: address 0 recurs at each enumeration, so its index
+    range spans the gap between them and overlaps every operational address.
+    Only assigned addresses can be compared for concurrency.
+    """
+    path = _write_packets(
+        tmp_path,
+        (
+            *_enumerating_device(dev_num=0, vendor_id=0x27C6, product_id=0x63AC, urb_id=1),
+            *_enumerating_device(dev_num=19, vendor_id=0x27C6, product_id=0x63AC, urb_id=2),
+            # Replug: back to address 0, then on to a fresh assigned address.
+            *_enumerating_device(dev_num=0, vendor_id=0x27C6, product_id=0x63AC, urb_id=3),
+            *_enumerating_device(dev_num=20, vendor_id=0x27C6, product_id=0x63AC, urb_id=4),
+        ),
+    )
+    session = Session()
+    session.load(path)
+
+    (device,) = session.list_devices()
+    assert [(a.bus_num, a.dev_num) for a in device.addresses] == [(1, 0), (1, 19), (1, 20)]
+    assert session.validate() == []


### PR DESCRIPTION
## What this does

Follow-up to #123, from review feedback on it. The commit was written against that branch but missed the merge, so it lands separately.

Device identity keys on vid:pid, so two identical units attached at the same time merge into one reported device with packet counts summed and endpoints unioned. The generic Linux root hub `1d6b_0002` sits on every bus, so any two-bus machine has two of them. Removing the capture-time `--device` filter in #123 made bus-wide capture the default, so multi-bus captures are now the normal case.

`validate()` already reported the opposite fault (one address reporting two identities) and was silent on this one. It now reports both.

Detection only. The merge, the ids, and every output are unchanged. This adds a warning string and nothing else.

## How it detects

One physical device cannot transmit at two addresses at once, so overlapping activity is positive evidence of two units. A replug produces disjoint ranges and stays quiet. The accumulator already tracks `first_index`/`last_index` per address, so the check costs one pass.

Address 0 is excluded, and has to be. It is the address every device answers on before `SET_ADDRESS` assigns one, so a device returns to it on every replug and its index range spans the capture. In `goodix_enroll_verify` its 22 packets span indices 0..1033 of 1122, overlapping all three assigned addresses (1:19, 1:20, 1:21).

Comparing address 0 would have flagged three of the four captures that merge addresses (`goodix_enroll_verify`, `goodix_enum_and_enroll`, `xrite`), including the one cited in #123 as proof the original bug was fixed, and would have failed the existing `validate() == []` assertion in `tests/int/test_goodix_enroll_verify_capture.py`. The accumulator already tracks `first_index`/`last_index` per address, so the check adds no walk of its own. `validate()` accumulates once and shares the result with the existing identity-conflict check.

## Changes

- **`_over_merge_conflicts`** in `session.py`, wired into `validate()` as fault 4.
- **`_accumulator_device_id`** extracted and shared with `_merge_by_identity`, so the audit cannot drift from the merge it audits. Same reasoning as the `device_identity.py` extraction in #123.
- **`validate()` accumulates once.** `_identity_conflicts` and `_over_merge_conflicts` take the per-address accumulators instead of rebuilding them, halving `validate()` (1.165 ms to 0.595 ms on the 1122-record capture). Both helpers are private, so no API change.

## Testing

447 passed, 4 skipped. `ruff check`, `ruff format`, `pyright` clean.

New coverage: two identical units on two buses flagged, and a replug reusing the enumeration address staying silent. All five reference captures still return `validate() == []`.

## Not closing the over-merge issue

This reports the fault. It does not resolve it: `list_devices()` still returns one device where there are two. Splitting them needs an id that distinguishes identical units, which is open. Tracked separately.
