### PR TITLE
136/bounded analysis response

### DIFF
--- a/bsu_tool/analysis/description.py
+++ b/bsu_tool/analysis/description.py
@@ -50,6 +50,8 @@ MAX_OBSERVATIONS_RETURNED: Final[int] = 10
 """Maximum observations returned by the assembly layer, matching spec §7."""
 MIN_OBSERVATION_STEPS: Final[int] = 2
 """Minimum OUT/IN steps for a single-occurrence multi-step observation."""
+MAX_ANOMALY_SAMPLES_REPORTED: Final[int] = 5
+"""Per-group evidence spans kept when pairing anomalies are grouped."""
 
 _Token = tuple[int, Direction, TransferType, SignatureMode, PayloadSignature]
 
@@ -152,6 +154,7 @@ class ResultLimitSummary:
 
     command_patterns_truncated: bool
     observations_truncated: bool
+    anomaly_groups_sampled: bool
     truncation_note: str | None
 
 
@@ -206,14 +209,27 @@ class ObservationDescription:
 
 @dataclass(frozen=True, slots=True)
 class PairingAnomalyDescription:
-    """Readable description of unanswered commands or unsolicited responses."""
+    """Unanswered commands or unsolicited responses on one endpoint role.
+
+    One entry per ``(endpoint_address, direction, transfer_type)`` group, not per
+    raw anomaly. A busy endpoint produces hundreds of individually uninteresting
+    anomalies that differ only in payload signature and packet index, so reporting
+    each one grows the response with traffic volume while saying the same thing.
+
+    ``occurrence_count`` is the group total and ``distinct_signatures`` is how many
+    anomalies were folded in, so neither number is lost. ``evidence`` spans the
+    whole group; ``samples`` holds up to ``MAX_ANOMALY_SAMPLES_REPORTED`` individual
+    spans for drill-down. Use ``get_packets`` for the full set.
+    """
 
     endpoint_address: str
     direction: Direction
     transfer_type: TransferType
     occurrence_count: int
+    distinct_signatures: int
     summary: str
     evidence: EvidenceSpan
