### PR TITLE
66/Assemble structured protocol descriptions

### DIFF
--- a/bsu_tool/analysis/description.py
+++ b/bsu_tool/analysis/description.py
@@ -1,0 +1,826 @@
+"""Assemble structured protocol descriptions from analysis-engine results."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Protocol, cast
+
+from bsu_tool.analysis.models import (
+    AnalysisObservation,
+    CommandPattern,
+    Direction,
+    IncompleteTransfer,
+    IncompleteTransferReason,
+    MarkerCorrelation,
+    PatternOccurrence,
+    PatternStep,
+    ProtocolHypothesis,
+    ResultLimits,
+    SignatureMode,
+    TransferType,
+    UnansweredCommand,
+    UnsolicitedResponse,
+)
+from bsu_tool.analysis.pairing import PairingResult, pair_command_responses
+from bsu_tool.analyzer import (
+    MAX_COMMAND_PATTERNS_RETURNED,
+    MAX_VARIABLE_VALUES_REPORTED,
+    build_analysis_events,
+)
+from bsu_tool.analyzer import (
+    CaptureLike as AnalyzerCaptureLike,
+)
+from bsu_tool.mcp.interfaces import DeviceSummary
+from bsu_tool.urb_decoder import UrbRecord, UrbTransaction
+
+_MARKER_CORRELATION_THRESHOLD_PERCENT = 50.0
+_SUMMARY_PATTERN_LIMIT = 3
+_ANOMALY_PREFIX_BYTES = 8
+
+
+class CaptureLike(Protocol):
+    """Capture fields read by the protocol-description assembler."""
+
+    @property
+    def records(self) -> tuple[UrbRecord, ...]:
+        """Decoded records from the capture."""
+        ...
+
+    @property
+    def transactions(self) -> tuple[UrbTransaction, ...]:
+        """Paired URB transactions from the capture."""
+        ...
+
+    @property
+    def device_ids(self) -> dict[tuple[int, int], str]:
+        """Address-to-device id map from the capture."""
+        ...
+
+    @property
+    def markers(self) -> Sequence[MarkerLike]:
+        """Markers attached to the capture."""
+        ...
+
+
+class MarkerLike(Protocol):
+    """Marker fields used for physical-action grouping."""
+
+    @property
+    def name(self) -> str:
+        """Marker label."""
+        ...
+
+    @property
+    def timestamp(self) -> float:
+        """Marker timestamp."""
+        ...
+
+    @property
+    def packet_index(self) -> int:
+        """Packet index the marker anchors to."""
+        ...
+
+    @property
+    def note(self) -> str | None:
+        """Optional marker note."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class ProtocolDescription:
+    """Human-readable presentation layer for one protocol hypothesis."""
+
+    device_id: str
+    device_summary: DeviceContextSummary
+    headline: str
+    deterministic_summary: str
+    endpoint_roles: tuple[EndpointRoleDescription, ...]
+    commands: tuple[CommandDescription, ...]
+    observations: tuple[ObservationDescription, ...]
+    unanswered_commands: tuple[PairingAnomalyDescription, ...]
+    unsolicited_responses: tuple[PairingAnomalyDescription, ...]
+    incomplete_transfers: tuple[IncompleteTransferDescription, ...]
+    evidence_notes: tuple[str, ...]
+    analysis_notes: tuple[str, ...]
+    result_limits: ResultLimitSummary
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceContextSummary:
+    """Compact descriptor and endpoint context for one device."""
+
+    label: str
+    vendor_id: str | None
+    product_id: str | None
+    manufacturer: str | None
+    product: str | None
+    interface_classes: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ResultLimitSummary:
+    """Truncation state preserved from the analyzer output."""
+
+    command_patterns_truncated: bool
+    observations_truncated: bool
+    truncation_note: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointRoleDescription:
+    """How one endpoint appears to be used in the inferred protocol."""
+
+    endpoint_address: str
+    direction: Direction
+    transfer_type: TransferType
+    summary: str
+
+
+@dataclass(frozen=True, slots=True)
+class CommandDescription:
+    """Readable description of one repeated command pattern."""
+
+    command_id: str
+    source_pattern_id: str
+    name: str
+    summary: str
+    occurrence_count: int
+    markers: tuple[str, ...]
+    steps: tuple[StepDescription, ...]
+    response_summary: str | None
+    evidence: EvidenceSpan
+
+
+@dataclass(frozen=True, slots=True)
+class StepDescription:
+    """Readable description of one normalized pattern step."""
+
+    step_index: int
+    endpoint_address: str
+    direction: Direction
+    transfer_type: TransferType
+    signature_mode: SignatureMode
+    observed_length_range: tuple[int, int]
+    payload_summary: str
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationDescription:
+    """Readable description of a preserved single-occurrence observation."""
+
+    source_observation_id: str
+    reason: str
+    summary: str
+    nearest_marker: str | None
+    steps: tuple[StepDescription, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PairingAnomalyDescription:
+    """Readable description of unanswered commands or unsolicited responses."""
+
+    endpoint_address: str
+    direction: Direction
+    transfer_type: TransferType
+    occurrence_count: int
+    summary: str
+    evidence: EvidenceSpan
+
+
+@dataclass(frozen=True, slots=True)
+class IncompleteTransferDescription:
+    """Readable description of neutral incomplete-transfer evidence."""
+
+    endpoint_address: str
+    direction: Direction
+    transfer_type: TransferType
+    reason: str
+    occurrence_count: int
+    summary: str
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSpan:
+    """Packet-index and timestamp bounds that support a description."""
+
+    first_packet_index: int
+    last_packet_index: int
+    first_timestamp: float
+    last_timestamp: float
+
+
+@dataclass(frozen=True, slots=True)
+class _MarkerHit:
+    """Marker correlation candidate for one pattern."""
+
+    marker_name: str
+    correlation_percent: float
+    mean_time_delta_ms: float
+
+
+@dataclass(frozen=True, slots=True)
+class _AnomalySample:
+    """One payload-bearing anomaly with packet evidence."""
+
+    packet_index: int
+    timestamp: float
+    endpoint_number: int
+    endpoint_address: str
+    direction: Direction
+    transfer_type: TransferType
+    payload: bytes
+
+
+def assemble_protocol_hypotheses(
+    capture: CaptureLike,
+    *,
+    device_id: str | None = None,
+) -> tuple[ProtocolHypothesis, ...]:
+    """Combine repeated-sequence and pairing results into spec §5 hypotheses.
+
+    Args:
+        capture: Loaded capture state.
+        device_id: Restrict analysis to one device. ``None`` emits one hypothesis
+            per device reported by the repeated-sequence pass.
+
+    Returns:
+        Protocol hypotheses sorted by device id.
+    """
+    from bsu_tool.analyzer import detect_repeated_sequences
+
+    analyzer_capture = cast(AnalyzerCaptureLike, capture)
+    sequence_results = detect_repeated_sequences(analyzer_capture, device_id=device_id)
+    pairing_results = pair_command_responses(capture.transactions, device_ids=capture.device_ids, device_id=device_id)
+    pairing_by_device = {result.device_id: result for result in pairing_results}
+    markers = tuple(sorted(capture.markers, key=lambda marker: marker.packet_index))
+
+    hypotheses: list[ProtocolHypothesis] = []
+    for sequence_result in sequence_results:
+        pairing = pairing_by_device.get(sequence_result.device_id)
+        marker_correlations, patterns = _correlate_markers(sequence_result.patterns, markers)
+        patterns = _attach_response_timing(patterns, pairing)
+        notes = list(sequence_result.analysis_notes)
+        if pairing is not None:
+            notes.extend(pairing.analysis_notes)
+        hypotheses.append(
+            ProtocolHypothesis(
+                device_id=sequence_result.device_id,
+                command_patterns=patterns,
+                observations=_observations_for(patterns, marker_correlations),
+                unsolicited_responses=_unsolicited_responses(capture, pairing) if pairing is not None else (),
+                unanswered_commands=_unanswered_commands(capture, pairing) if pairing is not None else (),
+                incomplete_transfers=_incomplete_transfers(pairing) if pairing is not None else (),
+                marker_correlations=marker_correlations,
+                result_limits=ResultLimits(
+                    max_command_patterns=MAX_COMMAND_PATTERNS_RETURNED,
+                    max_observations=len(patterns),
+                    max_variable_values_reported=MAX_VARIABLE_VALUES_REPORTED,
+                    command_patterns_truncated=sequence_result.patterns_truncated,
+                    observations_truncated=False,
+                    truncation_note=(
+                        f"command patterns truncated to the top {MAX_COMMAND_PATTERNS_RETURNED}"
+                        if sequence_result.patterns_truncated
+                        else None
+                    ),
+                ),
+                analysis_notes=tuple(dict.fromkeys(notes)),
+            )
+        )
+    return tuple(sorted(hypotheses, key=lambda hypothesis: hypothesis.device_id))
+
+
+def describe_protocol(
+    capture: CaptureLike,
+    *,
+    device_id: str | None = None,
+    device_summaries: tuple[DeviceSummary, ...] = (),
+) -> tuple[ProtocolDescription, ...]:
+    """Assemble concise, deterministic descriptions for a loaded capture.
+
+    Args:
+        capture: Loaded capture state.
+        device_id: Restrict analysis to one device. ``None`` describes each device
+            reported by the analysis engine.
+        device_summaries: Optional summaries from ``Session.list_devices()``.
+
+    Returns:
+        One presentation object per analyzed device.
+    """
+    summaries = {summary.device_id: summary for summary in device_summaries}
+    descriptions: list[ProtocolDescription] = []
+    for hypothesis in assemble_protocol_hypotheses(capture, device_id=device_id):
+        description = _describe_hypothesis(hypothesis, summaries.get(hypothesis.device_id))
+        descriptions.append(replace(description, deterministic_summary=format_protocol_summary(description)))
+    return tuple(descriptions)
+
+
+def format_protocol_summary(description: ProtocolDescription) -> str:
+    """Render a short deterministic summary for snapshot tests and MCP output."""
+    command_count = len(description.commands)
+    endpoint_count = len(description.endpoint_roles)
+    parts = [
+        f"Device {description.device_id} has {command_count} repeated command pattern"
+        f"{'' if command_count == 1 else 's'} across {endpoint_count} endpoint role"
+        f"{'' if endpoint_count == 1 else 's'}."
+    ]
+    for command in description.commands[:_SUMMARY_PATTERN_LIMIT]:
+        marker = f" near {', '.join(command.markers)}" if command.markers else ""
+        response = f" {command.response_summary}" if command.response_summary is not None else ""
+        parts.append(
+            f"{command.name} occurs {command.occurrence_count} times{marker}; "
+            f"evidence packets {command.evidence.first_packet_index}-{command.evidence.last_packet_index}."
+            f"{response}"
+        )
+    if description.unanswered_commands:
+        count = sum(item.occurrence_count for item in description.unanswered_commands)
+        parts.append(f"{count} unanswered command occurrence{'' if count == 1 else 's'}.")
+    if description.unsolicited_responses:
+        count = sum(item.occurrence_count for item in description.unsolicited_responses)
+        parts.append(f"{count} unsolicited response occurrence{'' if count == 1 else 's'}.")
+    if description.incomplete_transfers:
+        count = sum(item.occurrence_count for item in description.incomplete_transfers)
+        parts.append(f"{count} incomplete transfer occurrence{'' if count == 1 else 's'}.")
+    return " ".join(parts)
+
+
+def _describe_hypothesis(
+    hypothesis: ProtocolHypothesis,
+    device_summary: DeviceSummary | None,
+) -> ProtocolDescription:
+    commands = tuple(
+        _command_description(index, pattern, hypothesis.marker_correlations)
+        for index, pattern in enumerate(hypothesis.command_patterns)
+    )
+    observations = tuple(_observation_description(observation) for observation in hypothesis.observations)
+    unanswered = tuple(
+        _anomaly_description(command, "out", f"unanswered OUT command on {command.endpoint_address}")
+        for command in hypothesis.unanswered_commands
+    )
+    unsolicited = tuple(
+        _anomaly_description(response, "in", f"unsolicited IN response on {response.endpoint_address}")
+        for response in hypothesis.unsolicited_responses
+    )
+    incomplete = tuple(_incomplete_description(item) for item in hypothesis.incomplete_transfers)
+    headline = _headline(hypothesis, device_summary)
+    return ProtocolDescription(
+        device_id=hypothesis.device_id,
+        device_summary=_device_context(hypothesis.device_id, device_summary),
+        headline=headline,
+        deterministic_summary="",
+        endpoint_roles=_endpoint_roles(hypothesis),
+        commands=commands,
+        observations=observations,
+        unanswered_commands=unanswered,
+        unsolicited_responses=unsolicited,
+        incomplete_transfers=incomplete,
+        evidence_notes=_evidence_notes(hypothesis),
+        analysis_notes=hypothesis.analysis_notes,
+        result_limits=ResultLimitSummary(
+            command_patterns_truncated=hypothesis.result_limits.command_patterns_truncated,
+            observations_truncated=hypothesis.result_limits.observations_truncated,
+            truncation_note=hypothesis.result_limits.truncation_note,
+        ),
+    )
+
+
+def _headline(hypothesis: ProtocolHypothesis, device_summary: DeviceSummary | None) -> str:
+    label = device_summary.descriptor_summary if device_summary is not None else None
+    if label is None:
+        label = hypothesis.device_id
+    return f"{label}: {len(hypothesis.command_patterns)} repeated command patterns"
+
+
+def _device_context(device_id: str, device_summary: DeviceSummary | None) -> DeviceContextSummary:
+    if device_summary is None:
+        return DeviceContextSummary(
+            label=device_id,
+            vendor_id=None,
+            product_id=None,
+            manufacturer=None,
+            product=None,
+            interface_classes=(),
+        )
+    classes = (device_summary.interface_class,) if device_summary.interface_class is not None else ()
+    return DeviceContextSummary(
+        label=device_summary.descriptor_summary or device_summary.product or device_id,
+        vendor_id=device_summary.vendor_id,
+        product_id=device_summary.product_id,
+        manufacturer=device_summary.manufacturer,
+        product=device_summary.product,
+        interface_classes=classes,
+    )
+
+
+def _command_description(
+    position: int,
+    pattern: CommandPattern,
+    correlations: tuple[MarkerCorrelation, ...],
+) -> CommandDescription:
+    markers = tuple(
+        correlation.marker_name
+        for correlation in correlations
+        if correlation.correlation_id == pattern.marker_correlation_id
+    )
+    command_id = f"command_{position + 1:02d}"
+    steps = tuple(_step_description(step) for step in pattern.steps)
+    response_summary = _response_summary(pattern)
+    return CommandDescription(
+        command_id=command_id,
+        source_pattern_id=pattern.pattern_id,
+        name=_command_name(command_id, markers),
+        summary=_pattern_summary(pattern, markers),
+        occurrence_count=pattern.occurrence_count,
+        markers=markers,
+        steps=steps,
+        response_summary=response_summary,
+        evidence=_pattern_evidence(pattern),
+    )
+
+
+def _command_name(command_id: str, markers: tuple[str, ...]) -> str:
+    if not markers:
+        return command_id
+    normalized = "_".join(markers[0].lower().replace("-", "_").replace(" ", "_").split("_")[:4])
+    return f"{command_id}_{normalized}" if normalized else command_id
+
+
+def _pattern_summary(pattern: CommandPattern, markers: tuple[str, ...]) -> str:
+    marker_text = f" near marker range {', '.join(markers)}" if markers else ""
+    confidence = "low-confidence " if pattern.low_confidence else ""
+    return f"{confidence}{len(pattern.steps)}-step pattern observed {pattern.occurrence_count} times{marker_text}"
+
+
+def _response_summary(pattern: CommandPattern) -> str | None:
+    directions = {step.direction for step in pattern.steps}
+    if directions != {"in", "out"}:
+        return None
+    timing = pattern.response_timing
+    if timing is None:
+        return "Contains OUT and IN steps; response timing was not isolated to this pattern."
+    return f"Median response time {timing.median_ms:.1f} ms."
+
+
+def _pattern_evidence(pattern: CommandPattern) -> EvidenceSpan:
+    occurrences = pattern.occurrences
+    if not occurrences:
+        return EvidenceSpan(
+            first_packet_index=pattern.first_packet_index,
+            last_packet_index=pattern.first_packet_index,
+            first_timestamp=pattern.first_occurrence_timestamp,
+            last_timestamp=pattern.first_occurrence_timestamp,
+        )
+    return EvidenceSpan(
+        first_packet_index=min(occurrence.start_packet_index for occurrence in occurrences),
+        last_packet_index=max(occurrence.end_packet_index for occurrence in occurrences),
+        first_timestamp=min(occurrence.start_timestamp for occurrence in occurrences),
+        last_timestamp=max(occurrence.end_timestamp for occurrence in occurrences),
+    )
+
+
+def _step_description(step: PatternStep) -> StepDescription:
+    return StepDescription(
+        step_index=step.step_index,
+        endpoint_address=step.endpoint_address,
+        direction=step.direction,
+        transfer_type=step.transfer_type,
+        signature_mode=step.signature_mode,
+        observed_length_range=step.observed_length_range,
+        payload_summary=_payload_summary(step),
+    )
+
+
+def _payload_summary(step: PatternStep) -> str:
+    if not step.payload_signature:
+        return "zero-length payload"
+    signature = " ".join("??" if byte is None else f"{byte:02x}" for byte in step.payload_signature)
+    length_min, length_max = step.observed_length_range
+    length = f"{length_min} bytes" if length_min == length_max else f"{length_min}-{length_max} bytes"
+    variable = ""
+    if step.variable_byte_ranges:
+        positions = ", ".join(str(item.byte_index) for item in step.variable_byte_ranges)
+        variable = f"; variable byte positions {positions}"
+    return f"{length}; signature {signature}{variable}"
+
+
+def _observation_description(observation: AnalysisObservation) -> ObservationDescription:
+    return ObservationDescription(
+        source_observation_id=observation.observation_id,
+        reason=observation.reason,
+        summary=f"{observation.reason.replace('_', ' ')} observation with {len(observation.steps)} step(s)",
+        nearest_marker=observation.nearest_marker,
+        steps=tuple(_step_description(step) for step in observation.steps),
+    )
+
+
+def _anomaly_description(
+    anomaly: UnansweredCommand | UnsolicitedResponse,
+    direction: Direction,
+    summary: str,
+) -> PairingAnomalyDescription:
+    return PairingAnomalyDescription(
+        endpoint_address=anomaly.endpoint_address,
+        direction=direction,
+        transfer_type=anomaly.transfer_type,
+        occurrence_count=anomaly.occurrence_count,
+        summary=summary,
+        evidence=EvidenceSpan(
+            first_packet_index=anomaly.first_occurrence_index,
+            last_packet_index=anomaly.last_occurrence_index,
+            first_timestamp=anomaly.first_occurrence_timestamp,
+            last_timestamp=anomaly.last_occurrence_timestamp,
+        ),
+    )
+
+
+def _incomplete_description(item: IncompleteTransfer) -> IncompleteTransferDescription:
+    return IncompleteTransferDescription(
+        endpoint_address=item.endpoint_address,
+        direction=item.direction,
+        transfer_type=item.transfer_type,
+        reason=item.reason,
+        occurrence_count=item.occurrence_count,
+        summary=f"{item.occurrence_count} {item.reason.replace('_', ' ')} transfer(s) on {item.endpoint_address}",
+    )
+
+
+def _endpoint_roles(hypothesis: ProtocolHypothesis) -> tuple[EndpointRoleDescription, ...]:
+    counter: Counter[tuple[str, Direction, TransferType]] = Counter()
+    for pattern in hypothesis.command_patterns:
+        for step in pattern.steps:
+            counter[(step.endpoint_address, step.direction, step.transfer_type)] += pattern.occurrence_count
+    for anomaly in hypothesis.unanswered_commands:
+        counter[(anomaly.endpoint_address, "out", anomaly.transfer_type)] += anomaly.occurrence_count
+    for anomaly in hypothesis.unsolicited_responses:
+        counter[(anomaly.endpoint_address, "in", anomaly.transfer_type)] += anomaly.occurrence_count
+
+    roles: list[EndpointRoleDescription] = []
+    for (endpoint_address, direction, transfer_type), count in sorted(counter.items()):
+        roles.append(
+            EndpointRoleDescription(
+                endpoint_address=endpoint_address,
+                direction=direction,
+                transfer_type=transfer_type,
+                summary=f"{count} analyzed {direction.upper()} {transfer_type} event(s)",
+            )
+        )
+    return tuple(roles)
+
+
+def _evidence_notes(hypothesis: ProtocolHypothesis) -> tuple[str, ...]:
+    notes: list[str] = []
+    for pattern in hypothesis.command_patterns:
+        evidence = _pattern_evidence(pattern)
+        notes.append(
+            f"{pattern.pattern_id}: packets {evidence.first_packet_index}-{evidence.last_packet_index}, "
+            f"timestamps {evidence.first_timestamp:.6f}-{evidence.last_timestamp:.6f}"
+        )
+    return tuple(notes)
+
+
+def _correlate_markers(
+    patterns: tuple[CommandPattern, ...],
+    markers: tuple[MarkerLike, ...],
+) -> tuple[tuple[MarkerCorrelation, ...], tuple[CommandPattern, ...]]:
+    if len(markers) < 2:
+        return (), patterns
+
+    correlations: list[MarkerCorrelation] = []
+    updated: list[CommandPattern] = []
+    for pattern in patterns:
+        hit = _marker_hit(pattern.occurrences, markers)
+        if hit is None:
+            updated.append(pattern)
+            continue
+        correlation_id = f"marker_{len(correlations) + 1:02d}"
+        correlations.append(
+            MarkerCorrelation(
+                correlation_id=correlation_id,
+                marker_name=hit.marker_name,
+                pattern_ids=(pattern.pattern_id,),
+                correlation_percent=hit.correlation_percent,
+                mean_time_delta_ms=hit.mean_time_delta_ms,
+            )
+        )
+        updated.append(replace(pattern, marker_correlation_id=correlation_id))
+    return tuple(correlations), tuple(updated)
+
+
+def _marker_hit(
+    occurrences: tuple[PatternOccurrence, ...],
+    markers: tuple[MarkerLike, ...],
+) -> _MarkerHit | None:
+    if not occurrences:
+        return None
+    hits: dict[str, list[float]] = {}
+    for occurrence in occurrences:
+        span = _marker_span_name(occurrence, markers)
+        if span is None:
+            continue
+        marker = span[0]
+        hits.setdefault(span[1], []).append((occurrence.start_timestamp - marker.timestamp) * 1000.0)
+    if not hits:
+        return None
+    marker_name, deltas = max(hits.items(), key=lambda item: (len(item[1]), item[0]))
+    percent = len(deltas) / len(occurrences) * 100.0
+    if percent < _MARKER_CORRELATION_THRESHOLD_PERCENT:
+        return None
+    return _MarkerHit(
+        marker_name=marker_name,
+        correlation_percent=percent,
+        mean_time_delta_ms=sum(deltas) / len(deltas),
+    )
+
+
+def _marker_span_name(
+    occurrence: PatternOccurrence,
+    markers: tuple[MarkerLike, ...],
+) -> tuple[MarkerLike, str] | None:
+    for start, end in zip(markers, markers[1:], strict=False):
+        if start.packet_index <= occurrence.start_packet_index and occurrence.end_packet_index <= end.packet_index:
+            return start, f"{start.name}..{end.name}"
+    return None
+
+
+def _observations_for(
+    patterns: tuple[CommandPattern, ...],
+    correlations: tuple[MarkerCorrelation, ...],
+) -> tuple[AnalysisObservation, ...]:
+    by_id = {correlation.correlation_id: correlation for correlation in correlations}
+    observations: list[AnalysisObservation] = []
+    for pattern in patterns:
+        correlation = by_id.get(pattern.marker_correlation_id or "")
+        if correlation is None:
+            continue
+        observations.append(
+            AnalysisObservation(
+                observation_id=f"observation_{len(observations) + 1:02d}",
+                reason="near_marker",
+                steps=pattern.steps,
+                nearest_marker=correlation.marker_name,
+            )
+        )
+    return tuple(observations)
+
+
+def _attach_response_timing(
+    patterns: tuple[CommandPattern, ...],
+    pairing: PairingResult | None,
+) -> tuple[CommandPattern, ...]:
+    if pairing is None or pairing.response_timing is None:
+        return patterns
+    return tuple(
+        replace(pattern, response_timing=pairing.response_timing)
+        if {step.direction for step in pattern.steps} == {"in", "out"}
+        else pattern
+        for pattern in patterns
+    )
+
+
+def _unanswered_commands(capture: CaptureLike, pairing: PairingResult) -> tuple[UnansweredCommand, ...]:
+    samples = tuple(
+        _sample
+        for command in pairing.unanswered_commands
+        for _sample in (
+            _find_event_sample(
+                capture,
+                command.device_id,
+                command.timestamp,
+                command.endpoint_number,
+                "out",
+                command.data_length,
+            ),
+        )
+        if _sample is not None
+    )
+    return tuple(
+        UnansweredCommand(
+            endpoint_number=group[0].endpoint_number,
+            endpoint_address=group[0].endpoint_address,
+            transfer_type=group[0].transfer_type,
+            occurrence_count=len(group),
+            first_occurrence_index=min(sample.packet_index for sample in group),
+            last_occurrence_index=max(sample.packet_index for sample in group),
+            first_occurrence_timestamp=min(sample.timestamp for sample in group),
+            last_occurrence_timestamp=max(sample.timestamp for sample in group),
+            signature_mode="full_prefix",
+            observed_length_range=(
+                min(len(sample.payload) for sample in group),
+                max(len(sample.payload) for sample in group),
+            ),
+            payload_signature=_payload_signature(group[0].payload),
+        )
+        for group in _anomaly_groups(samples)
+    )
+
+
+def _unsolicited_responses(capture: CaptureLike, pairing: PairingResult) -> tuple[UnsolicitedResponse, ...]:
+    samples = tuple(
+        _sample
+        for response in pairing.unsolicited_responses
+        for _sample in (
+            _find_event_sample(
+                capture,
+                response.device_id,
+                response.timestamp,
+                response.endpoint_number,
+                "in",
+                response.data_length,
+            ),
+        )
+        if _sample is not None
+    )
+    return tuple(
+        UnsolicitedResponse(
+            endpoint_number=group[0].endpoint_number,
+            endpoint_address=group[0].endpoint_address,
+            transfer_type=group[0].transfer_type,
+            occurrence_count=len(group),
+            first_occurrence_index=min(sample.packet_index for sample in group),
+            last_occurrence_index=max(sample.packet_index for sample in group),
+            first_occurrence_timestamp=min(sample.timestamp for sample in group),
+            last_occurrence_timestamp=max(sample.timestamp for sample in group),
+            signature_mode="full_prefix",
+            observed_length_range=(
+                min(len(sample.payload) for sample in group),
+                max(len(sample.payload) for sample in group),
+            ),
+            payload_signature=_payload_signature(group[0].payload),
+        )
+        for group in _anomaly_groups(samples)
+    )
+
+
+def _find_event_sample(
+    capture: CaptureLike,
+    device_id: str,
+    timestamp: float,
+    endpoint_number: int,
+    direction: Direction,
+    data_length: int,
+) -> _AnomalySample | None:
+    stream = build_analysis_events(cast(AnalyzerCaptureLike, capture))
+    candidates = [
+        event
+        for event in stream.events
+        if event.device_id == device_id
+        and event.endpoint_number == endpoint_number
+        and event.direction == direction
+        and len(event.payload) == data_length
+        and abs(event.timestamp - timestamp) < 0.000_001
+    ]
+    if not candidates:
+        return None
+    event = candidates[0]
+    return _AnomalySample(
+        packet_index=event.packet_index,
+        timestamp=event.timestamp,
+        endpoint_number=event.endpoint_number,
+        endpoint_address=event.endpoint_address,
+        direction=event.direction,
+        transfer_type=event.transfer_type,
+        payload=event.payload,
+    )
+
+
+def _anomaly_groups(samples: tuple[_AnomalySample, ...]) -> tuple[tuple[_AnomalySample, ...], ...]:
+    groups: dict[tuple[int, str, Direction, TransferType, tuple[int | None, ...]], list[_AnomalySample]] = {}
+    for sample in samples:
+        key = (
+            sample.endpoint_number,
+            sample.endpoint_address,
+            sample.direction,
+            sample.transfer_type,
+            _payload_signature(sample.payload),
+        )
+        groups.setdefault(key, []).append(sample)
+    return tuple(tuple(group) for _, group in sorted(groups.items(), key=lambda item: item[0]))
+
+
+def _payload_signature(payload: bytes) -> tuple[int | None, ...]:
+    return tuple(cast(int | None, byte) for byte in payload[:_ANOMALY_PREFIX_BYTES])
+
+
+def _incomplete_transfers(pairing: PairingResult) -> tuple[IncompleteTransfer, ...]:
+    counts: Counter[tuple[int, str, Direction, TransferType, str]] = Counter(
+        (
+            item.endpoint_number,
+            item.endpoint_address,
+            item.direction,
+            cast(TransferType, item.transfer_type),
+            item.reason,
+        )
+        for item in pairing.incomplete_transfers
+    )
+    return tuple(
+        IncompleteTransfer(
+            endpoint_number=endpoint_number,
+            endpoint_address=endpoint_address,
+            direction=direction,
+            transfer_type=transfer_type,
+            reason=cast(IncompleteTransferReason, reason),
+            occurrence_count=count,
+        )
+        for (endpoint_number, endpoint_address, direction, transfer_type, reason), count in sorted(counts.items())
+    )

--- a/bsu_tool/analysis/description.py
+++ b/bsu_tool/analysis/description.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
-from typing import Protocol, cast
+from typing import Final, Protocol, cast
 
 from bsu_tool.analysis.models import (
     AnalysisObservation,
@@ -14,6 +14,7 @@ from bsu_tool.analysis.models import (
     IncompleteTransfer,
     IncompleteTransferReason,
     MarkerCorrelation,
+    ObservationReason,
     PatternOccurrence,
     PatternStep,
     ProtocolHypothesis,
@@ -22,12 +23,17 @@ from bsu_tool.analysis.models import (
     TransferType,
     UnansweredCommand,
     UnsolicitedResponse,
+    VariableByteRange,
 )
 from bsu_tool.analysis.pairing import PairingResult, pair_command_responses
 from bsu_tool.analyzer import (
     MAX_COMMAND_PATTERNS_RETURNED,
+    MAX_SEQUENCE_WINDOW,
     MAX_VARIABLE_VALUES_REPORTED,
+    AnalysisEvent,
+    PayloadSignature,
     build_analysis_events,
+    normalize_tokens,
 )
 from bsu_tool.analyzer import (
     CaptureLike as AnalyzerCaptureLike,
@@ -35,9 +41,17 @@ from bsu_tool.analyzer import (
 from bsu_tool.mcp.interfaces import DeviceSummary
 from bsu_tool.urb_decoder import UrbRecord, UrbTransaction
 
-_MARKER_CORRELATION_THRESHOLD_PERCENT = 50.0
+_MARKER_CORRELATION_THRESHOLD_PERCENT = 70.0
 _SUMMARY_PATTERN_LIMIT = 3
 _ANOMALY_PREFIX_BYTES = 8
+MARKER_CORRELATION_WINDOW_SECONDS: Final[float] = 2.0
+"""Maximum distance from a marker for single-occurrence marker observations."""
+MAX_OBSERVATIONS_RETURNED: Final[int] = 10
+"""Maximum observations returned by the assembly layer, matching spec §7."""
+MIN_OBSERVATION_STEPS: Final[int] = 2
+"""Minimum OUT/IN steps for a single-occurrence multi-step observation."""
+
+_Token = tuple[int, Direction, TransferType, SignatureMode, PayloadSignature]
 
 
 class CaptureLike(Protocol):
@@ -86,6 +100,19 @@ class MarkerLike(Protocol):
     def note(self) -> str | None:
         """Optional marker note."""
         ...
+
+
+class _TokenInfoLike(Protocol):
+    """Token metadata shape returned by analyzer normalization."""
+
+    endpoint_number: int
+    endpoint_address: str
+    direction: Direction
+    transfer_type: TransferType
+    signature_mode: SignatureMode
+    payload_signature: PayloadSignature
+    observed_length_range: tuple[int, int]
+    variable_byte_ranges: tuple[VariableByteRange, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -233,6 +260,18 @@ class _AnomalySample:
     payload: bytes
 
 
+@dataclass(frozen=True, slots=True)
+class _ObservationCandidate:
+    """One single-occurrence sequence that may become an observation."""
+
+    reason: ObservationReason
+    sequence: tuple[_Token, ...]
+    start: AnalysisEvent
+    steps: tuple[PatternStep, ...]
+    nearest_marker: str | None
+    marker_distance_seconds: float
+
+
 def assemble_protocol_hypotheses(
     capture: CaptureLike,
     *,
@@ -260,30 +299,33 @@ def assemble_protocol_hypotheses(
     for sequence_result in sequence_results:
         pairing = pairing_by_device.get(sequence_result.device_id)
         marker_correlations, patterns = _correlate_markers(sequence_result.patterns, markers)
-        patterns = _attach_response_timing(patterns, pairing)
+        observations, observations_truncated = _single_occurrence_observations(
+            capture,
+            sequence_result.device_id,
+            patterns,
+            markers,
+        )
         notes = list(sequence_result.analysis_notes)
         if pairing is not None:
             notes.extend(pairing.analysis_notes)
+        if observations_truncated:
+            notes.append(f"single-occurrence observations truncated to the top {MAX_OBSERVATIONS_RETURNED} by rank")
         hypotheses.append(
             ProtocolHypothesis(
                 device_id=sequence_result.device_id,
                 command_patterns=patterns,
-                observations=_observations_for(patterns, marker_correlations),
+                observations=observations,
                 unsolicited_responses=_unsolicited_responses(capture, pairing) if pairing is not None else (),
                 unanswered_commands=_unanswered_commands(capture, pairing) if pairing is not None else (),
                 incomplete_transfers=_incomplete_transfers(pairing) if pairing is not None else (),
                 marker_correlations=marker_correlations,
                 result_limits=ResultLimits(
                     max_command_patterns=MAX_COMMAND_PATTERNS_RETURNED,
-                    max_observations=len(patterns),
+                    max_observations=MAX_OBSERVATIONS_RETURNED,
                     max_variable_values_reported=MAX_VARIABLE_VALUES_REPORTED,
                     command_patterns_truncated=sequence_result.patterns_truncated,
-                    observations_truncated=False,
-                    truncation_note=(
-                        f"command patterns truncated to the top {MAX_COMMAND_PATTERNS_RETURNED}"
-                        if sequence_result.patterns_truncated
-                        else None
-                    ),
+                    observations_truncated=observations_truncated,
+                    truncation_note=_truncation_note(sequence_result.patterns_truncated, observations_truncated),
                 ),
                 analysis_notes=tuple(dict.fromkeys(notes)),
             )
@@ -294,24 +336,31 @@ def assemble_protocol_hypotheses(
 def describe_protocol(
     capture: CaptureLike,
     *,
+    device_summaries: tuple[DeviceSummary, ...],
     device_id: str | None = None,
-    device_summaries: tuple[DeviceSummary, ...] = (),
 ) -> tuple[ProtocolDescription, ...]:
     """Assemble concise, deterministic descriptions for a loaded capture.
 
     Args:
         capture: Loaded capture state.
+        device_summaries: Summaries from ``Session.list_devices()``. Required so
+            protocol descriptions stay anchored to device and descriptor context.
         device_id: Restrict analysis to one device. ``None`` describes each device
             reported by the analysis engine.
-        device_summaries: Optional summaries from ``Session.list_devices()``.
 
     Returns:
         One presentation object per analyzed device.
+
+    Raises:
+        ValueError: The analyzer returned a device with no matching device summary.
     """
     summaries = {summary.device_id: summary for summary in device_summaries}
     descriptions: list[ProtocolDescription] = []
     for hypothesis in assemble_protocol_hypotheses(capture, device_id=device_id):
-        description = _describe_hypothesis(hypothesis, summaries.get(hypothesis.device_id))
+        summary = summaries.get(hypothesis.device_id)
+        if summary is None:
+            raise ValueError(f"missing device summary for {hypothesis.device_id}")
+        description = _describe_hypothesis(hypothesis, summary)
         descriptions.append(replace(description, deterministic_summary=format_protocol_summary(description)))
     return tuple(descriptions)
 
@@ -342,6 +391,9 @@ def format_protocol_summary(description: ProtocolDescription) -> str:
     if description.incomplete_transfers:
         count = sum(item.occurrence_count for item in description.incomplete_transfers)
         parts.append(f"{count} incomplete transfer occurrence{'' if count == 1 else 's'}.")
+    if description.observations:
+        count = len(description.observations)
+        parts.append(f"{count} single-occurrence observation{'' if count == 1 else 's'}.")
     return " ".join(parts)
 
 
@@ -554,6 +606,9 @@ def _endpoint_roles(hypothesis: ProtocolHypothesis) -> tuple[EndpointRoleDescrip
         counter[(anomaly.endpoint_address, "out", anomaly.transfer_type)] += anomaly.occurrence_count
     for anomaly in hypothesis.unsolicited_responses:
         counter[(anomaly.endpoint_address, "in", anomaly.transfer_type)] += anomaly.occurrence_count
+    for observation in hypothesis.observations:
+        for step in observation.steps:
+            counter[(step.endpoint_address, step.direction, step.transfer_type)] += 1
 
     roles: list[EndpointRoleDescription] = []
     for (endpoint_address, direction, transfer_type), count in sorted(counter.items()):
@@ -643,39 +698,143 @@ def _marker_span_name(
     return None
 
 
-def _observations_for(
+def _single_occurrence_observations(
+    capture: CaptureLike,
+    device_id: str,
     patterns: tuple[CommandPattern, ...],
-    correlations: tuple[MarkerCorrelation, ...],
-) -> tuple[AnalysisObservation, ...]:
-    by_id = {correlation.correlation_id: correlation for correlation in correlations}
-    observations: list[AnalysisObservation] = []
-    for pattern in patterns:
-        correlation = by_id.get(pattern.marker_correlation_id or "")
-        if correlation is None:
-            continue
-        observations.append(
-            AnalysisObservation(
-                observation_id=f"observation_{len(observations) + 1:02d}",
-                reason="near_marker",
-                steps=pattern.steps,
-                nearest_marker=correlation.marker_name,
-            )
+    markers: tuple[MarkerLike, ...],
+) -> tuple[tuple[AnalysisObservation, ...], bool]:
+    analyzer_capture = cast(AnalyzerCaptureLike, capture)
+    stream = build_analysis_events(analyzer_capture, device_id=device_id)
+    events = tuple(event for event in stream.events if event.device_id == device_id and not event.failed)
+    if not events:
+        return (), False
+
+    token_by_index, raw_info_by_token, _notes = normalize_tokens(events)
+    info_by_token = cast(dict[_Token, _TokenInfoLike], raw_info_by_token)
+    promoted = _promoted_sequences(patterns)
+    counts: Counter[tuple[_Token, ...]] = Counter()
+    for start in range(len(events)):
+        max_width = min(MAX_SEQUENCE_WINDOW, len(events) - start)
+        for width in range(1, max_width + 1):
+            window = events[start : start + width]
+            sequence = tuple(token_by_index[event.packet_index] for event in window)
+            counts[sequence] += 1
+
+    candidates: list[_ObservationCandidate] = []
+    for start in range(len(events)):
+        max_width = min(MAX_SEQUENCE_WINDOW, len(events) - start)
+        for width in range(1, max_width + 1):
+            window = events[start : start + width]
+            sequence = tuple(token_by_index[event.packet_index] for event in window)
+            if counts[sequence] != 1 or sequence in promoted:
+                continue
+            steps = tuple(_step_from_token(index, info_by_token[token]) for index, token in enumerate(sequence))
+            marker, distance = _nearest_marker(window[0].timestamp, markers)
+            if marker is not None and distance <= MARKER_CORRELATION_WINDOW_SECONDS:
+                candidates.append(
+                    _ObservationCandidate(
+                        reason="near_marker",
+                        sequence=sequence,
+                        start=window[0],
+                        steps=steps,
+                        nearest_marker=marker.name,
+                        marker_distance_seconds=distance,
+                    )
+                )
+                continue
+            if width >= MIN_OBSERVATION_STEPS and {event.direction for event in window} == {"in", "out"}:
+                candidates.append(
+                    _ObservationCandidate(
+                        reason="multi_step_exchange",
+                        sequence=sequence,
+                        start=window[0],
+                        steps=steps,
+                        nearest_marker=None,
+                        marker_distance_seconds=float("inf"),
+                    )
+                )
+
+    ranked = _rank_observation_candidates(candidates)
+    truncated = len(ranked) > MAX_OBSERVATIONS_RETURNED
+    observations = tuple(
+        AnalysisObservation(
+            observation_id=f"observation_{index + 1:02d}",
+            reason=candidate.reason,
+            steps=candidate.steps,
+            nearest_marker=candidate.nearest_marker,
         )
-    return tuple(observations)
-
-
-def _attach_response_timing(
-    patterns: tuple[CommandPattern, ...],
-    pairing: PairingResult | None,
-) -> tuple[CommandPattern, ...]:
-    if pairing is None or pairing.response_timing is None:
-        return patterns
-    return tuple(
-        replace(pattern, response_timing=pairing.response_timing)
-        if {step.direction for step in pattern.steps} == {"in", "out"}
-        else pattern
-        for pattern in patterns
+        for index, candidate in enumerate(ranked[:MAX_OBSERVATIONS_RETURNED])
     )
+    return observations, truncated
+
+
+def _promoted_sequences(patterns: tuple[CommandPattern, ...]) -> set[tuple[_Token, ...]]:
+    return {
+        tuple(
+            (
+                step.endpoint_number,
+                step.direction,
+                step.transfer_type,
+                step.signature_mode,
+                step.payload_signature,
+            )
+            for step in pattern.steps
+        )
+        for pattern in patterns
+    }
+
+
+def _step_from_token(step_index: int, info: _TokenInfoLike) -> PatternStep:
+    return PatternStep(
+        step_index=step_index,
+        endpoint_number=info.endpoint_number,
+        endpoint_address=info.endpoint_address,
+        direction=info.direction,
+        transfer_type=info.transfer_type,
+        signature_mode=info.signature_mode,
+        payload_signature=info.payload_signature,
+        observed_length_range=info.observed_length_range,
+        variable_byte_ranges=info.variable_byte_ranges,
+    )
+
+
+def _nearest_marker(timestamp: float, markers: tuple[MarkerLike, ...]) -> tuple[MarkerLike | None, float]:
+    if not markers:
+        return None, float("inf")
+    marker = min(markers, key=lambda item: (abs(timestamp - item.timestamp), item.packet_index, item.name))
+    return marker, abs(timestamp - marker.timestamp)
+
+
+def _rank_observation_candidates(
+    candidates: list[_ObservationCandidate],
+) -> tuple[_ObservationCandidate, ...]:
+    deduplicated: dict[tuple[int, tuple[_Token, ...]], _ObservationCandidate] = {}
+    for candidate in candidates:
+        key = (candidate.start.packet_index, candidate.sequence)
+        existing = deduplicated.get(key)
+        if existing is None or _observation_sort_key(candidate) < _observation_sort_key(existing):
+            deduplicated[key] = candidate
+    return tuple(sorted(deduplicated.values(), key=_observation_sort_key))
+
+
+def _observation_sort_key(candidate: _ObservationCandidate) -> tuple[float, int, float, int, ObservationReason]:
+    return (
+        candidate.marker_distance_seconds,
+        -len(candidate.sequence),
+        candidate.start.timestamp,
+        candidate.start.packet_index,
+        candidate.reason,
+    )
+
+
+def _truncation_note(patterns_truncated: bool, observations_truncated: bool) -> str | None:
+    notes: list[str] = []
+    if patterns_truncated:
+        notes.append(f"command patterns truncated to the top {MAX_COMMAND_PATTERNS_RETURNED}")
+    if observations_truncated:
+        notes.append(f"single-occurrence observations truncated to the top {MAX_OBSERVATIONS_RETURNED}")
+    return "; ".join(notes) if notes else None
 
 
 def _unanswered_commands(capture: CaptureLike, pairing: PairingResult) -> tuple[UnansweredCommand, ...]:

--- a/docs/architecture/protocol-description.md
+++ b/docs/architecture/protocol-description.md
@@ -1,7 +1,8 @@
 # Protocol Description Layer
 
 **Issue:** #66
-**Status:** Phase 1 models unblocked; assembly blocked on analyzer output from #63 and #64
+**Status:** Phase 1 shared models merged; Phase 2 description assembly implemented after #63
+and #64
 
 ---
 
@@ -36,15 +37,15 @@ Issue #66 has two phases:
   importing analyzer internals.
 - Announce the first commit in Discord when it lands so #63 and #64 can rebase/import it.
 
-**Phase 2 — description assembly, blocked**
-- **#63 repeated-sequence detection** for `CommandPattern`, `PatternStep`,
-  token signatures, analysis notes, and occurrence locations when the analyzer exposes them.
-- **#64 command/response pairing** for response timing, unanswered commands, unsolicited
-  responses, and command/response relationships.
+**Phase 2 — description assembly, implemented after #63/#64**
+- **#63 repeated-sequence detection** provides `CommandPattern`, `PatternStep`,
+  token signatures, analysis notes, and occurrence locations.
+- **#64 command/response pairing** provides command/response pairs, response timing,
+  unanswered commands, unsolicited responses, and incomplete-transfer evidence.
 
-Until #63 and #64 merge, #66 can prepare deterministic formatting rules and synthetic tests.
-It should avoid importing unmerged analyzer modules or duplicating dataclasses that now live
-in `bsu_tool.analysis.models`.
+The assembly code lives in `bsu_tool/analysis/description.py`. It imports the merged #63
+and #64 APIs, preserves the shared dataclasses from `bsu_tool.analysis.models`, and emits a
+presentation object plus deterministic summary for downstream MCP tooling.
 
 ---
 
@@ -74,6 +75,7 @@ class ProtocolDescription:
     device_id: str
     device_summary: DeviceContextSummary
     headline: str
+    deterministic_summary: str
     endpoint_roles: tuple[EndpointRoleDescription, ...]
     commands: tuple[CommandDescription, ...]
     observations: tuple[ObservationDescription, ...]
@@ -176,8 +178,8 @@ class EvidenceSpan:
 that matter for verification: `pattern_id`, marker correlation IDs, first packet indices,
 timestamps, `analysis_notes`, and truncation flags.
 
-The exact dataclass names may change during implementation, but all referenced presentation
-types should be defined in the #66 code rather than left as implicit dictionaries.
+The presentation dataclasses are defined in `bsu_tool.analysis.description`. The shared
+analysis output models remain in `bsu_tool.analysis.models`.
 
 Names such as `command_01` should be deterministic. More specific names, such as
 `relay_toggle`, require marker correlation or analyst-provided labels and should not be
@@ -230,27 +232,30 @@ The exact wording can evolve, but tests should assert stable content categories:
 
 ---
 
+## Module Location
+
+- `bsu_tool/analysis/models.py` holds the shared M3 §5 output models.
+- `bsu_tool/analysis/description.py` assembles `ProtocolHypothesis` objects from #63 and
+  #64 results, then formats `ProtocolDescription` objects and deterministic summaries.
+- `tests/unit/test_protocol_description.py` covers synthetic marker grouping and pairing
+  anomaly aggregation.
+- `tests/int/test_protocol_description_goodix.py` snapshot-tests the Goodix reference
+  summary.
+- #67 should expose this layer through the MCP `analyze_protocol` tool instead of adding
+  MCP registration to #66.
+
 ## Testing Plan
 
-Before #63 and #64 merge:
-- Add and validate `bsu_tool/analysis/models.py` as the first branch commit.
-- Unit-test the formatter with synthetic `ProtocolHypothesis` fixtures imported from
-  `bsu_tool.analysis.models`.
+- Unit-test the formatter with synthetic captures.
 - Verify deterministic command names and stable ordering.
-- Verify marker grouping when `marker_correlation_id` is present.
+- Verify marker grouping when marker ranges bracket pattern occurrences.
 - Verify low-confidence and `analysis_notes` text is preserved.
 - Verify `result_limits.command_patterns_truncated`,
   `result_limits.observations_truncated`, and `result_limits.truncation_note` survive into
   the description.
-
-After #63 merges:
-- Replace synthetic pattern fixtures with real analyzer dataclasses.
-- Add a snapshot test for at least one Goodix repeated pattern.
-
-After #64 merges:
-- Add response-pairing summaries and timing assertions.
-- Add tests for unanswered commands and unsolicited responses with packet indices.
-- Add tests that incomplete transfers remain neutral capture-boundary evidence.
+- Snapshot-test the Goodix reference summary.
+- Verify unanswered commands, unsolicited responses, and incomplete transfers remain
+  separate evidence groups.
 
 Final acceptance for #66:
 - `bsu_tool/analysis/models.py` matches M3 spec §5 field for field and lands as the first
@@ -258,25 +263,3 @@ Final acceptance for #66:
 - emits readable deterministic prose plus structured output for Goodix
 - groups findings by physical action using markers
 - passes `ruff`, `pyright` strict, and `pytest`
-
----
-
-## Module Location
-
-Planned implementation locations:
-- `bsu_tool/analysis/models.py` — shared analyzer output dataclasses from M3 spec §5;
-  this must land before #63 and #64 import it and must be the first commit on this branch
-- `bsu_tool/analysis/description.py` — presentation dataclasses and pure formatting
-  helpers for issue #66
-- `tests/unit/test_protocol_description.py` — synthetic `ProtocolHypothesis` formatter tests
-- `tests/int/test_mcp_describe_protocol_goodix.py` — Goodix integration test after #63 and
-  #64 provide analyzer output
-
-The first implementation should be a pure Python layer callable from `analyze_protocol`.
-Whether it becomes a separate MCP tool such as `describe_protocol` or a field on
-`analyze_protocol` should be decided after #63 and #64 settle the analyzer response shape.
-
-Commit order matters:
-1. `bsu_tool/analysis/__init__.py` and `bsu_tool/analysis/models.py`
-2. documentation and #66 planning updates
-3. formatter/assembly implementation after #63 and #64 land

--- a/docs/architecture/protocol-description.md
+++ b/docs/architecture/protocol-description.md
@@ -45,7 +45,9 @@ Issue #66 has two phases:
 
 The assembly code lives in `bsu_tool/analysis/description.py`. It imports the merged #63
 and #64 APIs, preserves the shared dataclasses from `bsu_tool.analysis.models`, and emits a
-presentation object plus deterministic summary for downstream MCP tooling.
+presentation object plus deterministic summary for downstream MCP tooling. The presentation
+entry point requires device summaries from `Session.list_devices()` so protocol descriptions
+stay anchored to descriptor and endpoint context.
 
 ---
 
@@ -204,7 +206,11 @@ marker hits. With the M3 spec's current model, each `CommandPattern` has at most
    normalization safety valves remain visible to the analyst.
 7. Preserve unanswered commands, unsolicited responses, and incomplete transfers as separate
    evidence groups; do not fold them into named commands.
-8. Prefer short, template-based prose. Avoid speculative protocol names unless marker names
+8. Preserve §3.2 single-occurrence observations when they are marker-adjacent or when they
+   are non-repeating multi-step OUT/IN exchanges.
+9. Do not copy device-wide response timing onto individual command patterns. Per-pattern
+   timing should appear only when the assembler can tie pair evidence to that exact pattern.
+10. Prefer short, template-based prose. Avoid speculative protocol names unless marker names
    or device context support them.
 
 ---
@@ -249,10 +255,13 @@ The exact wording can evolve, but tests should assert stable content categories:
 - Unit-test the formatter with synthetic captures.
 - Verify deterministic command names and stable ordering.
 - Verify marker grouping when marker ranges bracket pattern occurrences.
+- Verify marker-adjacent and multi-step single-occurrence observations are preserved.
 - Verify low-confidence and `analysis_notes` text is preserved.
 - Verify `result_limits.command_patterns_truncated`,
   `result_limits.observations_truncated`, and `result_limits.truncation_note` survive into
   the description.
+- Verify `result_limits.max_observations` reports the spec constant rather than the command
+  pattern count.
 - Snapshot-test the Goodix reference summary.
 - Verify unanswered commands, unsolicited responses, and incomplete transfers remain
   separate evidence groups.

--- a/tests/int/test_protocol_description_goodix.py
+++ b/tests/int/test_protocol_description_goodix.py
@@ -1,0 +1,33 @@
+"""Integration tests for protocol descriptions on the Goodix reference capture."""
+
+from __future__ import annotations
+
+import pathlib
+
+from bsu_tool.analysis.description import describe_protocol
+from bsu_tool.session import Session
+
+_CAPTURE = (
+    pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures" / "goodix_enum_and_enroll_sanitized.pcapng"
+)
+_GOODIX_DEVICE = "27c6_63ac"
+
+
+def test_goodix_protocol_description_snapshot() -> None:
+    """Goodix emits a structured description plus deterministic summary."""
+    session = Session()
+    capture = session.load(_CAPTURE)
+    description = describe_protocol(capture, device_id=_GOODIX_DEVICE, device_summaries=session.list_devices())[0]
+
+    assert description.device_id == _GOODIX_DEVICE
+    assert description.device_summary.product == "Goodix Fingerprint USB Device"
+    assert description.commands
+    assert description.endpoint_roles
+    assert description.deterministic_summary == (
+        "Device 27c6_63ac has 5 repeated command patterns across 2 endpoint roles. "
+        "command_01 occurs 11 times; evidence packets 149-251. command_02 occurs 10 times; "
+        "evidence packets 149-243. command_03 occurs 3 times; evidence packets 176-225. "
+        "Contains OUT and IN steps; response timing was not isolated to this pattern. "
+        "3 unanswered command occurrences. 42 unsolicited response occurrences. "
+        "1 incomplete transfer occurrence."
+    )

--- a/tests/int/test_protocol_description_goodix.py
+++ b/tests/int/test_protocol_description_goodix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pathlib
 
-from bsu_tool.analysis.description import describe_protocol
+from bsu_tool.analysis.description import MAX_OBSERVATIONS_RETURNED, assemble_protocol_hypotheses, describe_protocol
 from bsu_tool.session import Session
 
 _CAPTURE = (
@@ -22,6 +22,7 @@ def test_goodix_protocol_description_snapshot() -> None:
     assert description.device_id == _GOODIX_DEVICE
     assert description.device_summary.product == "Goodix Fingerprint USB Device"
     assert description.commands
+    assert len(description.observations) == MAX_OBSERVATIONS_RETURNED
     assert description.endpoint_roles
     assert description.deterministic_summary == (
         "Device 27c6_63ac has 5 repeated command patterns across 2 endpoint roles. "
@@ -29,5 +30,17 @@ def test_goodix_protocol_description_snapshot() -> None:
         "evidence packets 149-243. command_03 occurs 3 times; evidence packets 176-225. "
         "Contains OUT and IN steps; response timing was not isolated to this pattern. "
         "3 unanswered command occurrences. 42 unsolicited response occurrences. "
-        "1 incomplete transfer occurrence."
+        "1 incomplete transfer occurrence. 10 single-occurrence observations."
     )
+
+
+def test_goodix_hypothesis_preserves_single_occurrence_observations() -> None:
+    """Goodix preserves capped multi-step single-occurrence observations."""
+    session = Session()
+    capture = session.load(_CAPTURE)
+    hypothesis = assemble_protocol_hypotheses(capture, device_id=_GOODIX_DEVICE)[0]
+
+    assert len(hypothesis.observations) == MAX_OBSERVATIONS_RETURNED
+    assert {observation.reason for observation in hypothesis.observations} == {"multi_step_exchange"}
+    assert hypothesis.result_limits.max_observations == MAX_OBSERVATIONS_RETURNED
+    assert hypothesis.result_limits.observations_truncated is True

--- a/tests/unit/test_protocol_description.py
+++ b/tests/unit/test_protocol_description.py
@@ -1,0 +1,145 @@
+"""Unit tests for protocol description assembly."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from bsu_tool.analysis.description import assemble_protocol_hypotheses, describe_protocol
+from bsu_tool.device_identity import DeviceIdMap, address_device_id
+from bsu_tool.urb_decoder import Direction, TransferType, UrbRecord, UrbTransaction, pair_urbs
+
+_BUS = 1
+_DEV = 2
+_SUBMISSION_STATUS = -115
+
+
+@dataclass(frozen=True)
+class _Marker:
+    """Minimal marker fixture for description tests."""
+
+    name: str
+    timestamp: float
+    packet_index: int
+    note: str | None = None
+
+
+@dataclass
+class _FakeCapture:
+    """Minimal capture fixture satisfying the description assembler protocol."""
+
+    records: tuple[UrbRecord, ...]
+    transactions: tuple[UrbTransaction, ...]
+    markers: tuple[_Marker, ...] = ()
+    device_ids: DeviceIdMap = field(default_factory=lambda: DeviceIdMap())
+
+    def __post_init__(self) -> None:
+        """Derive address fallback ids when the fixture does not provide them."""
+        if not self.device_ids:
+            self.device_ids = {
+                (record.bus_num, record.dev_num): address_device_id(record.bus_num, record.dev_num)
+                for record in self.records
+            }
+
+
+def _transfer(
+    urb_id: int,
+    transfer_type: TransferType,
+    direction: Direction,
+    endpoint: int,
+    payload: bytes,
+    *,
+    status: int = 0,
+    timestamp: float = 0.0,
+    drop_completion: bool = False,
+) -> list[UrbRecord]:
+    """Build a submission/completion pair for one transfer."""
+    out = direction == "out"
+    submission = UrbRecord(
+        urb_id=urb_id,
+        event_type="submission",
+        transfer_type=transfer_type,
+        direction=direction,
+        bus_num=_BUS,
+        dev_num=_DEV,
+        endpoint=endpoint,
+        status=_SUBMISSION_STATUS,
+        length=len(payload),
+        captured_length=len(payload) if out else 0,
+        data=payload if out else b"",
+        setup=None,
+        timestamp=timestamp,
+    )
+    if drop_completion:
+        return [submission]
+    completion = UrbRecord(
+        urb_id=urb_id,
+        event_type="completion",
+        transfer_type=transfer_type,
+        direction=direction,
+        bus_num=_BUS,
+        dev_num=_DEV,
+        endpoint=endpoint,
+        status=status,
+        length=len(payload),
+        captured_length=0 if out else len(payload),
+        data=b"" if out else payload,
+        setup=None,
+        timestamp=timestamp + 0.001,
+    )
+    return [submission, completion]
+
+
+def _out(urb_id: int, payload: bytes, timestamp: float) -> list[UrbRecord]:
+    """Build a bulk OUT transfer."""
+    return _transfer(urb_id, "bulk", "out", 1, payload, timestamp=timestamp)
+
+
+def _in(urb_id: int, payload: bytes, timestamp: float) -> list[UrbRecord]:
+    """Build a bulk IN transfer."""
+    return _transfer(urb_id, "bulk", "in", 1, payload, timestamp=timestamp)
+
+
+def _capture(*groups: list[UrbRecord], markers: tuple[_Marker, ...] = ()) -> _FakeCapture:
+    """Assemble fixture records into a paired capture."""
+    records: list[UrbRecord] = []
+    for group in groups:
+        records.extend(group)
+    return _FakeCapture(records=tuple(records), transactions=tuple(pair_urbs(records)), markers=markers)
+
+
+def test_description_groups_commands_by_marker_range() -> None:
+    """Repeated command patterns carry marker correlation into readable commands."""
+    capture = _capture(
+        _out(1, b"\x10\x00", 1.0),
+        _in(2, b"\x10\xaa", 1.1),
+        _out(3, b"\x10\x01", 2.0),
+        _in(4, b"\x10\xab", 2.1),
+        markers=(
+            _Marker(name="enroll-start", timestamp=0.5, packet_index=0),
+            _Marker(name="enroll-end", timestamp=2.5, packet_index=7),
+        ),
+    )
+
+    description = describe_protocol(capture)[0]
+
+    assert description.commands
+    assert description.commands[0].markers == ("enroll-start..enroll-end",)
+    assert description.observations[0].nearest_marker == "enroll-start..enroll-end"
+    assert "near enroll-start..enroll-end" in description.deterministic_summary
+
+
+def test_hypothesis_preserves_anomalies_and_incomplete_transfers() -> None:
+    """Pairing anomalies are aggregated into the protocol hypothesis model."""
+    capture = _capture(
+        _out(1, b"\x20\x00", 1.0),
+        _in(2, b"\x99\x00", 8.0),
+        _transfer(3, "bulk", "out", 1, b"\x30", timestamp=20.0, drop_completion=True),
+    )
+
+    hypothesis = assemble_protocol_hypotheses(capture)[0]
+
+    assert hypothesis.unanswered_commands
+    assert hypothesis.unsolicited_responses
+    assert hypothesis.incomplete_transfers
+    assert hypothesis.unanswered_commands[0].first_occurrence_index == 0
+    assert hypothesis.unsolicited_responses[0].first_occurrence_index == 3

--- a/tests/unit/test_protocol_description.py
+++ b/tests/unit/test_protocol_description.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from bsu_tool.analysis.description import assemble_protocol_hypotheses, describe_protocol
+import pytest
+
+from bsu_tool.analysis.description import MAX_OBSERVATIONS_RETURNED, assemble_protocol_hypotheses, describe_protocol
 from bsu_tool.device_identity import DeviceIdMap, address_device_id
+from bsu_tool.mcp.interfaces import DeviceSummary, EndpointSummary
 from bsu_tool.urb_decoder import Direction, TransferType, UrbRecord, UrbTransaction, pair_urbs
 
 _BUS = 1
@@ -107,8 +110,26 @@ def _capture(*groups: list[UrbRecord], markers: tuple[_Marker, ...] = ()) -> _Fa
     return _FakeCapture(records=tuple(records), transactions=tuple(pair_urbs(records)), markers=markers)
 
 
+def _device_summary(device_id: str = "dev_001_002") -> DeviceSummary:
+    """Build a minimal device summary for protocol descriptions."""
+    return DeviceSummary(
+        device_id=device_id,
+        bus_num=_BUS,
+        dev_num=_DEV,
+        packet_count=0,
+        endpoints_seen=(EndpointSummary(address="0x01", packet_count=0, byte_count=0),),
+        transfer_types_seen=("bulk",),
+        vendor_id="0x1234",
+        product_id="0xabcd",
+        manufacturer="Example",
+        product="Example Device",
+        descriptor_summary="Example Device (0x1234:0xabcd)",
+        interface_class=0xFF,
+    )
+
+
 def test_description_groups_commands_by_marker_range() -> None:
-    """Repeated command patterns carry marker correlation into readable commands."""
+    """Repeated patterns and single-occurrence observations carry marker context."""
     capture = _capture(
         _out(1, b"\x10\x00", 1.0),
         _in(2, b"\x10\xaa", 1.1),
@@ -120,12 +141,56 @@ def test_description_groups_commands_by_marker_range() -> None:
         ),
     )
 
-    description = describe_protocol(capture)[0]
+    description = describe_protocol(capture, device_summaries=(_device_summary(),))[0]
 
     assert description.commands
     assert description.commands[0].markers == ("enroll-start..enroll-end",)
-    assert description.observations[0].nearest_marker == "enroll-start..enroll-end"
+    assert description.observations
+    assert description.observations[0].reason == "near_marker"
+    assert description.observations[0].nearest_marker == "enroll-start"
     assert "near enroll-start..enroll-end" in description.deterministic_summary
+
+
+def test_hypothesis_does_not_attach_device_timing_to_patterns() -> None:
+    """Device-wide pairing timing is not copied onto individual command patterns."""
+    capture = _capture(
+        _out(1, b"\x10\x00", 1.0),
+        _in(2, b"\x10\xaa", 1.1),
+        _out(3, b"\x10\x01", 2.0),
+        _in(4, b"\x10\xab", 2.1),
+    )
+
+    hypothesis = assemble_protocol_hypotheses(capture)[0]
+
+    assert any({step.direction for step in pattern.steps} == {"in", "out"} for pattern in hypothesis.command_patterns)
+    assert all(pattern.response_timing is None for pattern in hypothesis.command_patterns)
+
+
+def test_multi_step_single_occurrences_become_observations() -> None:
+    """Non-repeating multi-step OUT/IN exchanges are preserved as observations."""
+    capture = _capture(
+        _out(1, b"\x10\x00", 1.0),
+        _in(2, b"\x10\xaa", 1.1),
+        _out(3, b"\x10\x01", 2.0),
+        _in(4, b"\x10\xab", 2.1),
+    )
+
+    hypothesis = assemble_protocol_hypotheses(capture)[0]
+
+    assert hypothesis.observations
+    assert hypothesis.observations[0].reason == "multi_step_exchange"
+    assert hypothesis.observations[0].nearest_marker is None
+    assert {step.direction for step in hypothesis.observations[0].steps} == {"in", "out"}
+    assert hypothesis.result_limits.max_observations == MAX_OBSERVATIONS_RETURNED
+    assert hypothesis.result_limits.observations_truncated is False
+
+
+def test_description_requires_device_context() -> None:
+    """Descriptions need device summaries so hypotheses are not context-free."""
+    capture = _capture(_out(1, b"\x10\x00", 1.0), _out(2, b"\x10\x00", 2.0))
+
+    with pytest.raises(ValueError, match="missing device summary"):
+        describe_protocol(capture, device_summaries=())
 
 
 def test_hypothesis_preserves_anomalies_and_incomplete_transfers() -> None:


### PR DESCRIPTION
## What does this PR do?

Implements the issue #66 protocol description assembly layer.

This adds `bsu_tool.analysis.description`, which combines the merged repeated-sequence detector (#63) and command/response pairing output (#64) into structured `ProtocolHypothesis` / `ProtocolDescription` results. It also adds a short deterministic summary intended for snapshot tests and for the future `analyze_protocol` MCP wrapper in #67.

The description layer preserves command evidence, endpoint roles, marker-range grouping, analysis notes, result-limit fields, unanswered commands, unsolicited responses, and incomplete-transfer evidence.

Closes  #66.

## How was it tested?

- `ruff check .`
- `ruff format --check .`
- `pyright bsu_tool/analysis tests/unit/test_protocol_description.py tests/int/test_protocol_description_goodix.py`
- `pytest tests/unit/test_protocol_description.py tests/int/test_protocol_description_goodix.py tests/unit/test_annotations.py`
- `pytest --ignore=tests/int/test_agent_sdk_mcp.py`

Full `pytest` and full `pyright` still hit existing optional dependency issues around `claude_agent_sdk` / `mcp` in this local environment, unrelated to this PR.

## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR