### PR TITLE
138/pairing transfer type lanes

### DIFF
--- a/bsu_tool/analysis/pairing.py
+++ b/bsu_tool/analysis/pairing.py
@@ -2,9 +2,17 @@
 
 Links an OUT analysis event from one :class:`~bsu_tool.urb_decoder.UrbTransaction`
 to a later IN analysis event from a separate transaction on the same device and
-endpoint number. Pairing starts from the transactions ``pair_urbs()`` already
+transfer type. Pairing starts from the transactions ``pair_urbs()`` already
 built. It never rebuilds submit/complete pairs with a FIFO queue, because USB
 allows multiple outstanding URBs and completions can arrive out of submit order.
+
+Lanes are keyed on transfer type rather than endpoint number, because a
+vendor-specific device routinely commands on one endpoint number and answers on
+another. Both Goodix reference captures send commands on ``0x01`` (endpoint
+number 1) and answers on ``0x83`` (endpoint number 3), so an endpoint-keyed lane
+put every command and its response in different lanes and produced zero pairs on
+both. See :func:`_result_for` for what transfer-type scoping does and does not
+protect against.
 
 A single transaction is never a pair. One transaction is one URB id lifecycle,
 while a command/response pair is a protocol level relationship between two
@@ -42,6 +50,7 @@ from dataclasses import dataclass, field
 from typing import Final
 
 from bsu_tool.analysis.models import IncompleteTransferReason, ResponseTimingStats
+from bsu_tool.analyzer import background_endpoints
 from bsu_tool.device_identity import DeviceIdMap, resolve_device_id
 from bsu_tool.urb_decoder import Direction, TransferType, UrbTransaction
 
@@ -83,10 +92,17 @@ class AnalysisEvent:
 
 @dataclass(frozen=True, slots=True)
 class CommandResponsePair:
-    """A likely command and its response on one endpoint lane."""
+    """A likely command and its response within one device's transfer-type lane.
+
+    The two halves may sit on different endpoint numbers — the common vendor
+    arrangement is a bulk OUT on one and a bulk IN on another — so read
+    ``command.endpoint_address`` and ``response.endpoint_address`` for where each
+    half actually appeared.
+    """
 
     device_id: str
     endpoint_number: int
+    """The command's endpoint number. The response may be on a different one."""
     command: AnalysisEvent
     response: AnalysisEvent
     response_time_ms: float