+    samples: tuple[EvidenceSpan, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -406,14 +422,11 @@ def _describe_hypothesis(
         for index, pattern in enumerate(hypothesis.command_patterns)
     )
     observations = tuple(_observation_description(observation) for observation in hypothesis.observations)
-    unanswered = tuple(
-        _anomaly_description(command, "out", f"unanswered OUT command on {command.endpoint_address}")
-        for command in hypothesis.unanswered_commands
+    unanswered, unanswered_sampled = _group_anomalies(hypothesis.unanswered_commands, "out", "unanswered OUT command")
+    unsolicited, unsolicited_sampled = _group_anomalies(
+        hypothesis.unsolicited_responses, "in", "unsolicited IN response"
     )
-    unsolicited = tuple(
-        _anomaly_description(response, "in", f"unsolicited IN response on {response.endpoint_address}")
-        for response in hypothesis.unsolicited_responses
-    )
+    anomaly_groups_sampled = unanswered_sampled or unsolicited_sampled
     incomplete = tuple(_incomplete_description(item) for item in hypothesis.incomplete_transfers)
     headline = _headline(hypothesis, device_summary)
     return ProtocolDescription(
@@ -432,7 +445,8 @@ def _describe_hypothesis(
         result_limits=ResultLimitSummary(
             command_patterns_truncated=hypothesis.result_limits.command_patterns_truncated,
             observations_truncated=hypothesis.result_limits.observations_truncated,
-            truncation_note=hypothesis.result_limits.truncation_note,
+            anomaly_groups_sampled=anomaly_groups_sampled,
+            truncation_note=_extend_truncation_note(hypothesis.result_limits.truncation_note, anomaly_groups_sampled),
         ),
     )
 
@@ -566,24 +580,71 @@ def _observation_description(observation: AnalysisObservation) -> ObservationDes
     )
 
 
-def _anomaly_description(
-    anomaly: UnansweredCommand | UnsolicitedResponse,
-    direction: Direction,
-    summary: str,
-) -> PairingAnomalyDescription:
-    return PairingAnomalyDescription(
-        endpoint_address=anomaly.endpoint_address,
-        direction=direction,
-        transfer_type=anomaly.transfer_type,
-        occurrence_count=anomaly.occurrence_count,
-        summary=summary,
-        evidence=EvidenceSpan(
-            first_packet_index=anomaly.first_occurrence_index,
-            last_packet_index=anomaly.last_occurrence_index,
-            first_timestamp=anomaly.first_occurrence_timestamp,
-            last_timestamp=anomaly.last_occurrence_timestamp,
-        ),
+def _anomaly_span(anomaly: UnansweredCommand | UnsolicitedResponse) -> EvidenceSpan:
+    """Packet and timestamp bounds for one raw pairing anomaly."""
+    return EvidenceSpan(
+        first_packet_index=anomaly.first_occurrence_index,
+        last_packet_index=anomaly.last_occurrence_index,
+        first_timestamp=anomaly.first_occurrence_timestamp,
+        last_timestamp=anomaly.last_occurrence_timestamp,
     )
+
+
+def _group_anomalies(
+    anomalies: Sequence[UnansweredCommand] | Sequence[UnsolicitedResponse],
+    direction: Direction,
+    label: str,
+) -> tuple[tuple[PairingAnomalyDescription, ...], bool]:
+    """Collapse raw pairing anomalies to one entry per endpoint role.
+
+    Groups on ``(endpoint_address, transfer_type)``; ``direction`` is fixed by the
+    caller, since unanswered commands are always OUT and unsolicited responses
+    always IN. Group order follows first appearance, so output is deterministic.
+
+    Returns the descriptions and whether any group held back samples, which the
+    caller reports through ``ResultLimitSummary`` rather than dropping silently.
+    """
+    grouped: dict[tuple[str, TransferType], list[UnansweredCommand | UnsolicitedResponse]] = {}
+    for anomaly in anomalies:
+        grouped.setdefault((anomaly.endpoint_address, anomaly.transfer_type), []).append(anomaly)
+
+    descriptions: list[PairingAnomalyDescription] = []
+    sampled = False
+    for (endpoint_address, transfer_type), members in grouped.items():
+        spans = sorted((_anomaly_span(item) for item in members), key=lambda span: span.first_packet_index)
+        total = sum(item.occurrence_count for item in members)
+        if len(spans) > MAX_ANOMALY_SAMPLES_REPORTED:
+            sampled = True
+        plural = "" if len(members) == 1 else "s"
+        descriptions.append(
+            PairingAnomalyDescription(
+                endpoint_address=endpoint_address,
+                direction=direction,
+                transfer_type=transfer_type,
+                occurrence_count=total,
+                distinct_signatures=len(members),
+                summary=(
+                    f"{len(members)} distinct {label} signature{plural} on {endpoint_address}, "
+                    f"{total} occurrence{'' if total == 1 else 's'}"
+                ),
+                evidence=EvidenceSpan(
+                    first_packet_index=spans[0].first_packet_index,
+                    last_packet_index=max(span.last_packet_index for span in spans),
+                    first_timestamp=spans[0].first_timestamp,
+                    last_timestamp=max(span.last_timestamp for span in spans),
+                ),
+                samples=tuple(spans[:MAX_ANOMALY_SAMPLES_REPORTED]),
+            )
+        )
+    return tuple(descriptions), sampled
+
+
+def _extend_truncation_note(note: str | None, anomaly_groups_sampled: bool) -> str | None:
+    """Append the anomaly-sampling note to whatever the analyzer already reported."""
+    if not anomaly_groups_sampled:
+        return note
+    added = f"pairing anomaly groups sampled to {MAX_ANOMALY_SAMPLES_REPORTED} spans each"
+    return f"{note}; {added}" if note else added
 
 
 def _incomplete_description(item: IncompleteTransfer) -> IncompleteTransferDescription:

--- a/bsu_tool/analysis/description.py
+++ b/bsu_tool/analysis/description.py
@@ -52,6 +52,8 @@ MIN_OBSERVATION_STEPS: Final[int] = 2
 """Minimum OUT/IN steps for a single-occurrence multi-step observation."""
 MAX_ANOMALY_SAMPLES_REPORTED: Final[int] = 5
 """Per-group evidence spans kept when pairing anomalies are grouped."""
+MAX_SIGNATURE_BYTES_SHOWN: Final[int] = 24
+"""Payload-signature bytes rendered in a step summary before eliding the rest."""
 
 _Token = tuple[int, Direction, TransferType, SignatureMode, PayloadSignature]
 
@@ -178,6 +180,7 @@ class CommandDescription:
     summary: str
     occurrence_count: int
     markers: tuple[str, ...]
+    step_count: int
     steps: tuple[StepDescription, ...]
     response_summary: str | None
     evidence: EvidenceSpan
@@ -204,6 +207,7 @@ class ObservationDescription:
     reason: str
     summary: str
     nearest_marker: str | None
+    step_count: int
     steps: tuple[StepDescription, ...]
 
 
@@ -354,6 +358,7 @@ def describe_protocol(
     *,
     device_summaries: tuple[DeviceSummary, ...],
     device_id: str | None = None,
+    include_steps: bool = False,
 ) -> tuple[ProtocolDescription, ...]:
     """Assemble concise, deterministic descriptions for a loaded capture.
 
@@ -363,6 +368,11 @@ def describe_protocol(
             protocol descriptions stay anchored to device and descriptor context.
         device_id: Restrict analysis to one device. ``None`` describes each device
             reported by the analysis engine.
+        include_steps: Return the per-step breakdown of every command and
+            observation. Off by default: steps carry the payload signatures and are
+            most of the response, so a caller that only needs the shape of the
+            protocol pays for detail it will not read. ``step_count`` is always
+            reported, so a caller can ask again for the detail it wants.
 
     Returns:
         One presentation object per analyzed device.
@@ -376,7 +386,7 @@ def describe_protocol(
         summary = summaries.get(hypothesis.device_id)
         if summary is None:
             raise ValueError(f"missing device summary for {hypothesis.device_id}")
-        description = _describe_hypothesis(hypothesis, summary)
+        description = _describe_hypothesis(hypothesis, summary, include_steps=include_steps)
         descriptions.append(replace(description, deterministic_summary=format_protocol_summary(description)))
     return tuple(descriptions)
 
@@ -416,12 +426,16 @@ def format_protocol_summary(description: ProtocolDescription) -> str:
 def _describe_hypothesis(
     hypothesis: ProtocolHypothesis,
     device_summary: DeviceSummary | None,
+    *,
+    include_steps: bool,
 ) -> ProtocolDescription:
     commands = tuple(
-        _command_description(index, pattern, hypothesis.marker_correlations)
+        _command_description(index, pattern, hypothesis.marker_correlations, include_steps=include_steps)
         for index, pattern in enumerate(hypothesis.command_patterns)
     )
-    observations = tuple(_observation_description(observation) for observation in hypothesis.observations)
+    observations = tuple(
+        _observation_description(observation, include_steps=include_steps) for observation in hypothesis.observations
+    )
     unanswered, unanswered_sampled = _group_anomalies(hypothesis.unanswered_commands, "out", "unanswered OUT command")
     unsolicited, unsolicited_sampled = _group_anomalies(
         hypothesis.unsolicited_responses, "in", "unsolicited IN response"
@@ -483,6 +497,8 @@ def _command_description(
     position: int,
     pattern: CommandPattern,
     correlations: tuple[MarkerCorrelation, ...],
+    *,
+    include_steps: bool,
 ) -> CommandDescription:
     markers = tuple(
         correlation.marker_name
@@ -490,7 +506,7 @@ def _command_description(
         if correlation.correlation_id == pattern.marker_correlation_id
     )
     command_id = f"command_{position + 1:02d}"
-    steps = tuple(_step_description(step) for step in pattern.steps)
+    steps = tuple(_step_description(step) for step in pattern.steps) if include_steps else ()
     response_summary = _response_summary(pattern)
     return CommandDescription(
         command_id=command_id,
@@ -499,6 +515,7 @@ def _command_description(
         summary=_pattern_summary(pattern, markers),
         occurrence_count=pattern.occurrence_count,
         markers=markers,
+        step_count=len(pattern.steps),
         steps=steps,
         response_summary=response_summary,
         evidence=_pattern_evidence(pattern),
@@ -560,7 +577,11 @@ def _step_description(step: PatternStep) -> StepDescription:
 def _payload_summary(step: PatternStep) -> str:
     if not step.payload_signature:
         return "zero-length payload"
-    signature = " ".join("??" if byte is None else f"{byte:02x}" for byte in step.payload_signature)
+    shown = step.payload_signature[:MAX_SIGNATURE_BYTES_SHOWN]
+    elided = len(step.payload_signature) - len(shown)
+    signature = " ".join("??" if byte is None else f"{byte:02x}" for byte in shown)
+    if elided:
+        signature = f"{signature} (+{elided} more byte{'' if elided == 1 else 's'})"
     length_min, length_max = step.observed_length_range
     length = f"{length_min} bytes" if length_min == length_max else f"{length_min}-{length_max} bytes"
     variable = ""
@@ -570,13 +591,14 @@ def _payload_summary(step: PatternStep) -> str:
     return f"{length}; signature {signature}{variable}"
 
 
-def _observation_description(observation: AnalysisObservation) -> ObservationDescription:
+def _observation_description(observation: AnalysisObservation, *, include_steps: bool) -> ObservationDescription:
     return ObservationDescription(
         source_observation_id=observation.observation_id,
         reason=observation.reason,
         summary=f"{observation.reason.replace('_', ' ')} observation with {len(observation.steps)} step(s)",
         nearest_marker=observation.nearest_marker,
-        steps=tuple(_step_description(step) for step in observation.steps),
+        step_count=len(observation.steps),
+        steps=tuple(_step_description(step) for step in observation.steps) if include_steps else (),
     )
 
 

--- a/bsu_tool/analysis/description.py
+++ b/bsu_tool/analysis/description.py
@@ -358,7 +358,8 @@ def describe_protocol(
     *,
     device_summaries: tuple[DeviceSummary, ...],
     device_id: str | None = None,
-    include_steps: bool = False,
+    include_command_steps: bool = False,
+    include_observation_steps: bool = False,
 ) -> tuple[ProtocolDescription, ...]:
     """Assemble concise, deterministic descriptions for a loaded capture.
 
@@ -368,11 +369,19 @@ def describe_protocol(
             protocol descriptions stay anchored to device and descriptor context.
         device_id: Restrict analysis to one device. ``None`` describes each device
             reported by the analysis engine.
-        include_steps: Return the per-step breakdown of every command and
-            observation. Off by default: steps carry the payload signatures and are
-            most of the response, so a caller that only needs the shape of the
-            protocol pays for detail it will not read. ``step_count`` is always
-            reported, so a caller can ask again for the detail it wants.
+        include_command_steps: Return the per-step breakdown of every command
+            pattern. Off by default: steps carry the payload signatures and are most
+            of the response, so a caller that only needs the shape of the protocol
+            pays for detail it will not read.
+        include_observation_steps: Return the per-step breakdown of every
+            single-occurrence observation. Off by default for the same reason.
+
+    Commands and observations opt in separately because they are read for different
+    reasons and cost different amounts: observation steps are a flat charge bounded
+    by ``MAX_OBSERVATIONS_RETURNED``, while command steps scale with how many
+    patterns the capture yields, up to ``MAX_COMMAND_PATTERNS_RETURNED``. A caller
+    chasing one unpaired transfer should not pay for every command's payloads.
+    ``step_count`` is reported either way, so the detail is deferred, never lost.
 
     Returns:
         One presentation object per analyzed device.
@@ -386,7 +395,12 @@ def describe_protocol(
         summary = summaries.get(hypothesis.device_id)
         if summary is None:
             raise ValueError(f"missing device summary for {hypothesis.device_id}")
-        description = _describe_hypothesis(hypothesis, summary, include_steps=include_steps)
+        description = _describe_hypothesis(
+            hypothesis,
+            summary,
+            include_command_steps=include_command_steps,
+            include_observation_steps=include_observation_steps,
+        )
         descriptions.append(replace(description, deterministic_summary=format_protocol_summary(description)))
     return tuple(descriptions)
 
@@ -427,14 +441,16 @@ def _describe_hypothesis(
     hypothesis: ProtocolHypothesis,
     device_summary: DeviceSummary | None,
     *,
-    include_steps: bool,
+    include_command_steps: bool,
+    include_observation_steps: bool,
 ) -> ProtocolDescription:
     commands = tuple(
-        _command_description(index, pattern, hypothesis.marker_correlations, include_steps=include_steps)
+        _command_description(index, pattern, hypothesis.marker_correlations, include_steps=include_command_steps)
         for index, pattern in enumerate(hypothesis.command_patterns)
     )
     observations = tuple(
-        _observation_description(observation, include_steps=include_steps) for observation in hypothesis.observations
+        _observation_description(observation, include_steps=include_observation_steps)
+        for observation in hypothesis.observations
     )
     unanswered, unanswered_sampled = _group_anomalies(hypothesis.unanswered_commands, "out", "unanswered OUT command")
     unsolicited, unsolicited_sampled = _group_anomalies(

--- a/tests/int/test_analysis_response_bounds.py
+++ b/tests/int/test_analysis_response_bounds.py
@@ -31,6 +31,12 @@ _GOODIX_DEVICE = "27c6_63ac"
 #: Headroom is deliberate: this catches a return to unbounded growth, not drift.
 _MAX_SERIALIZED_KB = 25.0
 
+#: Ceiling with both step collections requested on the same capture, measured at
+#: ~75.4 KB. Step detail is bounded by MAX_COMMAND_PATTERNS_RETURNED multiplied by
+#: MAX_SEQUENCE_WINDOW rather than by traffic, but at a far higher ceiling than the
+#: default, so it gets its own bound instead of going unpinned.
+_MAX_DETAILED_SERIALIZED_KB = 100.0
+
 
 def _encode(value: object) -> object:
     """Render a description the way the MCP layer serializes it."""
@@ -41,7 +47,9 @@ def _encode(value: object) -> object:
     return str(value)
 
 
-def _describe(path: pathlib.Path, *, include_steps: bool = False) -> tuple[ProtocolDescription, ...]:
+def _describe(
+    path: pathlib.Path, *, include_command_steps: bool = False, include_observation_steps: bool = False
+) -> tuple[ProtocolDescription, ...]:
     """Describe every device in a capture, as analyze_protocol does."""
     session = Session()
     capture = session.load(path)
@@ -49,7 +57,8 @@ def _describe(path: pathlib.Path, *, include_steps: bool = False) -> tuple[Proto
         capture,
         device_summaries=session.list_devices(),
         device_id=None,
-        include_steps=include_steps,
+        include_command_steps=include_command_steps,
+        include_observation_steps=include_observation_steps,
     )
 
 
@@ -145,18 +154,62 @@ def test_steps_are_deferred_by_default_but_counted() -> None:
 
 
 def test_include_steps_returns_the_full_detail() -> None:
-    """Detail is deferred, not lost: step_count matches what the flag returns."""
+    """Detail is deferred, not lost: step_count matches what the flags return."""
     default = next(d for d in _describe(_LARGE) if d.device_id == _GOODIX_DEVICE)
-    detailed = next(d for d in _describe(_LARGE, include_steps=True) if d.device_id == _GOODIX_DEVICE)
+    detailed = next(
+        d
+        for d in _describe(_LARGE, include_command_steps=True, include_observation_steps=True)
+        if d.device_id == _GOODIX_DEVICE
+    )
 
     assert [c.step_count for c in detailed.commands] == [len(c.steps) for c in detailed.commands]
     assert [c.step_count for c in default.commands] == [c.step_count for c in detailed.commands]
     assert [o.step_count for o in default.observations] == [len(o.steps) for o in detailed.observations]
 
 
+def test_command_and_observation_steps_opt_in_independently() -> None:
+    """Each flag returns its own steps and leaves the other collection deferred.
+
+    The two are read for different reasons, so a caller chasing one unpaired
+    transfer must not pay for every command's payloads, and vice versa.
+    """
+    commands_only = next(d for d in _describe(_LARGE, include_command_steps=True) if d.device_id == _GOODIX_DEVICE)
+    observations_only = next(
+        d for d in _describe(_LARGE, include_observation_steps=True) if d.device_id == _GOODIX_DEVICE
+    )
+
+    assert any(c.steps for c in commands_only.commands)
+    assert all(o.steps == () for o in commands_only.observations)
+
+    assert any(o.steps for o in observations_only.observations)
+    assert all(c.steps == () for c in observations_only.commands)
+
+
+def test_each_step_flag_charges_only_for_its_own_collection() -> None:
+    """The flags partition the step cost: neither pays for the other's steps.
+
+    That partition is the point of splitting them. Note that neither half is cheap
+    in absolute terms on this capture — measured at ~36.6 KB for observations and
+    ~54.7 KB for commands against a ~15.8 KB default — so the split narrows the
+    charge without bringing an opt-in under ``_MAX_SERIALIZED_KB``.
+    """
+    default = _serialized_kb(_describe(_LARGE))
+    commands_only = _serialized_kb(_describe(_LARGE, include_command_steps=True))
+    observations_only = _serialized_kb(_describe(_LARGE, include_observation_steps=True))
+    both = _serialized_kb(_describe(_LARGE, include_command_steps=True, include_observation_steps=True))
+
+    assert default < observations_only < commands_only < both
+    assert both < _MAX_DETAILED_SERIALIZED_KB
+
+    # Each increment is exactly its own collection's steps, so the two sum to both.
+    command_cost = commands_only - default
+    observation_cost = observations_only - default
+    assert abs((command_cost + observation_cost) - (both - default)) < 0.5
+
+
 def test_payload_signatures_are_bounded_and_report_elision() -> None:
     """A long signature is cut to the named bound and says what it dropped."""
-    detailed = next(d for d in _describe(_LARGE, include_steps=True) if d.device_id == _GOODIX_DEVICE)
+    detailed = next(d for d in _describe(_LARGE, include_command_steps=True) if d.device_id == _GOODIX_DEVICE)
     summaries = [
         step.payload_summary
         for command in detailed.commands

--- a/tests/int/test_analysis_response_bounds.py
+++ b/tests/int/test_analysis_response_bounds.py
@@ -1,0 +1,124 @@
+"""Response-size bounds for the protocol description on the Goodix captures.
+
+Pairing anomalies are grouped by endpoint role rather than reported one per raw
+anomaly. Without that, a busy IN endpoint contributes one entry per payload
+signature and the response grows with traffic volume, which the analyze_protocol
+tool then hands straight to a model.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import pathlib
+from typing import cast
+
+from bsu_tool.analysis.description import (
+    MAX_ANOMALY_SAMPLES_REPORTED,
+    ProtocolDescription,
+    describe_protocol,
+)
+from bsu_tool.session import Session
+
+_CAPTURES = pathlib.Path(__file__).parent.parent.parent / "test_data" / "captures"
+_SMALL = _CAPTURES / "goodix_enum_and_enroll_sanitized.pcapng"
+_LARGE = _CAPTURES / "goodix_enroll_verify_sanitized.pcapng"
+_GOODIX_DEVICE = "27c6_63ac"
+
+#: Serialized ceiling for the 1122-packet capture. Measured at ~91 KB after
+#: grouping, against ~162 KB before it. Headroom is deliberate: this catches a
+#: return to unbounded growth, not normal drift.
+_MAX_SERIALIZED_KB = 110.0
+
+
+def _encode(value: object) -> object:
+    """Render a description the way the MCP layer serializes it."""
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return dataclasses.asdict(value)
+    if isinstance(value, tuple):
+        return [_encode(item) for item in cast("tuple[object, ...]", value)]
+    return str(value)
+
+
+def _describe(path: pathlib.Path) -> tuple[ProtocolDescription, ...]:
+    """Describe every device in a capture, as analyze_protocol does."""
+    session = Session()
+    capture = session.load(path)
+    return describe_protocol(capture, device_summaries=session.list_devices(), device_id=None)
+
+
+def _serialized_kb(descriptions: tuple[ProtocolDescription, ...]) -> float:
+    """Size of the JSON an MCP client would receive, in KB."""
+    return len(json.dumps([_encode(d) for d in descriptions], default=_encode)) / 1024
+
+
+def test_large_capture_response_stays_under_ceiling() -> None:
+    """The 1122-packet capture serializes well under the pre-grouping size."""
+    assert _serialized_kb(_describe(_LARGE)) < _MAX_SERIALIZED_KB
+
+
+def test_anomaly_entries_do_not_grow_with_packet_count() -> None:
+    """Anomaly entry counts track endpoint roles, not traffic volume.
+
+    The large capture holds 4.4x the packets of the small one and far more raw
+    anomalies, but both devices answer on one endpoint per direction, so the
+    grouped entry counts must not move.
+    """
+    small = next(d for d in _describe(_SMALL) if d.device_id == _GOODIX_DEVICE)
+    large = next(d for d in _describe(_LARGE) if d.device_id == _GOODIX_DEVICE)
+
+    assert len(small.unsolicited_responses) == len(large.unsolicited_responses) == 1
+    assert len(small.unanswered_commands) == len(large.unanswered_commands) == 1
+
+
+def test_grouping_preserves_totals_and_reports_what_it_folded() -> None:
+    """Collapsing 181 anomalies keeps both the occurrence total and the count."""
+    description = next(d for d in _describe(_LARGE) if d.device_id == _GOODIX_DEVICE)
+
+    unsolicited = description.unsolicited_responses[0]
+    assert unsolicited.endpoint_address == "0x83"
+    assert unsolicited.direction == "in"
+    assert unsolicited.distinct_signatures == 181
+    assert unsolicited.occurrence_count == 368
+    assert "181 distinct" in unsolicited.summary
+
+    unanswered = description.unanswered_commands[0]
+    assert unanswered.endpoint_address == "0x01"
+    assert unanswered.direction == "out"
+    assert unanswered.distinct_signatures == 79
+    assert unanswered.occurrence_count == 87
+
+
+def test_samples_are_bounded_and_sampling_is_reported() -> None:
+    """Held-back spans are capped and flagged, never dropped silently."""
+    description = next(d for d in _describe(_LARGE) if d.device_id == _GOODIX_DEVICE)
+
+    for anomaly in (*description.unsolicited_responses, *description.unanswered_commands):
+        assert len(anomaly.samples) <= MAX_ANOMALY_SAMPLES_REPORTED
+        # Samples are ordered, and the group span covers every one of them.
+        indexes = [span.first_packet_index for span in anomaly.samples]
+        assert indexes == sorted(indexes)
+        assert anomaly.evidence.first_packet_index <= min(indexes)
+        assert anomaly.evidence.last_packet_index >= max(span.last_packet_index for span in anomaly.samples)
+
+    assert description.result_limits.anomaly_groups_sampled
+    note = description.result_limits.truncation_note
+    assert note is not None and "pairing anomaly groups sampled" in note
+
+
+def test_unsampled_group_reports_no_sampling() -> None:
+    """A group under the sample cap is not flagged as sampled."""
+    description = next(d for d in _describe(_SMALL) if d.device_id != _GOODIX_DEVICE)
+
+    assert description.unsolicited_responses[0].distinct_signatures == 1
+    assert description.result_limits.anomaly_groups_sampled is False
+
+
+def test_deterministic_summary_is_unchanged_by_grouping() -> None:
+    """Grouping must not move the pinned summary, which sums occurrences."""
+    description = next(d for d in _describe(_SMALL) if d.device_id == _GOODIX_DEVICE)
+
+    assert description.deterministic_summary.startswith(
+        "Device 27c6_63ac has 5 repeated command patterns across 2 endpoint roles."
+    )
+    assert "42 unsolicited response occurrences." in description.deterministic_summary

--- a/tests/int/test_analysis_response_bounds.py
+++ b/tests/int/test_analysis_response_bounds.py
@@ -15,6 +15,7 @@ from typing import cast
 
 from bsu_tool.analysis.description import (
     MAX_ANOMALY_SAMPLES_REPORTED,
+    MAX_SIGNATURE_BYTES_SHOWN,
     ProtocolDescription,
     describe_protocol,
 )
@@ -25,10 +26,10 @@ _SMALL = _CAPTURES / "goodix_enum_and_enroll_sanitized.pcapng"
 _LARGE = _CAPTURES / "goodix_enroll_verify_sanitized.pcapng"
 _GOODIX_DEVICE = "27c6_63ac"
 
-#: Serialized ceiling for the 1122-packet capture. Measured at ~91 KB after
-#: grouping, against ~162 KB before it. Headroom is deliberate: this catches a
-#: return to unbounded growth, not normal drift.
-_MAX_SERIALIZED_KB = 110.0
+#: Serialized ceiling for the 1122-packet capture at the default detail level.
+#: Measured at ~15.8 KB, against ~162 KB before grouping and step deferral.
+#: Headroom is deliberate: this catches a return to unbounded growth, not drift.
+_MAX_SERIALIZED_KB = 25.0
 
 
 def _encode(value: object) -> object:
@@ -40,11 +41,16 @@ def _encode(value: object) -> object:
     return str(value)
 
 
-def _describe(path: pathlib.Path) -> tuple[ProtocolDescription, ...]:
+def _describe(path: pathlib.Path, *, include_steps: bool = False) -> tuple[ProtocolDescription, ...]:
     """Describe every device in a capture, as analyze_protocol does."""
     session = Session()
     capture = session.load(path)
-    return describe_protocol(capture, device_summaries=session.list_devices(), device_id=None)
+    return describe_protocol(
+        capture,
+        device_summaries=session.list_devices(),
+        device_id=None,
+        include_steps=include_steps,
+    )
 
 
 def _serialized_kb(descriptions: tuple[ProtocolDescription, ...]) -> float:
@@ -122,3 +128,46 @@ def test_deterministic_summary_is_unchanged_by_grouping() -> None:
         "Device 27c6_63ac has 5 repeated command patterns across 2 endpoint roles."
     )
     assert "42 unsolicited response occurrences." in description.deterministic_summary
+
+
+def test_steps_are_deferred_by_default_but_counted() -> None:
+    """The default response omits steps and still says how many there are."""
+    description = next(d for d in _describe(_LARGE) if d.device_id == _GOODIX_DEVICE)
+
+    assert description.commands
+    assert description.observations
+    for command in description.commands:
+        assert command.steps == ()
+        assert command.step_count > 0
+    for observation in description.observations:
+        assert observation.steps == ()
+        assert observation.step_count > 0
+
+
+def test_include_steps_returns_the_full_detail() -> None:
+    """Detail is deferred, not lost: step_count matches what the flag returns."""
+    default = next(d for d in _describe(_LARGE) if d.device_id == _GOODIX_DEVICE)
+    detailed = next(d for d in _describe(_LARGE, include_steps=True) if d.device_id == _GOODIX_DEVICE)
+
+    assert [c.step_count for c in detailed.commands] == [len(c.steps) for c in detailed.commands]
+    assert [c.step_count for c in default.commands] == [c.step_count for c in detailed.commands]
+    assert [o.step_count for o in default.observations] == [len(o.steps) for o in detailed.observations]
+
+
+def test_payload_signatures_are_bounded_and_report_elision() -> None:
+    """A long signature is cut to the named bound and says what it dropped."""
+    detailed = next(d for d in _describe(_LARGE, include_steps=True) if d.device_id == _GOODIX_DEVICE)
+    summaries = [
+        step.payload_summary
+        for command in detailed.commands
+        for step in command.steps
+        if "signature" in step.payload_summary
+    ]
+    assert summaries
+
+    for summary in summaries:
+        rendered = summary.split("signature ", 1)[1].split(" (+", 1)[0].split(";", 1)[0]
+        assert len(rendered.split()) <= MAX_SIGNATURE_BYTES_SHOWN
+
+    elided = [summary for summary in summaries if "more byte" in summary]
+    assert elided, "expected at least one signature long enough to elide"


### PR DESCRIPTION
## What does this PR do?

Bounds the `analyze_protocol` response so it no longer scales with capture size.

**Groups pairing anomalies by endpoint role.** `unsolicited_responses` and `unanswered_commands` emitted one entry per raw anomaly. On the 1122-packet capture that was 181 and 79 entries, 72 KB of a 161.6 KB response, and every one of the 181 shared the same endpoint, direction, and transfer type. Both now emit one entry per `(endpoint_address, transfer_type)` group, carrying the summed `occurrence_count` and `distinct_signatures` so no total is lost, plus up to `MAX_ANOMALY_SAMPLES_REPORTED` spans for drill-down.

Grouped rather than truncated. A top-N cut hides the shape: seeing 10 of 181 does not tell you whether the endpoint emitted a few strays or a steady stream.

**Defers step detail, behind two separate flags.** `describe_protocol` gains `include_command_steps` and `include_observation_steps`, both defaulting to `False`. `CommandDescription` and `ObservationDescription` report `step_count` and omit `steps` unless asked. Steps were 76 KB of the 91 KB remaining after grouping.

The two opt in separately because they are read for different reasons and cost different amounts. A caller chasing one unpaired transfer should not pay for every command's payloads. The flags partition the cost exactly — each increment is its own collection's steps, and the two sum to the both-flags case.

**Bounds payload signatures.** `payload_summary` is capped by `MAX_SIGNATURE_BYTES_SHOWN` and states how many bytes it dropped. Signatures ran to 649 characters; 56 of 84 now elide and the longest is 351.

`ResultLimitSummary` gains `anomaly_groups_sampled`, and the truncation note is extended rather than replaced.

Measured, serialized as the MCP layer sends it:

| capture | before | default | `+observation` | `+command` | both |
|---|---|---|---|---|---|
| 253 packets | 40.9 KB / 10.5k tok | 9.9 KB / 2.5k tok | 28.9 KB | 14.5 KB | 33.6 KB |
| 1122 packets | 161.6 KB / 41k tok | 15.8 KB / 4.0k tok | 36.6 KB | 54.7 KB | 75.4 KB |

Which half is cheaper flips with capture size: the 253-packet capture yields 10 observations against 5 command patterns, so observation steps cost more there and less on the larger capture.

The deterministic summary is unchanged. It sums `occurrence_count`, which grouping preserves.

Closes #136

## How was it tested?

```bash
ruff check .
ruff format --check .
pyright
pytest
```

All clean: pyright strict reports 0 errors, 476 passed and 4 skipped.

`tests/int/test_analysis_response_bounds.py` adds 11 tests: the size ceiling, entry counts not growing with packet count, preserved occurrence totals and distinct-signature counts, the sample bound and its reporting, the unsampled case, step deferral with `step_count`, both flags returning full detail, each flag opting in independently, the two flags partitioning the cost, and signature elision.

The 471 pre-existing tests passed before any new ones were added, with no edits. Nothing in the suite asserted on `steps` content through `describe_protocol`, which the new tests now cover.

## Review notes

**Correcting a figure from an earlier revision of this description.** It read "one command's full detail is about 1.1 KB, so drill-down is cheap." The 1.1 KB is accurate *per command* — measured 0.9 to 1.9 KB — but it was quoted as though it were the cost of asking for detail, which it is not. Requesting steps returns them for every command and observation, and no flag combination selects a single command. That framing was carried into the review on #67 (PR #135) to justify exposing the flag there, so it is worth stating plainly: the split narrows the charge, it does not make it small. Neither half lands under `_MAX_SERIALIZED_KB` on the 1122-packet capture. Genuine per-command drill-down would need a selector this PR does not add.

**The opt-in path now has its own ceiling.** `_MAX_DETAILED_SERIALIZED_KB` bounds the both-flags response, which nothing pinned before. Step detail is capped by `MAX_COMMAND_PATTERNS_RETURNED` x `MAX_SEQUENCE_WINDOW` rather than by traffic, but at a far higher ceiling than the default, so it should not go unbounded.

**#67 (PR #135) needs no change to merge.** `analyze_protocol` calls `describe_protocol` without either flag, so it inherits the new defaults and is unblocked once this merges. Merging in that order means it publishes its output schema once, already including `anomaly_groups_sampled` and `step_count`. Exposing the two flags as parameters so a caller can request detail is a follow-on there, not a prerequisite.

**`MAX_SEQUENCE_WINDOW` is deliberately untouched.** It is an analysis parameter, not a presentation one. Lowering it would change which patterns the engine detects. Every change here leaves the analysis identical and alters only what is returned.

**`_describe_hypothesis` takes both flags as required keywords** rather than carrying its own defaults, so `describe_protocol` is the single place the policy is set.

## Checklist

- [x] PR description includes `closes #N`
- [x] No unintended files included in this PR