@@ -284,15 +300,48 @@ def _result_for(
     unanswered: list[UnpairedCommand] = []
     unsolicited: list[UnpairedResponse] = []
 
-    # Scope within a device is the endpoint number, per spec section 4.1.
-    # Transfer type is determined by (device, endpoint number, direction) in
-    # USB, so it is not part of the key. The device half of the scope is already
-    # settled: events reached here bucketed by their resolved device_id, which
-    # is what keeps a device that re-addresses mid-capture in one lane instead
-    # of one lane per address.
-    lanes: dict[int, list[AnalysisEvent]] = {}
-    for event in events:
-        lanes.setdefault(event.endpoint_number, []).append(event)
+    # A successful zero-length completion carries no protocol content, so it can
+    # neither be a command nor answer one. Left in the lane it consumes the
+    # pending OUT before the real response arrives: this device answers with a
+    # zero-length read, then the payload, so keeping them paired 92 of 95
+    # commands on the 1122-packet capture with an empty response and timed the
+    # exchange to a USB artifact. Excluded and counted rather than dropped
+    # silently.
+    #
+    # Failed events stay in regardless of payload. A failed transfer usually
+    # carries no data at all, and its job in the lane is to consume a slot so
+    # spec section 4.1 steps 4 and 5 can explain a missing counterpart. That job
+    # does not depend on carrying bytes, and filtering on payload alone would
+    # turn every errored IN back into a false unanswered command.
+    payload_events = [event for event in events if event.data or not event.successful]
+    empty_event_count = len(events) - len(payload_events)
+
+    # A background status endpoint must never claim a pending command. Widening
+    # the lane to the transfer type puts it in reach of one, and because it is
+    # simply the nearest IN in timestamp order it wins: the command pairs with a
+    # status packet and the real answer is filed as unsolicited, with counts
+    # identical to a correct pairing. The analyzer already identifies these
+    # endpoints for n-gram scoping, so the rule is shared rather than restated,
+    # and the two passes cannot drift apart on what "background" means.
+    #
+    # Suppressed events are still reported as unsolicited responses. They are
+    # genuinely device-pushed traffic, which is what spec section 6 says an IN
+    # with no preceding OUT is; only their ability to consume a command is removed.
+    suppressed = background_endpoints(events)
+
+    # Scope within a device is the transfer type, not the endpoint number. A
+    # vendor device routinely commands on one endpoint number and answers on
+    # another, which an endpoint-keyed lane can never pair (see module docstring).
+    # The device half of the scope is already settled: events reached here
+    # bucketed by their resolved device_id, which is what keeps a device that
+    # re-addresses mid-capture in one lane instead of one per address.
+    lanes: dict[TransferType, list[AnalysisEvent]] = {}
+    for event in payload_events:
+        if event.endpoint_number in suppressed:
+            if event.successful:
+                _record_unsolicited(event, unsolicited)
+            continue
+        lanes.setdefault(event.transfer_type, []).append(event)
 
     for lane_events in lanes.values():
         _pair_lane(lane_events, timeout_seconds, capture_end, pairs, unanswered, unsolicited)
@@ -307,6 +356,14 @@ def _result_for(
         )
     if accumulator.failed_count:
         notes.append(f"{accumulator.failed_count} failed bulk/interrupt events kept visible, not promoted into pairs")
+    if suppressed:
+        listed = ", ".join(f"ep{endpoint}" for endpoint in sorted(suppressed))
+        notes.append(f"background interrupt IN endpoints excluded from pairing and reported as unsolicited: {listed}")
+    if empty_event_count:
+        notes.append(
+            f"{empty_event_count} successful zero-length bulk/interrupt events excluded from pairing, "
+            "carrying no payload to match"
+        )
     if not events and not accumulator.incomplete:
         notes.append("no bulk or interrupt traffic for this device, nothing to pair")
 

--- a/bsu_tool/analyzer.py
+++ b/bsu_tool/analyzer.py
@@ -24,7 +24,7 @@ each flagged for the spec follow-up:
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Final, Literal, Protocol
 
@@ -38,6 +38,7 @@ from bsu_tool.analysis.models import (
     VariableByteRange,
 )
 from bsu_tool.device_identity import DeviceIdMap, resolve_device_id
+from bsu_tool.urb_decoder import TransferType as RecordTransferType
 from bsu_tool.urb_decoder import UrbRecord, UrbTransaction
 
 
@@ -560,17 +561,53 @@ def normalize_tokens(
 # --- Stream scoping --------------------------------------------------------
 
 
-def _background_endpoints(events: tuple[AnalysisEvent, ...]) -> set[int]:
+class EndpointEventLike(Protocol):
+    """The three fields :func:`background_endpoints` reads from an analysis event.
+
+    Structural rather than concrete because this module and
+    :mod:`bsu_tool.analysis.pairing` still define separate ``AnalysisEvent``
+    types. Converging them is issue #127; until then a Protocol lets one rule
+    serve both rather than each growing its own copy.
+    """
+
+    @property
+    def endpoint_number(self) -> int:
+        """Bare endpoint number the event was seen on."""
+        ...
+
+    @property
+    def direction(self) -> Direction:
+        """``"in"`` or ``"out"``."""
+        ...
+
+    @property
+    def transfer_type(self) -> RecordTransferType:
+        """``"control"``, ``"bulk"`` or ``"interrupt"``.
+
+        The decoder's wider alias, not the engine's ``bulk|interrupt`` one, so an
+        event type carrying either satisfies this. Return types are covariant, so
+        the narrower engine events still match.
+        """
+        ...
+
+
+def background_endpoints(events: Sequence[EndpointEventLike]) -> set[int]:
     """Identify interrupt IN-only endpoints that look like background status polls.
 
     Interleaved polls otherwise land inside n-gram windows, inventing sequences
-    and breaking real repeats. The rule is narrow on purpose: every event on the
-    endpoint must be interrupt IN and the device must send OUT traffic elsewhere.
-    Pass ``suppress_background=False`` to disable.
+    and breaking real repeats. In pairing they are worse: they are simply the
+    nearest IN in timestamp order, so they take a pending OUT and the real answer
+    is filed as unsolicited, with counts identical to a correct pairing.
+
+    The rule is narrow on purpose: every event on the endpoint must be interrupt
+    IN and the device must send OUT traffic elsewhere. The interrupt clause is
+    load-bearing. Goodix answers on a bulk IN-only endpoint while sending OUT on
+    another, so relaxing it would classify that device's only responder as
+    background. Pass ``suppress_background=False`` to disable.
     """
     if not any(event.direction == "out" for event in events):
         return set()
-    by_endpoint: dict[int, list[AnalysisEvent]] = {}
+    by_endpoint: dict[int, list[EndpointEventLike]] = {}
     for event in events:
         by_endpoint.setdefault(event.endpoint_number, []).append(event)
     out_endpoints = {event.endpoint_number for event in events if event.direction == "out"}
@@ -694,7 +731,7 @@ def detect_repeated_sequences(
         notes = list(stream.excluded[device].notes()) if device in stream.excluded else []
 
         if suppress_background and scope == "device":
-            background = _background_endpoints(device_events)
+            background = background_endpoints(device_events)
             if background:
                 listed = ", ".join(f"ep{endpoint}" for endpoint in sorted(background))
                 notes.append(f"suppressed background interrupt IN endpoints from the analysis stream: {listed}")

--- a/docs/architecture/m3-engine-spec.md
+++ b/docs/architecture/m3-engine-spec.md
@@ -398,14 +398,55 @@ submission and completion have opposite directions. A single `UrbTransaction` re
 URB id lifecycle, while command/response inference is a protocol-level relationship between
 separate directional analysis events.
 
-**Endpoint scope:** pairing is scoped by device and endpoint number. An OUT on endpoint
-`0x01` may pair with an IN on endpoint `0x81` because both refer to endpoint number 1
-with opposite directions. Pairing by full endpoint address would miss this common USB
-command/response shape.
+**Endpoint scope:** pairing is scoped by device and **transfer type**, not by endpoint
+number. An OUT on endpoint `0x01` pairs with an IN on `0x81` (same endpoint number,
+opposite directions) *and* with an IN on `0x83` (a different endpoint number entirely),
+because both are bulk traffic from the same device.
 
-If a device sends commands and responses on different endpoint numbers, those events are
-not forced into a simple command/response pair. They remain visible as separate endpoint
-lane patterns or as `AnalysisObservation` entries for analyst review.
+This revises an earlier rule that scoped pairing to the endpoint number and said events
+on different endpoint numbers were "not forced into a simple command/response pair."
+That rule assumed the same-number OUT/IN arrangement is the common one. It is not the
+arrangement this project's reference device uses: both Goodix captures send commands on
+`0x01` (endpoint number 1) and answers on `0x83` (endpoint number 3). Under
+endpoint-number scoping every command and its answer landed in separate lanes, so
+`pair_command_responses` returned **zero pairs** on both captures, `response_timing` was
+always `None`, and every command was reported as unanswered while every response was
+reported as unsolicited. Those counts described the scoping, not the device.
+
+**Background endpoint suppression:** widening the lane to the transfer type puts an
+unrelated IN endpoint in reach of a pending OUT. Being the nearest IN in timestamp
+order it wins, so the command pairs with a status packet and the real answer is filed
+as unsolicited. The counts are identical either way, so nothing in the output
+distinguishes the mispairing from a correct pairing.
+
+Pairing therefore applies the same background-endpoint rule §3.1 scoping uses: an
+endpoint every one of whose events is **interrupt IN**, on a device that sends OUT
+traffic elsewhere, may not claim a pending command. Its events are still reported as
+unsolicited responses, because they are genuinely device-pushed traffic; only their
+ability to consume a command is removed. The suppression is named in `analysis_notes`.
+
+The interrupt clause is load-bearing and must not be relaxed to "any IN-only
+endpoint". Goodix answers on a bulk IN-only endpoint (`0x83`) while sending OUT on
+`0x01`, so a wider rule would classify the reader's only responder as background and
+return pairing to zero pairs.
+
+What this does **not** separate is two independent protocols running on different
+endpoint pairs of the same transfer type on one device. Those interleave into one lane
+and may mispair; separating them needs correlation analysis this pass does not
+perform, and no capture in the corpus exercises it.
+
+**Zero-length events:** a **successful** event with an empty payload is excluded from
+pairing and counted in the result notes. It can neither be a command nor answer one,
+and leaving it in the lane lets it consume the pending OUT before the real response
+arrives — the Goodix reader answers with a zero-length read followed by the payload, so
+keeping them paired 92 of 95 commands on the 1122-packet capture with an empty response
+and timed each exchange to a USB artifact.
+
+**Failed events stay in the lane regardless of payload.** An errored transfer usually
+returns no data at all, and §2.1 goal 2 requires failed URBs to remain visible to
+pairing so they do not turn into false `UnansweredCommand` or `UnsolicitedResponse`
+results. Filtering on payload alone would drop exactly the events steps 4 and 5 rely on
+to explain a missing counterpart.
 
 ### 4.2 Control Transfer Handling
 
@@ -638,8 +679,10 @@ human-readable protocol description. The engine does not attempt narrative prose
 | Orphan submission | Recorded as `IncompleteTransfer`; does not by itself imply an unanswered protocol command |
 | Orphan completion | Recorded as `IncompleteTransfer`; does not by itself imply an unsolicited protocol response |
 | OUT and IN use same endpoint number with opposite directions | Pair as likely command/response, e.g. `0x01` OUT and `0x81` IN |
-| OUT and IN use different endpoint numbers | Preserve as separate endpoint-lane patterns or `AnalysisObservation`; do not force into simple pair |
-| Background endpoint traffic interleaves with command traffic | Analyze per endpoint lane by default so unrelated polling does not contaminate n-gram windows |
+| OUT and IN use different endpoint numbers | Pair within the device's transfer-type lane, e.g. `0x01` OUT and `0x83` IN. This is the arrangement both Goodix captures use (§4.1) |
+| Background endpoint traffic interleaves with command traffic | Suppress interrupt IN-only endpoints on a device that sends OUT elsewhere: excluded from n-gram windows (§3.1) and barred from claiming a pending command while still reported as `UnsolicitedResponse` (§4.1) |
+| Successful zero-length event | Excluded from pairing and counted in notes; it can neither be a command nor answer one |
+| Failed event with no payload | Stays in the lane; per §2.1 goal 2 it must remain able to explain a missing counterpart |
 | Overlapping marker windows | Occurrence assigned to the single nearest marker by timestamp |
 | Multiple devices in capture | Engine runs independently per device; results are separate `ProtocolHypothesis` objects |
 | All-zero payload | Treated as a valid payload; not filtered out |

--- a/tests/int/test_analysis_response_bounds.py
+++ b/tests/int/test_analysis_response_bounds.py
@@ -83,25 +83,26 @@ def test_anomaly_entries_do_not_grow_with_packet_count() -> None:
     large = next(d for d in _describe(_LARGE) if d.device_id == _GOODIX_DEVICE)
 
     assert len(small.unsolicited_responses) == len(large.unsolicited_responses) == 1
-    assert len(small.unanswered_commands) == len(large.unanswered_commands) == 1
+    # Zero, not one: transfer-type lanes let every OUT on 0x01 pair with its answer on
+    # 0x83. Under the old endpoint-number lanes these were 1 and 1 because nothing
+    # paired at all and every command fell out as unanswered.
+    assert len(small.unanswered_commands) == len(large.unanswered_commands) == 0
 
 
 def test_grouping_preserves_totals_and_reports_what_it_folded() -> None:
-    """Collapsing 181 anomalies keeps both the occurrence total and the count."""
+    """Collapsing 90 anomalies keeps both the occurrence total and the count."""
     description = next(d for d in _describe(_LARGE) if d.device_id == _GOODIX_DEVICE)
 
     unsolicited = description.unsolicited_responses[0]
     assert unsolicited.endpoint_address == "0x83"
     assert unsolicited.direction == "in"
-    assert unsolicited.distinct_signatures == 181
-    assert unsolicited.occurrence_count == 368
-    assert "181 distinct" in unsolicited.summary
+    assert unsolicited.distinct_signatures == 90
+    assert unsolicited.occurrence_count == 92
+    assert "90 distinct" in unsolicited.summary
 
-    unanswered = description.unanswered_commands[0]
-    assert unanswered.endpoint_address == "0x01"
-    assert unanswered.direction == "out"
-    assert unanswered.distinct_signatures == 79
-    assert unanswered.occurrence_count == 87
+    # Nothing unanswered to fold: this device answers every command it is sent, which
+    # only became visible once lanes stopped being keyed on endpoint number.
+    assert description.unanswered_commands == ()
 
 
 def test_samples_are_bounded_and_sampling_is_reported() -> None:
@@ -136,7 +137,7 @@ def test_deterministic_summary_is_unchanged_by_grouping() -> None:
     assert description.deterministic_summary.startswith(
         "Device 27c6_63ac has 5 repeated command patterns across 2 endpoint roles."
     )
-    assert "42 unsolicited response occurrences." in description.deterministic_summary
+    assert "10 unsolicited response occurrences." in description.deterministic_summary
 
 
 def test_steps_are_deferred_by_default_but_counted() -> None:

--- a/tests/int/test_protocol_description_goodix.py
+++ b/tests/int/test_protocol_description_goodix.py
@@ -29,7 +29,10 @@ def test_goodix_protocol_description_snapshot() -> None:
         "command_01 occurs 11 times; evidence packets 149-251. command_02 occurs 10 times; "
         "evidence packets 149-243. command_03 occurs 3 times; evidence packets 176-225. "
         "Contains OUT and IN steps; response timing was not isolated to this pattern. "
-        "3 unanswered command occurrences. 42 unsolicited response occurrences. "
+        # No unanswered commands since pairing moved to transfer-type lanes: every OUT
+        # on 0x01 now reaches its answer on 0x83. The 10 that remain unsolicited are the
+        # second payload-bearing IN of each exchange, which a one-to-one pass cannot claim.
+        "10 unsolicited response occurrences. "
         "1 incomplete transfer occurrence. 10 single-occurrence observations."
     )
 

--- a/tests/unit/test_pairing.py
+++ b/tests/unit/test_pairing.py
@@ -648,3 +648,213 @@ def test_capture_boundary_is_shared_across_devices() -> None:
     )
     by_id = {result.device_id: result for result in results}
     assert len(by_id["dev_001_005"].unanswered_commands) == 1
+
+
+def test_out_and_in_on_different_endpoint_numbers_pair() -> None:
+    """A command on one endpoint number pairs with its answer on another.
+
+    This is the arrangement both Goodix reference captures use: commands on
+    endpoint 1 OUT, answers on endpoint 3 IN. Keying lanes on endpoint number put
+    the two halves in separate lanes, so a device that answered every command it
+    was sent reported zero pairs and every command unanswered.
+    """
+    result = _run(
+        _out_transaction(1, _BASE_TIME, data=b"\xd0\x01", endpoint=1),
+        _in_transaction(2, _BASE_TIME + 0.002, data=b"\xaa\x01", endpoint=3),
+    )
+
+    (pair,) = result.pairs
+    assert pair.command.endpoint_address == "0x01"
+    assert pair.response.endpoint_address == "0x83"
+    assert result.unanswered_commands == ()
+    assert result.unsolicited_responses == ()
+    assert result.response_timing is not None
+
+
+def test_zero_length_in_does_not_consume_the_pending_command() -> None:
+    """A zero-length read cannot answer a command, so the real response still pairs.
+
+    The Goodix reader answers with a zero-length read before the payload. Letting
+    the empty one take the slot pairs the command with a USB artifact and times the
+    exchange to it, which is more misleading than reporting nothing at all.
+    """
+    result = _run(
+        _out_transaction(1, _BASE_TIME, data=b"\xd0\x01", endpoint=1),
+        _in_transaction(2, _BASE_TIME + 0.001, data=b"", endpoint=3),
+        _in_transaction(3, _BASE_TIME + 0.002, data=b"\xaa\x01", endpoint=3),
+    )
+
+    (pair,) = result.pairs
+    assert pair.response.data == b"\xaa\x01", "the payload-bearing IN must be the response"
+    assert result.unsolicited_responses == (), "the empty read is excluded, not filed as unsolicited"
+    assert any("zero-length" in note for note in result.analysis_notes), "exclusion must be reported, not silent"
+
+
+def test_interrupt_traffic_does_not_answer_a_bulk_command() -> None:
+    """Transfer type still separates lanes, so a status endpoint cannot mispair.
+
+    Scoping lanes to the whole device would let a background interrupt IN consume a
+    pending bulk OUT. Transfer type is the widest scope that admits the
+    cross-endpoint bulk case without reopening that one.
+    """
+    interrupt_in = UrbTransaction(
+        urb_id=2,
+        submission=None,
+        completion=_record(
+            urb_id=2,
+            event_type="completion",
+            direction="in",
+            timestamp=_BASE_TIME + 0.001,
+            transfer_type="interrupt",
+            endpoint=2,
+            data=b"\x04\x00",
+        ),
+    )
+    result = _run(
+        _out_transaction(1, _BASE_TIME, data=b"\xd0\x01", endpoint=1),
+        interrupt_in,
+    )
+
+    assert result.pairs == (), "an interrupt event must not answer a bulk command"
+
+
+def test_failed_in_with_no_payload_still_consumes_the_command() -> None:
+    """A failed IN suppresses the false unanswered even carrying no data.
+
+    An errored transfer usually returns no data at all, so a zero-payload filter
+    that looks only at the bytes drops exactly the events spec section 4.1 step 5
+    relies on. The trailing OUT holds the capture open past the timeout, without
+    which the boundary rule would suppress the result and hide the regression.
+    """
+    result = _run(
+        _out_transaction(1, _BASE_TIME),
+        _in_transaction(2, _BASE_TIME + 0.010, status=-71, data=b""),
+        _out_transaction(3, _BASE_TIME + 20.0, data=b"\x11\x22"),
+    )
+
+    assert result.pairs == ()
+    assert result.failed_event_count == 1
+    # The first OUT is explained by the failed IN. The trailing OUT is explained
+    # by the capture boundary. Neither is a real unanswered command.
+    assert result.unanswered_commands == ()
+
+
+def test_successful_zero_length_in_is_excluded_but_failed_one_is_not() -> None:
+    """The exclusion is scoped to successful events, and says so in the notes."""
+    result = _run(
+        _out_transaction(1, _BASE_TIME),
+        _in_transaction(2, _BASE_TIME + 0.001, data=b""),
+        _in_transaction(3, _BASE_TIME + 0.002, data=b"\xaa\x01"),
+        _out_transaction(4, _BASE_TIME + 20.0, data=b"\x11\x22"),
+    )
+
+    (pair,) = result.pairs
+    assert pair.response.data == b"\xaa\x01"
+    assert any("successful zero-length" in note for note in result.analysis_notes)
+
+
+def _interrupt_in(urb_id: int, at: float, *, endpoint: int, data: bytes) -> UrbTransaction:
+    """Build an interrupt IN transaction, the shape a status endpoint produces."""
+    return UrbTransaction(
+        urb_id=urb_id,
+        submission=_record(
+            urb_id=urb_id,
+            event_type="submission",
+            direction="in",
+            timestamp=at - 0.0005,
+            transfer_type="interrupt",
+            endpoint=endpoint,
+            status=-115,
+        ),
+        completion=_record(
+            urb_id=urb_id,
+            event_type="completion",
+            direction="in",
+            timestamp=at,
+            transfer_type="interrupt",
+            endpoint=endpoint,
+            data=data,
+        ),
+    )
+
+
+def _interrupt_out(urb_id: int, at: float, *, endpoint: int, data: bytes) -> UrbTransaction:
+    """Build an interrupt OUT transaction."""
+    return UrbTransaction(
+        urb_id=urb_id,
+        submission=_record(
+            urb_id=urb_id,
+            event_type="submission",
+            direction="out",
+            timestamp=at,
+            transfer_type="interrupt",
+            endpoint=endpoint,
+            data=data,
+            status=-115,
+        ),
+        completion=_record(
+            urb_id=urb_id,
+            event_type="completion",
+            direction="out",
+            timestamp=at + 0.0005,
+            transfer_type="interrupt",
+            endpoint=endpoint,
+        ),
+    )
+
+
+def test_background_status_endpoint_cannot_claim_a_command() -> None:
+    """A status endpoint firing mid-exchange must not take the pending command.
+
+    Widening the lane to the transfer type puts an unrelated interrupt IN in
+    reach of a pending OUT, and being the nearest IN in timestamp order it wins.
+    The counts alone cannot reveal the error: a mispairing and a correct pairing
+    both report one pair and one unsolicited response, so this asserts which
+    endpoint answered.
+    """
+    result = _run(
+        _interrupt_out(1, _BASE_TIME, endpoint=1, data=b"\xd0\x01"),
+        _interrupt_in(2, _BASE_TIME + 0.001, endpoint=2, data=b"\x99\x99"),
+        _interrupt_in(3, _BASE_TIME + 0.002, endpoint=1, data=b"\xd0\xaa"),
+        _interrupt_out(9, _BASE_TIME + 20.0, endpoint=1, data=b"\x11\x22"),
+    )
+
+    (pair,) = result.pairs
+    assert pair.response.endpoint_address == "0x81", "the real answer must win, not the status endpoint"
+    assert pair.response.data == b"\xd0\xaa"
+    # The status packet is still reported, just not as an answer.
+    assert [event.endpoint_address for event in result.unsolicited_responses] == ["0x82"]
+    assert any("background interrupt IN" in note for note in result.analysis_notes)
+
+
+def test_background_suppression_needs_out_traffic_elsewhere() -> None:
+    """An interrupt IN-only device has nothing to protect, so nothing is suppressed.
+
+    This is the hub shape. With no OUT anywhere the endpoint cannot steal a
+    command, and suppressing it would only hide real device-pushed traffic.
+    """
+    result = _run(
+        _interrupt_in(1, _BASE_TIME, endpoint=1, data=b"\x04\x00"),
+        _interrupt_in(2, _BASE_TIME + 1.0, endpoint=1, data=b"\x04\x00"),
+    )
+
+    assert result.pairs == ()
+    assert len(result.unsolicited_responses) == 2
+    assert not any("background interrupt IN" in note for note in result.analysis_notes)
+
+
+def test_bulk_in_only_responder_is_never_suppressed() -> None:
+    """The interrupt clause is load-bearing: Goodix answers on a bulk IN-only endpoint.
+
+    Relaxing the rule to any IN-only endpoint would classify `0x83` as background
+    on a device sending OUT on `0x01`, which is the reader's only responder, and
+    return pairing to zero pairs.
+    """
+    result = _run(
+        _out_transaction(1, _BASE_TIME, data=b"\xd0\x01", endpoint=1),
+        _in_transaction(2, _BASE_TIME + 0.002, data=b"\xaa\x01", endpoint=3),
+    )
+
+    (pair,) = result.pairs
+    assert pair.command.endpoint_address == "0x01"
+    assert pair.response.endpoint_address == "0x83"


### PR DESCRIPTION
## What does this PR do?

Makes command/response pairing work on devices that answer on a different endpoint than they command on.

Pairing lanes were keyed on `endpoint_number`. The Goodix reader commands on `0x01` and answers on `0x83`, so a command and its answer never shared a lane. Both Goodix captures returned zero pairs, `response_timing` was always `None`, and every command was reported unanswered while every response was reported unsolicited. Those counts described the lane scoping, not the device.

Three changes, all needed together:

- Lanes are keyed on transfer type. This alone fixes Goodix.
- Successful zero-length events are excluded from pairing and counted in the notes. With only the lane change they consume the pending OUT before the real response, pairing 92 of 95 commands against a zero-length packet. Failed events stay in regardless of payload, because spec §2.1 goal 2 needs them visible so they do not become false unanswered commands.
- Background interrupt IN endpoints cannot claim a pending command. Widening the lane put a status endpoint in reach of one, and being the nearest IN in timestamp order it won. The rule is shared with the analyzer's n-gram scoping rather than restated, so the two passes cannot drift on what background means. Suppressed events are still reported as unsolicited.

| capture | pairs | unanswered | unsolicited |
|---|---|---|---|
| `goodix_enum_and_enroll` | 0 to 11 | 3 to 0 | 42 to 10 |
| `goodix_enroll_verify` | 0 to 92 | 87 to 0 | 368 to 92 |
| `xrite-i1displaypro` | 269, unchanged | 0 | 0 |

SRS PROTO-02 asks for pairing validated against at least two reference devices. It passed on one before this.

Spec §4.1 and §6 are updated to match, including the edge-case rows that still described the endpoint-number rule.

Known limit: two independent protocols on different endpoint pairs of the same transfer type on one device still share a lane. No capture in the corpus does this.

Closes #138

#142 stacks on this branch and should be reviewed after it.

## How was it tested?

```bash
source .venv/bin/activate
ruff check .
ruff format --check .
pyright
pytest
```

All checks pass: 493 tests, ruff clean, pyright strict clean.

Five new unit tests in `tests/unit/test_pairing.py` cover cross-endpoint pairing, a zero-length IN not consuming the command, a failed IN with no payload still suppressing a false unanswered command, a background status endpoint being barred from claiming a command, and the interrupt clause protecting a bulk IN-only responder.

Three existing tests were updated because they pinned the old counts. Each carries a comment explaining what the number now means.

The X-Rite capture is the only non-bulk pairing device in the corpus. Its 269 pairs are identical before and after, which is the guard that this change does not disturb interrupt traffic.

## Checklist

- PR description includes `closes #N`
- No unintended files included in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
